### PR TITLE
Update several artifacts to latest stable versions.

### DIFF
--- a/config.json
+++ b/config.json
@@ -200,8 +200,8 @@
 		,{
 			"groupId" : "androidx.concurrent",
 			"artifactId" : "concurrent-futures",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.Concurrent.Futures",
 			"dependencyOnly" : false
 		}
@@ -240,8 +240,8 @@
 		,{
 			"groupId" : "androidx.core",
 			"artifactId" : "core",
-			"version" : "1.3.0",
-			"nugetVersion" : "1.3.0.3",
+			"version" : "1.3.2",
+			"nugetVersion" : "1.3.2",
 			"nugetId" : "Xamarin.AndroidX.Core",
 			"dependencyOnly" : false
 		}
@@ -272,8 +272,8 @@
 		,{
 			"groupId" : "androidx.customview",
 			"artifactId" : "customview",
-			"version" : "1.1.0-rc01",
-			"nugetVersion" : "1.1.0.3-rc01",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.CustomView",
 			"dependencyOnly" : false
 		}
@@ -304,24 +304,24 @@
 		,{
 			"groupId" : "androidx.emoji",
 			"artifactId" : "emoji",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.Emoji",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.emoji",
 			"artifactId" : "emoji-appcompat",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.Emoji.AppCompat",
 			"dependencyOnly" : false
 		}
 		,{
 			"groupId" : "androidx.emoji",
 			"artifactId" : "emoji-bundled",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.Emoji.Bundled",
 			"dependencyOnly" : false
 		}
@@ -720,8 +720,8 @@
 		,{
 			"groupId" : "androidx.slidingpanelayout",
 			"artifactId" : "slidingpanelayout",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.SlidingPaneLayout",
 			"dependencyOnly" : false
 		}
@@ -744,8 +744,8 @@
 		,{
 			"groupId" : "androidx.swiperefreshlayout",
 			"artifactId" : "swiperefreshlayout",
-			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"version" : "1.1.0",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.SwipeRefreshLayout",
 			"dependencyOnly" : false
 		}


### PR DESCRIPTION
Updates several artifacts to latest stable versions. No breaking changes reported.

Xamarin.AndroidX.Concurrent.Futures (1.0.0 -> 1.1.0) - [diff](https://github.com/xamarin/AndroidX/files/5374033/Xamarin.AndroidX.Concurrent.Futures.dll.diff.txt)
Xamarin.AndroidX.Core (1.3.0 -> 1.3.2) - no changes
Xamarin.AndroidX.CustomView (1.1.0-rc01 -> 1.1.0) - no changes
Xamarin.AndroidX.Emoji (1.0.0 -> 1.1.0) - no changes
Xamarin.AndroidX.Emoji.AppCompat (1.0.0 -> 1.1.0) - no changes
Xamarin.AndroidX.Emoji.Bundled (1.0.0 -> 1.1.0) - no changes
Xamarin.AndroidX.SlidingPaneLayout (1.0.0 -> 1.1.0) - [diff](https://github.com/xamarin/AndroidX/files/5374110/Xamarin.AndroidX.SlidingPaneLayout.dll.diff.txt)
Xamarin.AndroidX.SwipeRefreshLayout (1.0.0 -> 1.1.0) - [diff](https://github.com/xamarin/AndroidX/files/5374115/Xamarin.AndroidX.SwipeRefreshLayout.dll.diff.txt)
