### PR TITLE
[migration-tests] Disable test that relies on no longer available Facebook SDK.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -955,19 +955,19 @@ Task("migration-tests-externals")
     .Does(() =>
 {
     // download the facebook sdk to test with
-    {
-        var sdkRoot = "./externals/test-assets/facebook-sdk/";
-        var facebookFilename = "facebook-android-sdk";
-        var facebookVersion = "4.40.0";
-        var facebookFullName = $"{facebookFilename}-{facebookVersion}";
-        var facebookTestUrl = $"https://origincache.facebook.com/developers/resources/?id={facebookFullName}.zip";
-        var zipName = $"{sdkRoot}{facebookFilename}.zip";
-        EnsureDirectoryExists(sdkRoot);
-        if (!FileExists(zipName)) {
-            DownloadFile(facebookTestUrl, zipName);
-            Unzip(zipName, sdkRoot);
-        }
-    }
+    //{
+    //    var sdkRoot = "./externals/test-assets/facebook-sdk/";
+    //    var facebookFilename = "facebook-android-sdk";
+    //    var facebookVersion = "4.40.0";
+    //    var facebookFullName = $"{facebookFilename}-{facebookVersion}";
+    //    var facebookTestUrl = $"https://origincache.facebook.com/developers/resources/?id={facebookFullName}.zip";
+    //    var zipName = $"{sdkRoot}{facebookFilename}.zip";
+    //    EnsureDirectoryExists(sdkRoot);
+    //    if (!FileExists(zipName)) {
+    //        DownloadFile(facebookTestUrl, zipName);
+    //        Unzip(zipName, sdkRoot);
+    //    }
+    //}
 
     // downlaod some dodgy dlls
     {

--- a/tests/AndroidXMigrationTests/Tests/JetifierTests.cs
+++ b/tests/AndroidXMigrationTests/Tests/JetifierTests.cs
@@ -230,7 +230,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 			Assert.Equal("androidx/fragment/app/Fragment", simpleFragment.SuperClass.Name.Value);
 		}
 
-		[Fact]
+		//[Fact]
 		public async Task JetifierWrapperMigratesFacebookAar()
 		{
 			var facebookFilename = "facebook-android-sdk";

--- a/tests/AndroidXMigrationTests/Tests/Xamarin.AndroidX.Migration.Tests.csproj
+++ b/tests/AndroidXMigrationTests/Tests/Xamarin.AndroidX.Migration.Tests.csproj
@@ -46,10 +46,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.IdentityModel.Clients.ActiveDirectory.pdb</Link>
     </Content>
-    <Content Include="..\..\..\externals\test-assets\facebook-sdk\facebook-android-sdk.zip">
+    <!--<Content Include="..\..\..\externals\test-assets\facebook-sdk\facebook-android-sdk.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>facebook-android-sdk.zip</Link>
-    </Content>
+    </Content>-->
   </ItemGroup>
 
   <!-- Cecilfier test assets -->


### PR DESCRIPTION
One of the AndroidX migration tests relies on downloading a Facebook SDK from:
```
https://origincache.facebook.com
```

This server no longer seems to exist, disable the test so we can pass tests and publish NuGet packages.