### PR TITLE
Release a stable Material 1.1.0.

### DIFF
--- a/config.json
+++ b/config.json
@@ -837,7 +837,7 @@
 			"groupId" : "com.google.android.material",
 			"artifactId" : "material",
 			"version" : "1.1.0",
-			"nugetVersion" : "1.1.0.5-rc3",
+			"nugetVersion" : "1.1.0.5",
 			"nugetId" : "Xamarin.Google.Android.Material",
 			"dependencyOnly" : false
 		},


### PR DESCRIPTION
Creates a stable release of `Xamarin.Google.Android.Material` 1.1.0.5.  We realize there is still a known bug in this package (https://github.com/xamarin/AndroidX/issues/76), however we want to start binding preview versions of 1.2.1 so users can have the latest features, so we should release a stable version of 1.1.0 first.