### PR TITLE
AndroidX.Media2 namespaces typos fixes

### DIFF
--- a/source/androidx.media2/media2-common/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.media2/media2-common/Transforms/Metadata.Namespaces.xml
@@ -11,13 +11,13 @@
         path="/api/package[@name='androidx.media2.common']" 
         name="managedName"
         >
-        AndroidX.Medai2.Common
+        AndroidX.Media2.Common
     </attr>
     <attr 
         path="/api/package[@name='androidx.media2.common.futures']" 
         name="managedName"
         >
-        AndroidX.Medai2.Common.Futures
+        AndroidX.Media2.Common.Futures
     </attr>
     
 </metadata>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

androidx.media2

### Does this change any of the generated binding API's?

No.

### Describe your contribution

namespace typos fixes
