### PR TITLE
Bump packages affecting by fixing Accessibiity typo fix.

### DIFF
--- a/config.json
+++ b/config.json
@@ -245,7 +245,7 @@
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.1",
+        "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.Core",
         "dependencyOnly": false
       },
@@ -277,7 +277,7 @@
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.CustomView",
         "dependencyOnly": false
       },
@@ -661,7 +661,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.6",
+        "nugetVersion": "1.1.1.7",
         "nugetId": "Xamarin.AndroidX.Preference",
         "dependencyOnly": false
       },
@@ -685,7 +685,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.6",
+        "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
         "dependencyOnly": false
       },


### PR DESCRIPTION
In https://github.com/xamarin/AndroidX/pull/238 we fixed a namespace typo `AndroidX.Core.View.Accessibiity` -> `AndroidX.Core.View.Accessibility`.

These packages depend on types in that namespace, so they need to be bumped so they point to the new namespace.