### PR TITLE
Fix migration issue with obfuscated classes

### DIFF
--- a/source/migration/Migration/CecilMigrator.cs
+++ b/source/migration/Migration/CecilMigrator.cs
@@ -468,8 +468,8 @@ namespace Xamarin.AndroidX.Migration
 			string nested = "";
 			while (javaClass.Contains("$"))
 			{
-				nested = javaClass.Substring(javaClass.LastIndexOf("$")) + nested;
-				javaClass = javaClass.Substring(0, javaClass.LastIndexOf("$"));
+				nested = javaClass.Substring(javaClass.LastIndexOf('$')) + nested;
+				javaClass = javaClass.Substring(0, javaClass.LastIndexOf('$'));
 
 				if (Mapping.TryGetAndroidXClass(javaClass, out newClass))
 				{

--- a/tests/AndroidXMigrationTests/Tests/JniStringMigrationTests.cs
+++ b/tests/AndroidXMigrationTests/Tests/JniStringMigrationTests.cs
@@ -469,6 +469,9 @@ namespace Xamarin.AndroidX.Migration.Tests
 		[InlineData(
 			"(Landroid/support/wear/widget/drawer/WearableNavigationDrawerView;Landroid/support/wear/internal/widget/drawer/WearableNavigationDrawerPresenter;)V",
 			"(Landroidx/wear/widget/drawer/WearableNavigationDrawerView;Landroidx/wear/internal/widget/drawer/WearableNavigationDrawerPresenter;)V")]
+		[InlineData(
+			"com/test/test/test/a/b/ʹ$ʹ",
+			"com/test/test/test/a/b/ʹ$ʹ")]
 		public void JniStringAreCorrectlyMapped(string supportJni, string androidxJni)
 		{
 			var cecilMigrator = new CecilMigrator();


### PR DESCRIPTION
Some tools generate weird class names:

```csharp
[Register("com/test/test/test/a/b/ʹ$ʹ", DoNotGenerateAcw = true)]
```

This PR will add tests and fix for these cases.

Fixes #209