### PR TITLE
Bump all package revisions to force newer resolution of Migration package.

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Activity",
         "dependencyOnly": false
       },
@@ -37,7 +37,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.3-alpha04",
+        "nugetVersion": "1.0.0.4-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.Idetifier",
         "dependencyOnly": false
       },
@@ -45,7 +45,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.3-alpha04",
+        "nugetVersion": "1.0.0.4-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon",
         "dependencyOnly": false
       },
@@ -53,7 +53,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.3-alpha04",
+        "nugetVersion": "1.0.0.4-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider",
         "dependencyOnly": false
       },
@@ -61,7 +61,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.7",
+        "nugetVersion": "1.1.0.8",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "dependencyOnly": false
       },
@@ -69,7 +69,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental",
         "dependencyOnly": false
       },
@@ -77,7 +77,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.5",
+        "nugetVersion": "1.2.0.6",
         "nugetId": "Xamarin.AndroidX.AppCompat",
         "dependencyOnly": false
       },
@@ -85,7 +85,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.5",
+        "nugetVersion": "1.2.0.6",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
         "dependencyOnly": false
       },
@@ -93,7 +93,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.6",
+        "nugetVersion": "2.1.0.7",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common",
         "dependencyOnly": false
       },
@@ -101,7 +101,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.6",
+        "nugetVersion": "2.1.0.7",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime",
         "dependencyOnly": false
       },
@@ -109,7 +109,7 @@
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater",
         "dependencyOnly": false
       },
@@ -117,7 +117,7 @@
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.1.0-beta01",
-        "nugetVersion": "1.1.0.3-beta01",
+        "nugetVersion": "1.1.0.4-beta01",
         "nugetId": "Xamarin.AndroidX.AutoFill",
         "dependencyOnly": false
       },
@@ -125,7 +125,7 @@
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.6",
+        "nugetVersion": "1.0.1.7",
         "nugetId": "Xamarin.AndroidX.Biometric",
         "dependencyOnly": false
       },
@@ -133,7 +133,7 @@
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Browser",
         "dependencyOnly": false
       },
@@ -141,7 +141,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.3-beta05",
+        "nugetVersion": "1.0.0.4-beta05",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2",
         "dependencyOnly": false
       },
@@ -149,7 +149,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.3-beta05",
+        "nugetVersion": "1.0.0.4-beta05",
         "nugetId": "Xamarin.AndroidX.Camera.Core",
         "dependencyOnly": false
       },
@@ -157,7 +157,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.0.0-beta05",
-        "nugetVersion": "1.0.0.3-beta05",
+        "nugetVersion": "1.0.0.4-beta05",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle",
         "dependencyOnly": false
       },
@@ -165,7 +165,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
         "version": "1.0.0-alpha12",
-        "nugetVersion": "1.0.0.3-alpha12",
+        "nugetVersion": "1.0.0.4-alpha12",
         "nugetId": "Xamarin.AndroidX.Camera.View",
         "dependencyOnly": false
       },
@@ -173,7 +173,7 @@
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.3-alpha7",
+        "nugetVersion": "1.0.0.4-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car",
         "dependencyOnly": false
       },
@@ -181,7 +181,7 @@
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.3-alpha5",
+        "nugetVersion": "1.0.0.4-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster",
         "dependencyOnly": false
       },
@@ -189,7 +189,7 @@
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.CardView",
         "dependencyOnly": false
       },
@@ -197,7 +197,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Collection",
         "dependencyOnly": false
       },
@@ -205,7 +205,7 @@
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures",
         "dependencyOnly": false
       },
@@ -213,7 +213,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4",
+        "nugetVersion": "2.0.4.1",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout",
         "dependencyOnly": false
       },
@@ -221,7 +221,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4",
+        "nugetVersion": "2.0.4.1",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver",
         "dependencyOnly": false
       },
@@ -229,7 +229,7 @@
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.ContentPager",
         "dependencyOnly": false
       },
@@ -237,7 +237,7 @@
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout",
         "dependencyOnly": false
       },
@@ -245,7 +245,7 @@
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2",
+        "nugetVersion": "1.3.2.1",
         "nugetId": "Xamarin.AndroidX.Core",
         "dependencyOnly": false
       },
@@ -253,7 +253,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.3-alpha01",
+        "nugetVersion": "1.0.0.4-alpha01",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
@@ -261,7 +261,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.0.0-rc01",
-        "nugetVersion": "1.0.0.3-rc01",
+        "nugetVersion": "1.0.0.4-rc01",
         "nugetId": "Xamarin.AndroidX.Core.Role",
         "dependencyOnly": false
       },
