### PR TITLE
DataBinding artifacts

### DIFF
--- a/config.json
+++ b/config.json
@@ -282,6 +282,38 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "androidx.databinding",
+        "artifactId": "databinding-adapters",
+        "version": "4.1.2",
+        "nugetVersion": "4.1.2",
+        "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.databinding",
+        "artifactId": "databinding-common",
+        "version": "4.1.2",
+        "nugetVersion": "4.1.2",
+        "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.databinding",
+        "artifactId": "databinding-runtime",
+        "version": "4.1.2",
+        "nugetVersion": "4.1.2",
+        "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.databinding",
+        "artifactId": "viewbinding",
+        "version": "4.1.2",
+        "nugetVersion": "4.1.2",
+        "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding",
+        "dependencyOnly": false
+      },
+      {
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",

--- a/source/androidx.databinding/databinding-adapters/Additions/Additions.cs
+++ b/source/androidx.databinding/databinding-adapters/Additions/Additions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+
+namespace AndroidX.DataBinding.Adapters
+{
+    
+}

--- a/source/androidx.databinding/databinding-adapters/Transforms/EnumFields.xml
+++ b/source/androidx.databinding/databinding-adapters/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.databinding/databinding-adapters/Transforms/EnumMethods.xml
+++ b/source/androidx.databinding/databinding-adapters/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.databinding/databinding-adapters/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.databinding/databinding-adapters/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,16 @@
+﻿<metadata>
+
+    <attr 
+        path="/api/package[@name='androidx.databinding.adapters']"
+        name="managedName"
+        >
+        AndroidX.DataBinding.Adapters
+    </attr>
+    <attr 
+        path="/api/package[@name='androidx.databinding.library']"
+        name="managedName"
+        >
+        AndroidX.DataBinding.Library
+    </attr>
+
+</metadata>

--- a/source/androidx.databinding/databinding-adapters/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.databinding/databinding-adapters/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.databinding/databinding-adapters/Transforms/Metadata.xml
+++ b/source/androidx.databinding/databinding-adapters/Transforms/Metadata.xml
@@ -1,0 +1,7 @@
+﻿<metadata>
+
+    <remove-node
+        path="/api/package[@name='androidx.databinding.adapters']/class[@name='AbsSpinnerBindingAdapter']/method[@name='setEntries' and count(parameter)=2 and parameter[1][@type='android.widget.AbsSpinner'] and parameter[2][@type='T[]']]"
+        />
+
+</metadata>

--- a/source/androidx.databinding/databinding-common/Additions/Additions.cs
+++ b/source/androidx.databinding/databinding-common/Additions/Additions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+
+namespace AndroidX.DataBinding
+{
+    
+}

--- a/source/androidx.databinding/databinding-common/Transforms/EnumFields.xml
+++ b/source/androidx.databinding/databinding-common/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.databinding/databinding-common/Transforms/EnumMethods.xml
+++ b/source/androidx.databinding/databinding-common/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.databinding/databinding-common/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.databinding/databinding-common/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+
+    <attr 
+        path="/api/package[@name='androidx.databinding']"
+        name="managedName"
+        >
+        AndroidX.DataBinding
+    </attr>
+
+</metadata>

--- a/source/androidx.databinding/databinding-common/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.databinding/databinding-common/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.databinding/databinding-common/Transforms/Metadata.xml
+++ b/source/androidx.databinding/databinding-common/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/androidx.databinding/databinding-runtime/Additions/Additions.cs
+++ b/source/androidx.databinding/databinding-runtime/Additions/Additions.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+
+namespace AndroidX.DataBinding
+{
+}

--- a/source/androidx.databinding/databinding-runtime/Transforms/EnumFields.xml
+++ b/source/androidx.databinding/databinding-runtime/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.databinding/databinding-runtime/Transforms/EnumMethods.xml
+++ b/source/androidx.databinding/databinding-runtime/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.databinding/databinding-runtime/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.databinding/databinding-runtime/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,16 @@
+﻿<metadata>
+
+    <attr 
+        path="/api/package[@name='androidx.databinding']"
+        name="managedName"
+        >
+        AndroidX.DataBinding
+    </attr>
+    <attr 
+        path="/api/package[@name='androidx.databinding.library']"
+        name="managedName"
+        >
+        AndroidX.DataBinding.Library
+    </attr>
+
+</metadata>

--- a/source/androidx.databinding/databinding-runtime/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.databinding/databinding-runtime/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.databinding/databinding-runtime/Transforms/Metadata.xml
+++ b/source/androidx.databinding/databinding-runtime/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/androidx.databinding/viewbinding/Additions/Additions.cs
+++ b/source/androidx.databinding/viewbinding/Additions/Additions.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+
+namespace AndroidX.ViewBinding
+{
+}

--- a/source/androidx.databinding/viewbinding/Transforms/EnumFields.xml
+++ b/source/androidx.databinding/viewbinding/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.databinding/viewbinding/Transforms/EnumMethods.xml
+++ b/source/androidx.databinding/viewbinding/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.databinding/viewbinding/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.databinding/viewbinding/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,9 @@
+﻿<metadata>
+    <attr 
+        path="/api/package[@name='androidx.viewbinding']"
+        name="managedName"
+        >
+        AndroidX.ViewBinding
+    </attr>
+    
+</metadata>

--- a/source/androidx.databinding/viewbinding/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.databinding/viewbinding/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.databinding/viewbinding/Transforms/Metadata.xml
+++ b/source/androidx.databinding/viewbinding/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

-   androidx.databinding.databinding-adapters - 4.1.2

-   androidx.databinding.databinding-common - 4.1.2

-   androidx.databinding.databinding-runtime - 4.1.2

-   androidx.databinding.viewbinding - 4.1.2


### Does this change any of the generated binding API's?

yes. New artifacts.

### Describe your contribution

Bindings of new DataBinding artifacts

See related issues:

https://github.com/xamarin/AndroidX/issues/243

https://github.com/xamarin/xamarin-android/issues/3853

