### PR TITLE
Update to Xamarin.Android 16.9.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,13 +34,13 @@ jobs:
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-8-macos
+            boots https://aka.ms/xamarin-android-commercial-d16-9-macos
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-8-windows
+            boots https://aka.ms/xamarin-android-commercial-d16-9-windows
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '0.4.2'


### PR DESCRIPTION
ApiDiff shows no differences in API between this and current `master`, so this should be safe to update.