### PR TITLE
Bump packages needed for 16.9 template updates.

### DIFF
--- a/config.json
+++ b/config.json
@@ -397,7 +397,7 @@
 			"groupId" : "androidx.legacy",
 			"artifactId" : "legacy-support-core-ui",
 			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"nugetVersion" : "1.0.0.6",
 			"nugetId" : "Xamarin.AndroidX.Legacy.Support.Core.UI",
 			"dependencyOnly" : false
 		}
@@ -621,7 +621,7 @@
 			"groupId" : "androidx.percentlayout",
 			"artifactId" : "percentlayout",
 			"version" : "1.0.0",
-			"nugetVersion" : "1.0.0.5",
+			"nugetVersion" : "1.0.0.6",
 			"nugetId" : "Xamarin.AndroidX.PercentLayout",
 			"dependencyOnly" : false
 		}


### PR DESCRIPTION
Bump the NuGet version of the following packages used by new VS 16.9 templates.  This is due to a previous signing error and we need to ensure nothing is referencing `Xamarin.AndroidX.Migration 1.0.7.1`.

* Xamarin.AndroidX.Legacy.Support.Core.UI
* Xamarin.AndroidX.PercentLayout