@@ -269,7 +269,7 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.CursorAdapter",
         "dependencyOnly": false
       },
@@ -277,7 +277,7 @@
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.CustomView",
         "dependencyOnly": false
       },
@@ -285,7 +285,7 @@
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.5",
+        "nugetVersion": "1.0.1.6",
         "nugetId": "Xamarin.AndroidX.DocumentFile",
         "dependencyOnly": false
       },
@@ -293,7 +293,7 @@
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1",
+        "nugetVersion": "1.1.1.1",
         "nugetId": "Xamarin.AndroidX.DrawerLayout",
         "dependencyOnly": false
       },
@@ -301,7 +301,7 @@
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation",
         "dependencyOnly": false
       },
@@ -309,7 +309,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Emoji",
         "dependencyOnly": false
       },
@@ -317,7 +317,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat",
         "dependencyOnly": false
       },
@@ -325,7 +325,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled",
         "dependencyOnly": false
       },
@@ -333,7 +333,7 @@
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2",
+        "nugetVersion": "1.3.2.1",
         "nugetId": "Xamarin.AndroidX.ExifInterface",
         "dependencyOnly": false
       },
@@ -341,7 +341,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.2.5",
-        "nugetVersion": "1.2.5.3",
+        "nugetVersion": "1.2.5.4",
         "nugetId": "Xamarin.AndroidX.Fragment",
         "dependencyOnly": false
       },
@@ -349,7 +349,7 @@
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.GridLayout",
         "dependencyOnly": false
       },
@@ -357,7 +357,7 @@
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.HeifWriter",
         "dependencyOnly": false
       },
@@ -365,7 +365,7 @@
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Interpolator",
         "dependencyOnly": false
       },
@@ -373,7 +373,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Leanback",
         "dependencyOnly": false
       },
@@ -381,7 +381,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference",
         "dependencyOnly": false
       },
@@ -389,7 +389,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14",
         "dependencyOnly": false
       },
@@ -397,7 +397,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.6",
+        "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI",
         "dependencyOnly": false
       },
@@ -405,7 +405,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
         "dependencyOnly": false
       },
@@ -413,7 +413,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13",
         "dependencyOnly": false
       },
@@ -421,7 +421,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
         "dependencyOnly": false
       },
@@ -429,7 +429,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common",
         "dependencyOnly": false
       },
@@ -437,7 +437,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.5",
+        "nugetVersion": "2.2.0.6",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
         "dependencyOnly": false
       },
@@ -445,7 +445,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData",
         "dependencyOnly": false
       },
@@ -453,7 +453,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core",
         "dependencyOnly": false
       },
@@ -461,7 +461,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process",
         "dependencyOnly": false
       },
@@ -469,7 +469,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime",
         "dependencyOnly": false
       },
@@ -477,7 +477,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service",
         "dependencyOnly": false
       },
@@ -485,7 +485,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel",
         "dependencyOnly": false
       },
@@ -493,7 +493,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState",
         "dependencyOnly": false
       },
@@ -501,7 +501,7 @@
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Loader",
         "dependencyOnly": false
       },
@@ -509,7 +509,7 @@
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
         "dependencyOnly": false
       },
@@ -517,7 +517,7 @@
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.Media",
         "dependencyOnly": false
       },
@@ -525,7 +525,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Media2.Common",
         "dependencyOnly": false
       },
@@ -533,7 +533,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Media2.Session",
         "dependencyOnly": false
       },
@@ -541,7 +541,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Media2.Widget",
         "dependencyOnly": false
       },
@@ -549,7 +549,7 @@
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.MediaRouter",
         "dependencyOnly": false
       },
@@ -557,7 +557,7 @@
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.5",
+        "nugetVersion": "2.0.1.6",
         "nugetId": "Xamarin.AndroidX.MultiDex",
         "dependencyOnly": false
       },
@@ -565,7 +565,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.3.2",
-        "nugetVersion": "2.3.2",
+        "nugetVersion": "2.3.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common",
         "dependencyOnly": false
       },
@@ -573,7 +573,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.3.2",
-        "nugetVersion": "2.3.2",
+        "nugetVersion": "2.3.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment",
         "dependencyOnly": false
       },
@@ -581,7 +581,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.3.2",
-        "nugetVersion": "2.3.2",
+        "nugetVersion": "2.3.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime",
         "dependencyOnly": false
       },
@@ -589,7 +589,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.3.2",
-        "nugetVersion": "2.3.2",
+        "nugetVersion": "2.3.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI",
         "dependencyOnly": false
       },
@@ -597,7 +597,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "2.1.2",
-        "nugetVersion": "2.1.2.5",
+        "nugetVersion": "2.1.2.6",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
         "dependencyOnly": false
       },
