### PR TITLE
Enable overriding for codesigning when manually launching CI Builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,8 +25,7 @@ resources:
 parameters:
   - name: CodeSignOverride
     type: string
-    default: ''
-    values: ["", "true", "false"]
+    default: '' # set to true to force realsigning, false to force testsigning, keep blank to let the pipeline infer
 
 jobs:
   - template: .ci/build.yml@components

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,12 @@ resources:
       name: xamarin/XamarinComponents
       endpoint: xamarin
 
+parameters:
+  - name: CodeSignOverride
+    type: string
+    default: ''
+    values: ['', 'true', 'false']
+
 jobs:
   - template: .ci/build.yml@components
     parameters:
@@ -46,4 +52,5 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v1.yml@internal-templates
       parameters:
+        CodeSignOverride: true # testing true case
         dependsOn: [ 'build' ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ resources:
     - repository: internal-templates
       type: github
       name: xamarin/yaml-templates
+      ref: refs/heads/main # this should be the default, but I notice it still picks master
       endpoint: xamarin
     - repository: components
       type: github
@@ -25,7 +26,7 @@ resources:
 parameters:
   - name: CodeSignOverride
     type: string
-    default: '' # set to true to force realsigning, false to force testsigning, keep blank to let the pipeline infer
+    default: ' ' # set to true to force realsigning, false to force testsigning, keep blank to let the pipeline infer
 
 jobs:
   - template: .ci/build.yml@components

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,5 +51,5 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v1.yml@internal-templates
       parameters:
-        CodeSignOverride: true # testing true case
+        CodeSignOverride: false # testing true case
         dependsOn: [ 'build' ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ parameters:
   - name: CodeSignOverride
     type: string
     default: ''
-    values: ['', 'true', 'false']
+    values: ["", "true", "false"]
 
 jobs:
   - template: .ci/build.yml@components


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

N/A

### Does this change any of the generated binding API's?

No

### Describe your contribution

Allows specification of a parameter called CodeSignOverride when launching build:
- When the parameter is not set, the pipeline will infer if it should RealSign based on whether or not it is a build on the main branch.
- When set to `true`, force codesign to use production Microsoft certificates to sign
- WHen set to `false`, force codesign to use test Microsoft certificates