### PR TITLE
Update CameraX to version 1.0.0-beta05

### DIFF
--- a/config.json
+++ b/config.json
@@ -114,40 +114,40 @@
 		,{
 			"groupId" : "androidx.camera",
 			"artifactId" : "camera-camera2",
-			"version" : "1.0.0-beta03",
-			"nugetVersion" : "1.0.0-beta03",
+			"version" : "1.0.0-beta05",
+			"nugetVersion" : "1.0.0-beta05",
 			"nugetId" : "Xamarin.AndroidX.Camera.Camera2",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.camera",
 			"artifactId" : "camera-core",
-			"version" : "1.0.0-beta03",
-			"nugetVersion" : "1.0.0-beta03",
+			"version" : "1.0.0-beta05",
+			"nugetVersion" : "1.0.0-beta05",
 			"nugetId" : "Xamarin.AndroidX.Camera.Core",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.camera",
 			"artifactId" : "camera-extensions",
-			"version" : "1.0.0-alpha10",
-			"nugetVersion" : "1.0.0-alpha10",
+			"version" : "1.0.0-alpha12",
+			"nugetVersion" : "1.0.0-alpha12",
 			"nugetId" : "Xamarin.AndroidX.Camera.Extensions",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.camera",
 			"artifactId" : "camera-lifecycle",
-			"version" : "1.0.0-beta03",
-			"nugetVersion" : "1.0.0-beta03",
+			"version" : "1.0.0-beta05",
+			"nugetVersion" : "1.0.0-beta05",
 			"nugetId" : "Xamarin.AndroidX.Camera.Lifecycle",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.camera",
 			"artifactId" : "camera-view",
-			"version" : "1.0.0-alpha10",
-			"nugetVersion" : "1.0.0-alpha10",
+			"version" : "1.0.0-alpha12",
+			"nugetVersion" : "1.0.0-alpha12",
 			"nugetId" : "Xamarin.AndroidX.Camera.View",
 			"dependencyOnly" : false
 		}

--- a/mappings/androidx-assemblies.csv
+++ b/mappings/androidx-assemblies.csv
@@ -19,7 +19,7 @@ Xamarin.Android.Support.Annotations,Xamarin.AndroidX.Annotation,Xamarin.Android.
 Xamarin.Android.Support.AsyncLayoutInflater,Xamarin.AndroidX.AsyncLayoutInflater,Xamarin.Android.Support.AsyncLayoutInflater,Xamarin.AndroidX.AsyncLayoutInflater,1.0.0
 Xamarin.Android.Support.Collections,Xamarin.AndroidX.Collection,Xamarin.Android.Support.Collections,Xamarin.AndroidX.Collection,1.1.0
 Xamarin.Android.Support.Compat,Xamarin.AndroidX.Core,Xamarin.Android.Support.Compat,Xamarin.AndroidX.Core,1.2.0
-Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.Camera.Extensions,Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.Camera.Extensions,1.0.0-alpha10
+Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.Camera.Extensions,Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.Camera.Extensions,1.0.0-alpha12
 Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.ConstraintLayout,Xamarin.Android.Support.Constraint.Layout,Xamarin.AndroidX.ConstraintLayout,1.1.3
 Xamarin.Android.Support.Constraint.Layout.Solver,Xamarin.AndroidX.ConstraintLayout.Solver,Xamarin.Android.Support.Constraint.Layout.Solver,Xamarin.AndroidX.ConstraintLayout.Solver,1.1.3
 Xamarin.Android.Support.CoordinaterLayout,Xamarin.AndroidX.CoordinatorLayout,Xamarin.Android.Support.CoordinaterLayout,Xamarin.AndroidX.CoordinatorLayout,1.1.0

--- a/source/androidx.camera/camera-core/Transforms/Metadata.xml
+++ b/source/androidx.camera/camera-core/Transforms/Metadata.xml
@@ -22,4 +22,9 @@
         >
         protected
     </attr>
+
+    <remove-node
+        path="/api/package[@name='androidx.camera.core.impl']/interface[@name='Config']"
+        />    
+
 </metadata>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):
AndroidX

### Does this change any of the generated binding API's?
Yes, just the changes that the CameraX API had.

### Describe your contribution
I've updated the CameraX bindings to 1.0.0-beta05. Particulary, I've updated

- androidx.camera.camera-camera2 to the version 1.0.0-beta05
- androidx.camera.camera-core to the version 1.0.0-beta05
- androidx.camera.camera-lifecycle to the version 1.0.0-beta05
- androidx.camera.camera-extensions to the version 1.0.0-alpha12
- androidx.camera.camera-view to the version 1.0.0-alpha12


