### PR TITLE
[msbuild] don't add @(AndroidJavaLibrary) in class libraries

### DIFF
--- a/source/AndroidXTargets.cshtml
+++ b/source/AndroidXTargets.cshtml
@@ -36,7 +36,7 @@
       <AndroidFragmentType>AndroidX.Fragment.App.Fragment</AndroidFragmentType> 
   </PropertyGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
     @foreach (var art in @Model.MavenArtifacts) {
       if ($"{art.MavenGroupId}.{art.MavenArtifactId}" == "androidx.multidex.multidex") {
         // multidex is a special case that only includes the aar conditionally


### PR DESCRIPTION
### Describe your contribution

Context: https://github.com/xamarin/xamarin-android/pull/5477

I found that adding the AndroidX packages to a class library adds some
AndroidX `.jar` files to the build output...

Such as:

https://github.com/xamarin/xamarin-android/blob/597e7169b069eff781d8f29ddb7746b719d7f781/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Legacy.targets#L452-L466

I think that we only want to add `.jar` files to Android application
projects. Otherwise, this is attempting to add these files to the
`__AndroidLibraryProjects__.zip` file that is an `EmbeddedResource` of
Xamarin.Android class libraries.

Let's add a `Condition=" '$(AndroidApplication)' == 'true' "`, so that
these `@(AndroidJavaLibrary)` or `@(AndroidAarLibrary)` items are only
added for Xamarin.Android application projects and not class
libraries.

### Does this change any of the generated binding API's?

No