@@ -605,7 +605,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "2.1.2",
-        "nugetVersion": "2.1.2.5",
+        "nugetVersion": "2.1.2.6",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime",
         "dependencyOnly": false
       },
@@ -613,7 +613,7 @@
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Palette",
         "dependencyOnly": false
       },
@@ -621,7 +621,7 @@
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.6",
+        "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.PercentLayout",
         "dependencyOnly": false
       },
@@ -629,7 +629,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Preference",
         "dependencyOnly": false
       },
@@ -637,7 +637,7 @@
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Print",
         "dependencyOnly": false
       },
@@ -645,7 +645,7 @@
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Recommendation",
         "dependencyOnly": false
       },
@@ -653,7 +653,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
         "dependencyOnly": false
       },
@@ -661,7 +661,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection",
         "dependencyOnly": false
       },
@@ -669,7 +669,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.2.5",
-        "nugetVersion": "2.2.5.5",
+        "nugetVersion": "2.2.5.6",
         "nugetId": "Xamarin.AndroidX.Room.Common",
         "dependencyOnly": false
       },
@@ -677,7 +677,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.2.5",
-        "nugetVersion": "2.2.5.5",
+        "nugetVersion": "2.2.5.6",
         "nugetId": "Xamarin.AndroidX.Room.Guava",
         "dependencyOnly": false
       },
@@ -685,7 +685,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.2.5",
-        "nugetVersion": "2.2.5.5",
+        "nugetVersion": "2.2.5.6",
         "nugetId": "Xamarin.AndroidX.Room.Runtime",
         "dependencyOnly": false
       },
@@ -693,7 +693,7 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.1.0-alpha01",
-        "nugetVersion": "1.1.0.3-alpha01",
+        "nugetVersion": "1.1.0.4-alpha01",
         "nugetId": "Xamarin.AndroidX.SavedState",
         "dependencyOnly": false
       },
@@ -701,7 +701,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Slice.Builders",
         "dependencyOnly": false
       },
@@ -709,7 +709,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Slice.Core",
         "dependencyOnly": false
       },
@@ -717,7 +717,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Slice.View",
         "dependencyOnly": false
       },
@@ -725,7 +725,7 @@
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout",
         "dependencyOnly": false
       },
@@ -733,7 +733,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.5",
+        "nugetVersion": "2.1.0.6",
         "nugetId": "Xamarin.AndroidX.Sqlite",
         "dependencyOnly": false
       },
@@ -741,7 +741,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.5",
+        "nugetVersion": "2.1.0.6",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework",
         "dependencyOnly": false
       },
@@ -749,7 +749,7 @@
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout",
         "dependencyOnly": false
       },
@@ -757,7 +757,7 @@
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.5",
+        "nugetVersion": "1.3.1.6",
         "nugetId": "Xamarin.AndroidX.Transition",
         "dependencyOnly": false
       },
@@ -765,7 +765,7 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.TvProvider",
         "dependencyOnly": false
       },
@@ -773,7 +773,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },
@@ -781,7 +781,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated",
         "dependencyOnly": false
       },
@@ -789,7 +789,7 @@
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable",
         "dependencyOnly": false
       },
@@ -797,7 +797,7 @@
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.ViewPager",
         "dependencyOnly": false
       },
@@ -805,7 +805,7 @@
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.ViewPager2",
         "dependencyOnly": false
       },
@@ -813,7 +813,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Wear",
         "dependencyOnly": false
       },
@@ -821,7 +821,7 @@
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.WebKit",
         "dependencyOnly": false
       },
@@ -829,7 +829,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.AndroidX.Work.Runtime",
         "dependencyOnly": false
       },
@@ -837,7 +837,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.Google.Android.Material",
         "dependencyOnly": false
       },


### PR DESCRIPTION
In order to include new Xamarin.Forms templates in Visual Studio, there is a process that downloads every NuGet package referenced by the templates.  Unfortunately it doesn't do normal NuGet resolution; it downloads *every* referenced version of a package instead of just the one that NuGet would resolve.  This creates another issue because the `AndroidX.Migration` version `1.0.7.1` contains an unsigned `Mono.Cecil.dll` assembly which the script also doesn't like.

Unfortunately the dependency tree used by XF is expansive and it isn't really feasible to only update a few packages as was done in #201.  So we have to bump all packages instead.

Additionally updates the `update-config.csx` script to make this revision bump automatically, as well as updates to include a trailing linefeed and support for GPS's pattern of prepending a `1` in front of version numbers.  (`19.0.0` -> `119.0.0`)