### PR TITLE
[camera-core] Add IExtendableBuilder to several *.Builder classes.

### DIFF
--- a/config.json
+++ b/config.json
@@ -140,32 +140,32 @@
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
-        "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.4-beta05",
+        "version": "1.0.0-rc01",
+        "nugetVersion": "1.0.0.4-rc01",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
-        "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.4-beta05",
+        "version": "1.0.0-rc01",
+        "nugetVersion": "1.0.0.4-rc01",
         "nugetId": "Xamarin.AndroidX.Camera.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
-        "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.4-beta05",
+        "version": "1.0.0-rc01",
+        "nugetVersion": "1.0.0.4-rc01",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
-        "version": "1.0.0-alpha12",
-        "nugetVersion": "1.0.0.4-alpha12",
+        "version": "1.0.0-alpha20",
+        "nugetVersion": "1.0.0.4-alpha20",
         "nugetId": "Xamarin.AndroidX.Camera.View",
         "dependencyOnly": false
       },

--- a/source/androidx.camera/camera-camera2/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.camera/camera-camera2/Transforms/Metadata.Namespaces.xml
@@ -49,6 +49,18 @@
         >
         AndroidX.Camera.Camera2.InterOp
     </attr>    
-    
+        <attr 
+        path="/api/package[@name='androidx.camera.camera2.internal.compat.quirk']" 
+        name="managedName"
+        >
+        AndroidX.Camera.Camera2.Internal.Compat.Quirk
+    </attr>    
+    <attr 
+        path="/api/package[@name='androidx.camera.camera2.internal.compat.workaround']" 
+        name="managedName"
+        >
+        AndroidX.Camera.Camera2.Internal.Compat.Workaround
+    </attr>    
+
     
 </metadata>

--- a/source/androidx.camera/camera-camera2/Transforms/Metadata.xml
+++ b/source/androidx.camera/camera-camera2/Transforms/Metadata.xml
@@ -27,5 +27,12 @@
     <remove-node
         path="/api/package[@name='androidx.camera.camera2.internal']/class[@name='MeteringRepeatingConfig.Builder']/implements"
         />
-    
+    <remove-node
+        path="/api/package[@name='androidx.camera.camera2.interop']/class[@name='CaptureRequestOptions.Builder']/implements"
+        />
+    <remove-node
+        path="/api/package[@name='androidx.camera.camera2.interop']/class[@name='CaptureRequestOptions']/implements"
+        />
+
+  <attr path="/api/package[@name='androidx.camera.camera2.internal']/class[@name='Camera2CameraFactory']/method[@name='getCameraManager' and count(parameter)=0]" name="managedReturn">Java.Lang.Object</attr>
 </metadata>

