### PR TITLE
Bump Browser NuGet version to be greater than published beta

### DIFF
--- a/config.json
+++ b/config.json
@@ -133,7 +133,7 @@
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.3",
         "nugetId": "Xamarin.AndroidX.Browser",
         "dependencyOnly": false
       },


### PR DESCRIPTION
We released a stable `1.3.0` for `Xamarin.AndroidX.Browser`, however we had already released a `1.3.0.3-alpha01` version which is a higher version.

This bumps the stable version to `1.3.0.3` so it is considered the highest version.