### PR TITLE
[material] Mark 1.2.1 as 'stable'.

### DIFF
--- a/config.json
+++ b/config.json
@@ -837,7 +837,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1-rc1",
+        "nugetVersion": "1.2.1",
         "nugetId": "Xamarin.Google.Android.Material",
         "dependencyOnly": false
       },


### PR DESCRIPTION
We've had `Xamarin.Google.Android.Material` as `rc1` for a few weeks now and there have not been any new reported issues.  We should mark it as `stable` so more people can use it.