--- a/source/androidx.camera/camera-core/Additions/ImageAnalysisBuilder.cs
+++ b/source/androidx.camera/camera-core/Additions/ImageAnalysisBuilder.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AndroidX.Camera.Core.Internal;
+using Java.Lang;
+
+namespace AndroidX.Camera.Core
+{
+	public partial class ImageAnalysis
+	{
+		public partial class Builder
+		{
+			// Explicitly implement these interface methods that have
+			// covariant return types in the public API.
+			Java.Lang.Object IExtendableBuilder.Build ()
+			{
+				return Build ();
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetClass (Class @class)
+			{
+				return SetTargetClass (@class);
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetName (string name)
+			{
+				return SetTargetName (name);
+			}
+
+			Java.Lang.Object IUseCaseEventConfigBuilder.SetUseCaseEventCallback (IEventCallback p0)
+			{
+				return SetUseCaseEventCallback (p0);
+			}
+		}
+	}
+}

--- a/source/androidx.camera/camera-core/Additions/ImageCaptureBuilder.cs
+++ b/source/androidx.camera/camera-core/Additions/ImageCaptureBuilder.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AndroidX.Camera.Core.Internal;
+using Java.Lang;
+
+namespace AndroidX.Camera.Core
+{
+	public partial class ImageCapture
+	{
+		public partial class Builder
+		{
+			// Explicitly implement these interface methods that have
+			// covariant return types in the public API.
+			Java.Lang.Object IExtendableBuilder.Build ()
+			{
+				return Build ();
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetClass (Class @class)
+			{
+				return SetTargetClass (@class);
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetName (string name)
+			{
+				return SetTargetName (name);
+			}
+
+			Java.Lang.Object IUseCaseEventConfigBuilder.SetUseCaseEventCallback (IEventCallback p0)
+			{
+				return SetUseCaseEventCallback (p0);
+			}
+		}
+	}
+}

--- a/source/androidx.camera/camera-core/Additions/PreviewBuilder.cs
+++ b/source/androidx.camera/camera-core/Additions/PreviewBuilder.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AndroidX.Camera.Core.Internal;
+using Java.Lang;
+
+namespace AndroidX.Camera.Core
+{
+	public partial class Preview
+	{
+		public partial class Builder
+		{
+			// Explicitly implement these interface methods that have
+			// covariant return types in the public API.
+			Java.Lang.Object IExtendableBuilder.Build ()
+			{
+				return Build ();
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetClass (Class @class)
+			{
+				return SetTargetClass (@class);
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetName (string name)
+			{
+				return SetTargetName (name);
+			}
+
+			Java.Lang.Object IUseCaseEventConfigBuilder.SetUseCaseEventCallback (IEventCallback p0)
+			{
+				return SetUseCaseEventCallback (p0);
+			}
+		}
+	}
+}

--- a/source/androidx.camera/camera-core/Additions/VideoCaptureBuilder.cs
+++ b/source/androidx.camera/camera-core/Additions/VideoCaptureBuilder.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AndroidX.Camera.Core.Internal;
+using Java.Lang;
+
+namespace AndroidX.Camera.Core
+{
+	public partial class VideoCapture
+	{
+		public partial class Builder
+		{
+			// Explicitly implement these interface methods that have
+			// covariant return types in the public API.
+			Java.Lang.Object IExtendableBuilder.Build ()
+			{
+				return Build ();
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetClass (Class @class)
+			{
+				return SetTargetClass (@class);
+			}
+
+			Java.Lang.Object ITargetConfigBuilder.SetTargetName (string name)
+			{
+				return SetTargetName (name);
+			}
+
+			Java.Lang.Object IUseCaseEventConfigBuilder.SetUseCaseEventCallback (IEventCallback p0)
+			{
+				return SetUseCaseEventCallback (p0);
+			}
+		}
+	}
+}

--- a/source/androidx.camera/camera-core/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.camera/camera-core/Transforms/Metadata.Namespaces.xml
@@ -56,5 +56,23 @@
         >
         AndroidX.Camera.Core.Internal.Utils
     </attr>
-    
+        <attr 
+        path="/api/package[@name='androidx.camera.core.internal.compat']" 
+        name="managedName"
+        >
+        AndroidX.Camera.Core.Internal.Utils
+    </attr>
+    <attr 
+        path="/api/package[@name='androidx.camera.core.internal.compat.quirk']" 
+        name="managedName"
+        >
+        AndroidX.Camera.Core.Internal.Compat.Quirk
+    </attr>
+    <attr 
+        path="/api/package[@name='androidx.camera.core.internal.compat.workaround']" 
+        name="managedName"
+        >
+        AndroidX.Camera.Core.Internal.Compat.Workaround
+    </attr>
+
 </metadata>

--- a/source/androidx.camera/camera-core/Transforms/Metadata.xml
+++ b/source/androidx.camera/camera-core/Transforms/Metadata.xml
@@ -23,15 +23,6 @@
     <remove-node path="/api/package[@name='androidx.camera.core']/class/implements[@name='androidx.camera.core.TargetConfig.Builder']" />
     
     <remove-node
-        path="/api/package[@name='androidx.camera.core']/class[@name='Preview.Builder']/implements"
-        />
-    <remove-node
-        path="/api/package[@name='androidx.camera.core']/class[@name='ImageAnalysis.Builder']/implements"
-        />
-    <remove-node
-        path="/api/package[@name='androidx.camera.core']/class[@name='ImageCapture.Builder']/implements"
-        />
-    <remove-node
         path="/api/package[@name='androidx.camera.core.impl']/class[@name='VideoCaptureConfig.Builder']"
         />
 

--- a/source/androidx.camera/camera-view/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.camera/camera-view/Transforms/Metadata.Namespaces.xml
@@ -31,6 +31,12 @@
         >
         AndroidX.Camera.View.Preview.Transform.Transformation
     </attr>
+    <attr 
+        path="/api/package[@name='androidx.camera.view.video']" 
+        name="managedName"
+        >
+        AndroidX.Camera.View.Video
+    </attr>
     
     
 </metadata>


### PR DESCRIPTION
Fixes #216 
Fixes #233 

When binding `androidx.camera.camera-core`, the interfaces were removed from `AndroidX.Camera.Core.Preview.Builder` to fix some binding errors. This makes the class not usable with the `Camera2Interop.Extender (IExtendableBuilder)` ctor.

I added back the interfaces, which resulted in errors due to covariant return types for methods such as `SetTargetName (string)`.  Instead of changing to return type to JLO to match using metadata, I made an explicit interface implementation that implements the interface.  

This is because the API is designed to be used as a fluent API, and if we change the return type to JLO, it can no longer be used fluently:

```
var previewBuilder = new Preview.Builder()
    .SetTargetName ("camera")
    .SetTargetAspectRatio (AspectRatio.Ratio43)
    .SetTargetRotation ((int)viewFinder.Display.Rotation);
```

The same fix is also applied for `ImageAnalysis.Builder`, `ImageCapture.Builder`, and `VideoCapture.Builder`.

Also bumps to latest unstable versions to include newer APIs.