### PR TITLE
Sign Mono.Cecil with the third party signature

### DIFF
--- a/SignList.xml
+++ b/SignList.xml
@@ -11,6 +11,8 @@
     <ThirdParty Include="ILRepack.dll" />
     <ThirdParty Include="protobuf-net.dll" />
     <ThirdParty Include="Newtonsoft.Json.dll" />
+    <ThirdParty Include="Mono.Cecil.dll" />
+    <ThirdParty Include="Mono.Cecil.*.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/config.json
+++ b/config.json
@@ -61,7 +61,7 @@
 			"groupId" : "androidx.annotation",
 			"artifactId" : "annotation",
 			"version" : "1.1.0",
-			"nugetVersion" : "1.1.0.6",
+			"nugetVersion" : "1.1.0.7",
 			"nugetId" : "Xamarin.AndroidX.Annotation",
 			"dependencyOnly" : false
 		}
@@ -69,7 +69,7 @@
 			"groupId" : "androidx.annotation",
 			"artifactId" : "annotation-experimental",
 			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.6",
+			"nugetVersion" : "1.0.0.7",
 			"nugetId" : "Xamarin.AndroidX.Annotation.Experimental",
 			"dependencyOnly" : false
 		}
@@ -77,7 +77,7 @@
 			"groupId" : "androidx.appcompat",
 			"artifactId" : "appcompat",
 			"version" : "1.2.0",
-			"nugetVersion" : "1.2.0.4",
+			"nugetVersion" : "1.2.0.5",
 			"nugetId" : "Xamarin.AndroidX.AppCompat",
 			"dependencyOnly" : false
 		}
@@ -85,7 +85,7 @@
 			"groupId" : "androidx.appcompat",
 			"artifactId" : "appcompat-resources",
 			"version" : "1.2.0",
-			"nugetVersion" : "1.2.0.4",
+			"nugetVersion" : "1.2.0.5",
 			"nugetId" : "Xamarin.AndroidX.AppCompat.AppCompatResources",
 			"dependencyOnly" : false
 		}
@@ -813,7 +813,7 @@
 			"groupId" : "androidx.wear",
 			"artifactId" : "wear",
 			"version" : "1.1.0",
-			"nugetVersion" : "1.1.0",
+			"nugetVersion" : "1.1.0.1",
 			"nugetId" : "Xamarin.AndroidX.Wear",
 			"dependencyOnly" : false
 		}

--- a/config.json
+++ b/config.json
@@ -871,7 +871,7 @@
 			"artifactId" : "migration",
 			"nugetId" : "Xamarin.AndroidX.Migration",
 			"version" : "1.0",
-			"nugetVersion" : "1.0.7.1",
+			"nugetVersion" : "1.0.8",
 			"dependencyOnly" : true
 		}
 	]

--- a/config.json
+++ b/config.json
@@ -813,7 +813,7 @@
 			"groupId" : "androidx.wear",
 			"artifactId" : "wear",
 			"version" : "1.1.0",
-			"nugetVersion" : "1.1.0.1",
+			"nugetVersion" : "1.1.0",
 			"nugetId" : "Xamarin.AndroidX.Wear",
 			"dependencyOnly" : false
 		}


### PR DESCRIPTION
We usually sign all the Mono.* bits, because we usually own it... but not Mono.Cecil.

That is a great library by other great people.

---

Additionally this does a "NuGet-version only" bump to the following "top-level" references used by our templates:
- Xamarin.AndroidX.Annotation
- Xamarin.AndroidX.AppCompat
- Xamarin.AndroidX.Wear is already bumped via https://github.com/xamarin/AndroidX/pull/185 which will go out with these packages.

This will force these packages to be rebuilt with a transitive `Xamarin.AndroidX.Migration >= 1.0.8` dependency which will force the NuGet graph resolution to use this newer version.