### PR TITLE
[.NET 6] fix for AndroidX.Migration

### DIFF
--- a/source/migration/BuildTasks/Xamarin.AndroidX.Migration.targets
+++ b/source/migration/BuildTasks/Xamarin.AndroidX.Migration.targets
@@ -36,7 +36,7 @@
 
     <!-- "private" properties -->
     <PropertyGroup>
-        <_AndroidXShouldRunMigration Condition="'$(_AndroidXShouldRunMigration)' == '' and '$(AndroidApplication)' == 'true' and '$(AndroidXIsUsingAndroidXLibraries)' == 'true' and '$(AndroidXSkipMigration)' != 'true'">true</_AndroidXShouldRunMigration>
+        <_AndroidXShouldRunMigration Condition="'$(_AndroidXShouldRunMigration)' == '' and ('$(AndroidApplication)' == 'true' or '$(OutputType)' == 'Exe') and '$(AndroidXIsUsingAndroidXLibraries)' == 'true' and '$(AndroidXSkipMigration)' != 'true'">true</_AndroidXShouldRunMigration>
         <_AndroidXIntermediateOutputPath>$(IntermediateOutputPath)androidx\</_AndroidXIntermediateOutputPath>
         <_AndroidXProguardIntermediateOutputPath>$(_AndroidXIntermediateOutputPath)proguard\</_AndroidXProguardIntermediateOutputPath>
         <_AndroidXJavaLibraryIntermediateOutputPath>$(_AndroidXIntermediateOutputPath)jl\</_AndroidXJavaLibraryIntermediateOutputPath>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

### Does this change any of the generated binding API's?

No

### Describe your contribution

Context: https://github.com/xamarin/xamarin-android/pull/5195

Due to the way `<Import/>` ordering has changed with .NET 6 workloads,
`$(AndroidApplication)` is not set until after NuGet packages have had
their MSBuild targets evaluated.

The result is `$(_AndroidXShouldRunMigration)` is blank, and
AndroidX.Migration doesn't do any work. We noticed this happening in
MSBuild tests using Xamarin.Forms.Maps.

To solve this issue, we can check for `$(OutputType)` set to `Exe`, as
this is what developers will set in their `.csproj` file.

We may eventually get another MSBuild extension point from dotnet/sdk
to make this possible to fix on the `xamarin-android`-side, but I
think we can simply check both properties for now.