### PR TITLE
[yaml] Update to XA 16.10.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,13 +34,13 @@ jobs:
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-9-macos
+            boots https://aka.ms/xamarin-android-commercial-d16-10-macos
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-9-windows
+            boots https://aka.ms/xamarin-android-commercial-d16-10-windows
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '0.4.2'

--- a/config.json
+++ b/config.json
@@ -133,7 +133,7 @@
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Biometric",
         "dependencyOnly": false
       },
@@ -437,7 +437,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.8",
+        "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AndroidX.Leanback",
         "dependencyOnly": false
       },
@@ -525,7 +525,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.1",
+        "nugetVersion": "2.3.1.2",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
         "dependencyOnly": false
       },
@@ -749,7 +749,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.1",
+        "nugetVersion": "3.0.0.2",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
         "dependencyOnly": false
       },
@@ -765,7 +765,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.1",
+        "nugetVersion": "3.0.0.2",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime",
         "dependencyOnly": false
       },
@@ -1013,7 +1013,7 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.8",
+        "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AndroidX.TvProvider",
         "dependencyOnly": false
       },
@@ -1093,7 +1093,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.5.0",
-        "nugetVersion": "2.5.0.1",
+        "nugetVersion": "2.5.0.2",
         "nugetId": "Xamarin.AndroidX.Work.Runtime",
         "dependencyOnly": false
       },


### PR DESCRIPTION
Currently our CI seems to be producing **different** builds between Windows & Mac:

16.9 - Windows:
![image](https://user-images.githubusercontent.com/179295/124021899-bc81e400-d9b1-11eb-933d-72daa0324b7a.png)

16.9 - Mac:
![image](https://user-images.githubusercontent.com/179295/124021982-d4f1fe80-d9b1-11eb-8acc-90df47d1677d.png)

This comparison works against the versions on NuGet.org, so I guess we publish the packages created on Mac to NuGet, which shows no differences.

Unrelated, we should update to the latest XA: 16.10.  Using this version, both Windows & Mac show the same diffs as Windows XA 16.9.  It would seem like the Mac XA 16.9 package was not as recent as the Windows one.

16.10 - Mac
![image](https://user-images.githubusercontent.com/179295/124022501-7da05e00-d9b2-11eb-9e43-5d57a868243d.png)

Additionally, let's bump the patch version of the NuGets with diffs, so updated versions will get pushed to NuGet.org, reducing noise on future diffs.