### PR TITLE
Update AndroidX.ExifInterface to 1.3.1.

### DIFF
--- a/config.json
+++ b/config.json
@@ -332,8 +332,8 @@
 		,{
 			"groupId" : "androidx.exifinterface",
 			"artifactId" : "exifinterface",
-			"version" : "1.1.0",
-			"nugetVersion" : "1.1.0.5",
+			"version" : "1.3.1",
+			"nugetVersion" : "1.3.1",
 			"nugetId" : "Xamarin.AndroidX.ExifInterface",
 			"dependencyOnly" : false
 		}


### PR DESCRIPTION
android.exifinterface - 1.1.0 -> 1.3.1
- [breaking.txt](https://github.com/xamarin/AndroidX/files/5404236/Xamarin.AndroidX.ExifInterface.dll.breaking.txt)
- [diff.txt](https://github.com/xamarin/AndroidX/files/5404237/Xamarin.AndroidX.ExifInterface.dll.diff.txt)

I investigated the breakages since it's `long` -> `Java.Lang.Long` to see if it was an issue with our tooling, but this was really changed by Google, and these are actually different types in Java, so we can't just fix it with metadata.

https://android.googlesource.com/platform/frameworks/support/+/6f437ca8ffec256c8a7ac21f73f17ccd1ab505a0%5E%21/exifinterface/exifinterface/src/main/java/androidx/exifinterface/media/ExifInterface.java