### PR TITLE
Migration Improvements

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -667,6 +667,9 @@ Task("migration-nuget")
 		.WithTarget("Pack");
 
 	MSBuild("./source/migration/BuildTasks/Xamarin.AndroidX.Migration.BuildTasks.csproj", settings);
+
+	settings.EnableBinaryLogger("./output/migration-tool-nuget.binlog");
+
 	MSBuild("./source/migration/Tool/Xamarin.AndroidX.Migration.Tool.csproj", settings);
 });
 

--- a/source/migration/BuildTasks/Xamarin.AndroidX.Migration.targets
+++ b/source/migration/BuildTasks/Xamarin.AndroidX.Migration.targets
@@ -225,6 +225,7 @@
             Condition="'$(_AndroidXShouldRunMigration)' == 'true'">
 
         <CecilfyFiles Assemblies="@(_AndroidXFileToCecilfy)"
+                      References="@(ResolvedAssemblies)"
                       SkipEmbeddedResources="true"
                       Verbose="$(_AndroidXUseVerboseToolOutput)" />
 

--- a/source/migration/Migration/CecilMigrator.cs
+++ b/source/migration/Migration/CecilMigrator.cs
@@ -104,7 +104,7 @@ namespace Xamarin.AndroidX.Migration
 				LogVerboseMessage($"Processing assembly '{source}'...");
 				using (var assembly = AssemblyDefinition.ReadAssembly(destination, readerParams))
 				{
-					if (!File.Exists(pdbPath) && !File.Exists(mdbPath))
+					if (!hasSymbols)
 						LogVerboseMessage($"  No debug symbols found for the assembly.");
 
 					result = MigrateAssembly(assembly);

--- a/source/migration/Migration/CecilMigrator.cs
+++ b/source/migration/Migration/CecilMigrator.cs
@@ -86,12 +86,15 @@ namespace Xamarin.AndroidX.Migration
 			var requiresSave = false;
 			using (var resolver = new AssemblyResolver())
 			{
-				var refs = References
-					.Where(r => Path.GetFileName(r) != Path.GetFileName(destination))
-					.ToList();
-				foreach (var reference in refs)
+				if (References?.Count > 0)
 				{
-					resolver.AddAssembly(reference);
+					var refs = References
+						.Where(r => Path.GetFileName(r) != Path.GetFileName(destination))
+						.ToList();
+					foreach (var reference in refs)
+					{
+						resolver.AddAssembly(reference);
+					}
 				}
 
 				var readerParams = new ReaderParameters


### PR DESCRIPTION
This PR makes sure that all the referenced assemblies are available to Cecil as well as making sure that the assembly is saved correctly.

Although this PR appears to have changes all over the show, it actually just changes the loading and saving of the assembly. Previously, I tried to be clever and work all in place - which was unnecessary. I now copy the assembly to the new location first, and then edit it right there. 