### PR TITLE
[msbuild] allow @(AndroidAarLibrary) in class libraries

### DIFF
--- a/samples/BuildAll/BuildAll.sln
+++ b/samples/BuildAll/BuildAll.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.28606.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildAll", "BuildAll\BuildAll.csproj", "{F47B1471-0F85-4690-B8A7-09F86ABBB1F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{49B04B11-434E-4579-AB17-D636343568AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{F47B1471-0F85-4690-B8A7-09F86ABBB1F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F47B1471-0F85-4690-B8A7-09F86ABBB1F6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F47B1471-0F85-4690-B8A7-09F86ABBB1F6}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{49B04B11-434E-4579-AB17-D636343568AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49B04B11-434E-4579-AB17-D636343568AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49B04B11-434E-4579-AB17-D636343568AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49B04B11-434E-4579-AB17-D636343568AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/BuildAll/ClassLibrary/Class1.cs
+++ b/samples/BuildAll/ClassLibrary/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/samples/BuildAll/ClassLibrary/ClassLibrary.csproj
+++ b/samples/BuildAll/ClassLibrary/ClassLibrary.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{49B04B11-434E-4579-AB17-D636343568AC}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{9ef11e43-1701-4396-8835-8392d57abb70}</TemplateGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ClassLibrary</RootNamespace>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>True</Deterministic>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Resources\Resource.designer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\values\strings.xml" />
+  </ItemGroup>
+  <Import Project="..\..\..\output\AllPackages.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+</Project>

--- a/samples/BuildAll/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/samples/BuildAll/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Android.App;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/BuildAll/ClassLibrary/Resources/values/strings.xml
+++ b/samples/BuildAll/ClassLibrary/Resources/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="hello">Hello World, Click Me!</string>
+    <string name="app_name">ClassLibrary</string>
+</resources>

--- a/samples/NuGet.config
+++ b/samples/NuGet.config
@@ -7,4 +7,7 @@
         <!--
         -->
     </packageSources>
+    <config>
+        <add key="globalPackagesFolder" value="../packages" />
+    </config>
 </configuration>

--- a/source/AndroidXTargets.cshtml
+++ b/source/AndroidXTargets.cshtml
@@ -36,7 +36,7 @@
       <AndroidFragmentType>AndroidX.Fragment.App.Fragment</AndroidFragmentType> 
   </PropertyGroup>
   
-  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
+  <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if ($"{art.MavenGroupId}.{art.MavenArtifactId}" == "androidx.multidex.multidex") {
         // multidex is a special case that only includes the aar conditionally
@@ -48,7 +48,7 @@
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidAarLibrary>
       } else {
-    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar">
+    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidJavaLibrary>
       }


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

### Does this change any of the generated binding API's?

No

### Describe your contribution

Fixes: https://github.com/xamarin/AndroidX/issues/267

A minimal combination of these packages causes a build failure in a
class library:

    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.6" />
    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.2" />

Fails with:

    (_UpdateAndroidResgenAapt2 target) ->
        ClassLibrary1\obj\Debug\monoandroid10.0\lp\42\jl\res\color\abc_btn_colored_borderless_text_material.xml(21): error APT2260: attribute alpha (aka ClassLibrary1.ClassLibrary1:alpha) not found.
        ...
        ClassLibrary1\obj\Debug\monoandroid10.0\lp\42\jl\res\color\abc_tint_switch_track.xml(22): error APT2260: attribute alpha (aka ClassLibrary1.ClassLibrary1:alpha) not found.
        C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Aapt2.targets(164,3): error APT2061: failed linking file resources.

This broke in 8625c58a / #239 when I was trying to fix a situation
where we were adding `@(AndroidJavaLibary)` to class libraries. This
was bad because it was *repackaging* the `.jar` from a NuGet package
into the user's library.

The fix in 8625c58a, was to to not add these to class library
projects. We mistakenly thought we should do this for
`@(AndroidAarLibrary)` as well, but that was a bad idea! We need the
`@(AndroidAarLibrary)` for `Resource.designer.cs` generation.

To test for this problem in the future, I added a
`BuildAll/ClassLibrary.csproj` that reproduced the issue. We now build
a class library that references all the AndroidX packages.

I also updated the `NuGet.config` to use a local `packages` folder. I
was seeing my global NuGet cache `%userprofile%\.nuget\packages` being
used when building these samples.