### PR TITLE
Fixing the typo (missing "arch)"

### DIFF
--- a/config.json
+++ b/config.json
@@ -501,7 +501,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1",
+        "nugetVersion": "2.3.1.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime",
         "dependencyOnly": false
       },
@@ -869,7 +869,7 @@
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.0-alpha05",
+        "nugetVersion": "1.0.0.1-alpha05",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -877,7 +877,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.0-alpha01",
+        "nugetVersion": "1.0.0.1-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions",
         "dependencyOnly": false
       },

--- a/mappings/dependencies.json
+++ b/mappings/dependencies.json
@@ -30,6 +30,7 @@
       "dependencies": [
         "Xamarin.AndroidX.Annotation",
         "Xamarin.AndroidX.Arch.Core.Common",
+        "Xamarin.AndroidX.Arch.Core.Runtime",
         "Xamarin.AndroidX.Lifecycle.Common"
       ]
     },
@@ -836,16 +837,12 @@
     {
       "id": "Xamarin.AndroidX.Window",
       "dependencies": [
-        "Xamarin.AndroidX.Annotation",
-        "Xamarin.AndroidX.Collection",
         "Xamarin.AndroidX.Core"
       ]
     },
     {
       "id": "Xamarin.AndroidX.Window.WindowExtensions",
-      "dependencies": [
-        "Xamarin.AndroidX.Annotation"
-      ]
+      "dependencies": []
     },
     {
       "id": "Xamarin.AndroidX.Work.Runtime",

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -189,7 +189,7 @@
     }
     @if (@Model.NuGetPackageId == "Xamarin.AndroidX.Lifecycle.Runtime") 
     {
-        <ProjectReference Include="..\androidx.core.core-runtime\androidx.core.core-runtime.csproj" PrivateAssets="none" />
+        <ProjectReference Include="..\androidx.arch.core.core-runtime\androidx.arch.core.core-runtime.csproj" PrivateAssets="none" />
     }
   </ItemGroup>
   

--- a/tests/AndroidXMigrationTests/Tests/DependenciesTests.cs
+++ b/tests/AndroidXMigrationTests/Tests/DependenciesTests.cs
@@ -269,7 +269,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 				"Xamarin.AndroidX.AppCompat",
 				"Xamarin.AndroidX.AppCompat.AppCompatResources",
 				"Xamarin.AndroidX.Arch.Core.Common",
-				//"Xamarin.AndroidX.Arch.Core.Runtime",
+				"Xamarin.AndroidX.Arch.Core.Runtime",
 				"Xamarin.AndroidX.AsyncLayoutInflater",
 				"Xamarin.AndroidX.Browser",
 				"Xamarin.AndroidX.CardView",


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

### Does this change any of the generated binding API's?

No
