### PR TITLE
Revert `androidx.savedstate.savedstate` to stable version.

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Activity",
         "dependencyOnly": false
       },
@@ -373,7 +373,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.2.5",
-        "nugetVersion": "1.2.5.4",
+        "nugetVersion": "1.2.5.5",
         "nugetId": "Xamarin.AndroidX.Fragment",
         "dependencyOnly": false
       },
@@ -525,7 +525,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.4",
+        "nugetVersion": "2.2.0.5",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState",
         "dependencyOnly": false
       },
@@ -724,8 +724,8 @@
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
-        "version": "1.1.0-alpha01",
-        "nugetVersion": "1.1.0.4-alpha01",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.SavedState",
         "dependencyOnly": false
       },


### PR DESCRIPTION
Fixes #229.

When we bind unstable versions previews of Google packages that we already have stable versions of we can no longer push updates to the stable version.  Additionally our dependency generation will cause stable versions of other packages to depend on the unstable version.

This happens for:
* androidx.savedstate.savedstate (1.0.0 and 1.1.0-alpha01)
* androidx.autofill.autofill (1.0.0 and 1.1.0-beta01)

`autofill` will be fixed in #251 because Google has made `1.1.0` the stable version.  This leaves `savedstate`.  We need to revert `config.json` to be the stable version of `savedstate`.  Additionally we need to bump the 3 packages that depend on `savedstate` so they will re-release depending on the stable version.

Going forward we need to not bind preview versions of packages that we are already binding stable versions of, until we find a way around this.  Binding a preview version of a package that has never had a stable version, like `androidx.camera.camera-camera2 1.0.0-rc01` is fine.