### PR TITLE
Generate solution filters for working in Visual Studio.

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,10 @@
 		{
 			"templateFile": "source/AndroidXPom.cshtml",
 			"outputFileRule" : "generated/{groupid}.{artifactid}/dependencies.pom"
+		},
+		{
+			"templateFile": "source/AndroidXSolutionFilter.cshtml",
+			"outputFileRule" : "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
 		}
 	],
 	"artifacts" : [

--- a/source/AndroidXSolutionFilter.cshtml
+++ b/source/AndroidXSolutionFilter.cshtml
@@ -1,0 +1,16 @@
+@using System.Linq
+{
+  "solution": {
+    "path": "..\\AndroidX.sln",
+    "projects": [
+@foreach (var dep in @Model.NuGetDependencies)
+{
+    if (dep.IsProjectReference)
+    {
+        <text>"@($"{dep.MavenArtifact.MavenGroupId}.{dep.MavenArtifact.MavenArtifactId}\\\\{dep.MavenArtifact.MavenGroupId}.{dep.MavenArtifact.MavenArtifactId}.csproj")",</text>
+    }
+}
+"@($"{Model.MavenGroupId}.{Model.Name}\\\\{Model.MavenGroupId}.{Model.Name}.csproj")"
+    ]
+  }
+}


### PR DESCRIPTION
Binderator generates an `AndroidX.sln` file which can be used in Visual Studio, however it contains 104 projects, which does not make VS very happy.  This adds a template to generate solution filter (.slnf) files next to each project file.  This allows you to open only the current project plus its project references in Visual Studio.