### PR TITLE
AndroidX.Ads.Identifier fixed nugetId typo (was AndroidX.Ads.Idetifier)

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha04",
         "nugetVersion": "1.0.0.4-alpha04",
-        "nugetId": "Xamarin.AndroidX.Ads.Idetifier",
+        "nugetId": "Xamarin.AndroidX.Ads.Identifier",
         "dependencyOnly": false
       },
       {


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

### Does this change any of the generated binding API's?

No, but dependency

### Describe your contribution

Changed nugetId typo
