### PR TITLE
[build] Enable 'strictRuntimeDependencies'.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ pr:
   - main
   
 variables:
+  AndroidBinderatorVersion: 0.4.7
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now
@@ -43,7 +44,7 @@ jobs:
             boots https://aka.ms/xamarin-android-commercial-d16-10-windows
           condition: eq(variables['System.JobName'], 'windows')
       tools:
-        - 'xamarin.androidbinderator.tool': '0.4.2'
+        - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'
         - 'xamarin.androidx.migration.tool': '1.0.7.1'
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ pr:
   
 variables:
   AndroidBinderatorVersion: 0.4.7
+  AndroidXMigrationVersion: 1.0.8
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now
@@ -45,7 +46,7 @@ jobs:
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'
-        - 'xamarin.androidx.migration.tool': '1.0.7.1'
+        - 'xamarin.androidx.migration.tool': '$(AndroidXMigrationVersion)'
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:

--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -184,6 +184,9 @@ public class ArtifactModel
 
 	[JsonProperty ("dependencyOnly")]
 	public bool DependencyOnly { get; set; }
+
+	[JsonProperty ("excludedRuntimeDependencies")]
+	public string ExcludedRuntimeDependencies { get; set; }
 }
 
 public class MyArray
@@ -193,6 +196,12 @@ public class MyArray
 
 	[JsonProperty ("slnFile")]
 	public string SlnFile { get; set; }
+
+	[JsonProperty ("strictRuntimeDependencies")]
+	public bool StrictRuntimeDependencies { get; set; }
+
+	[JsonProperty ("excludedRuntimeDependencies")]
+	public string ExcludedRuntimeDependencies { get; set; }
 
 	[JsonProperty ("additionalProjects")]
 	public List<string> AdditionalProjects { get; set; }

--- a/config.json
+++ b/config.json
@@ -2,6 +2,8 @@
   {
     "mavenRepositoryType": "Google",
     "slnFile": "generated/AndroidX.sln",
+    "strictRuntimeDependencies": true,
+    "excludedRuntimeDependencies": "com.google.crypto.tink.tink-android",
     "additionalProjects": [
       "source/migration/Dummy/Xamarin.AndroidX.Migration.Dummy.csproj",
       "source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj"
@@ -1114,6 +1116,14 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "com.google.auto.value",
+        "artifactId": "auto-value-annotations",
+        "version": "1.6.6",
+        "nugetVersion": "1.6.6",
+        "nugetId": "Xamarin.Google.AutoValue.Annotations",
+        "dependencyOnly": true
+      },
+      {
         "groupId": "com.google.guava",
         "artifactId": "guava",
         "version": "28.2.0",
@@ -1183,6 +1193,14 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "org.jetbrains.kotlinx",
+        "artifactId": "kotlinx-coroutines-rx2",
+        "version": "1.5.0",
+        "nugetVersion": "1.5.0",
+        "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "dependencyOnly": true
       },
       {

--- a/tests/AndroidXMigrationTests/Tests/DependenciesTests.cs
+++ b/tests/AndroidXMigrationTests/Tests/DependenciesTests.cs
@@ -274,6 +274,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 				"Xamarin.AndroidX.Browser",
 				"Xamarin.AndroidX.CardView",
 				"Xamarin.AndroidX.Collection",
+				"Xamarin.AndroidX.Concurrent.Futures",
 				"Xamarin.AndroidX.ConstraintLayout",
 				"Xamarin.AndroidX.ConstraintLayout.Solver",
 				"Xamarin.AndroidX.CoordinatorLayout",
@@ -303,6 +304,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 				"Xamarin.AndroidX.SavedState",
 				"Xamarin.AndroidX.SlidingPaneLayout",
 				"Xamarin.AndroidX.SwipeRefreshLayout",
+				"Xamarin.AndroidX.Tracing.Tracing",
 				"Xamarin.AndroidX.Transition",
 				"Xamarin.AndroidX.VectorDrawable",
 				"Xamarin.AndroidX.VectorDrawable.Animated",
@@ -318,7 +320,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 			var flattened = tree.Flatten(ids).ToList();
 			flattened.Sort();
 
-			Assert.Equal(expected, flattened);
+			Assert.Equal(expected, flattened.ToArray());
 		}
 
 		[Fact]
@@ -373,7 +375,6 @@ namespace Xamarin.AndroidX.Migration.Tests
 				"Xamarin.AndroidX.Legacy.Support.V4",
 				"Xamarin.AndroidX.Lifecycle.LiveData",
 				"Xamarin.AndroidX.MediaRouter",
-				"Xamarin.AndroidX.Palette",
 				"Xamarin.Google.Android.Material",
 			};
 
@@ -382,7 +383,7 @@ namespace Xamarin.AndroidX.Migration.Tests
 			var flattened = tree.Reduce(ids).ToList();
 			flattened.Sort();
 
-			Assert.Equal(expected, flattened);
+			Assert.Equal(expected, flattened.ToArray());
 		}
 	}
 }


### PR DESCRIPTION
Today, we only consider `compile` dependencies listed in a package's `.pom` and not `runtime` dependencies.  This can lead to instances like https://github.com/xamarin/AndroidX/issues/86 where the `.pom` references were changed from `compile` to `runtime` and we no longer have the proper dependencies.

`androidx.work.work-runtime 2.2.0:`
```xml
  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>listenablefuture</artifactId>
      <version>1.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.lifecycle</groupId>
      <artifactId>lifecycle-livedata</artifactId>
      <version>2.0.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.room</groupId>
      <artifactId>room-runtime</artifactId>
      <version>2.1.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.core</groupId>
      <artifactId>core</artifactId>
      <version>1.0.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.lifecycle</groupId>
      <artifactId>lifecycle-service</artifactId>
      <version>2.0.0</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```

`androidx.work.work-runtime 2.3.0:`
```xml
  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>listenablefuture</artifactId>
      <version>1.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.lifecycle</groupId>
      <artifactId>lifecycle-livedata</artifactId>
      <version>2.1.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>androidx.room</groupId>
      <artifactId>room-runtime</artifactId>
      <version>2.2.2</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>androidx.core</groupId>
      <artifactId>core</artifactId>
      <version>1.1.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>androidx.lifecycle</groupId>
      <artifactId>lifecycle-service</artifactId>
      <version>2.1.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```

By opting into the new `strictRuntimeDependencies` mode of `binderator` we will add `runtime` dependencies to the NuGet dependency tree as well, hopefully preventing future issues where we release packages without proper dependency information.

To fulfill some `runtime` dependencies we needed to add the following NuGet references:
- `com.google.auto.value.auto-value-annotations`
- `org.jetbrains.kotlinx.kotlinx-coroutines-rx2`

The following `runtime` dependency is one that is referenced but we do not have a binding for.  At least we have explicitly referenced it in the `config.json` so we know it is missing:
- `com.google.crypto.tink.tink-android`