### PR TITLE
[build] Convert to Xamarin.Legacy.Sdk.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.4.7
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100-preview.5.21302.13
+  DotNetVersion: 6.0.100-preview.6.21355.2
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
   LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
   BUILD_NUMBER: $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,9 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.4.7
   AndroidXMigrationVersion: 1.0.8
+  DotNetVersion: 6.0.100-preview.5.21302.13
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now
@@ -31,18 +34,25 @@ jobs:
       timeoutInMinutes: 120
       validPackagePrefixes: [ 'Xamarin' ]   
       areaPath: 'DevDiv\Xamarin SDK\Android'
+      initSteps:
+        - task: UseDotNet@2
+          displayName: install .NET $(DotNetVersion)
+          inputs:
+            version: $(DotNetVersion)
+        - pwsh: |
+            dotnet workload install microsoft-android-sdk-full
       preBuildSteps:
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-10-macos
+            boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-10-windows
+            boots $(LegacyXamarinAndroidVsix)
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'

--- a/build.cake
+++ b/build.cake
@@ -636,12 +636,10 @@ Task("libs")
     .IsDependentOn("libs-native")
     .Does(() =>
 {
-    var settings = new MSBuildSettings()
+    var settings = new DotNetCoreMSBuildSettings()
         .SetConfiguration(CONFIGURATION)
-        .SetVerbosity(VERBOSITY)
         .SetMaxCpuCount(0)
         .EnableBinaryLogger($"./output/libs.{CONFIGURATION}.binlog")
-        .WithRestore()
         .WithProperty("MigrationPackageVersion", MIGRATION_PACKAGE_VERSION)
         .WithProperty("DesignTimeBuild", "false")
         .WithProperty("AndroidSdkBuildToolsVersion", $"{AndroidSdkBuildTools}");
@@ -649,10 +647,12 @@ Task("libs")
     if (!string.IsNullOrEmpty(ANDROID_HOME))
         settings.WithProperty("AndroidSdkDirectory", $"{ANDROID_HOME}");
 
-    if (!string.IsNullOrEmpty(MSBUILD_PATH))
-        settings.ToolPath = MSBUILD_PATH;
+    DotNetCoreRestore("./generated/AndroidX.sln", new DotNetCoreRestoreSettings
+    {
+        MSBuildSettings = settings.EnableBinaryLogger("./output/restore.binlog")
+    });
 
-    MSBuild("./generated/AndroidX.sln", settings);
+    DotNetCoreMSBuild("./generated/AndroidX.sln", settings);
 });
 
 Task("libs-native")
@@ -674,9 +674,8 @@ Task("nuget")
     .IsDependentOn("libs")
     .Does(() =>
 {
-    var settings = new MSBuildSettings()
+    var settings = new DotNetCoreMSBuildSettings()
         .SetConfiguration(CONFIGURATION)
-        .SetVerbosity(VERBOSITY)
         .SetMaxCpuCount(0)
         .EnableBinaryLogger($"./output/nuget.{CONFIGURATION}.binlog")
         .WithProperty("MigrationPackageVersion", MIGRATION_PACKAGE_VERSION)
@@ -688,10 +687,7 @@ Task("nuget")
     if (!string.IsNullOrEmpty(ANDROID_HOME))
         settings.WithProperty("AndroidSdkDirectory", $"{ANDROID_HOME}");
 
-    if (!string.IsNullOrEmpty(MSBUILD_PATH))
-        settings.ToolPath = MSBUILD_PATH;
-
-    MSBuild("./generated/AndroidX.sln", settings);
+    DotNetCoreMSBuild("./generated/AndroidX.sln", settings);
 });
 
 Task("samples-generate-all-targets")

--- a/global.json
+++ b/global.json
@@ -3,6 +3,7 @@
     {
         "MSBuild.Sdk.Extras": "3.0.23",
         "Microsoft.Build.Traversal": "2.1.1",
-        "Microsoft.Build.NoTargets": "2.0.1"
+        "Microsoft.Build.NoTargets": "2.0.1",
+        "Xamarin.Legacy.Sdk": "0.1.0-alpha2"
     }
 }

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -1,6 +1,6 @@
 ﻿@using System
 @using System.Linq
-<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
     <TargetFramework>MonoAndroid9.0</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
@@ -9,17 +9,8 @@
     } else {
     <AssemblyName>@(Model.NuGetPackageId)</AssemblyName>
     }
-    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
     <RootNamespace>@(Model.NuGetPackageId.Replace("Xamarin.", ""))</RootNamespace>
-    <EnableProguard>true</EnableProguard>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <AndroidUseAapt2>true</AndroidUseAapt2>
-    <AndroidDexTool>d8</AndroidDexTool>
-    <AndroidLinkTool>r8</AndroidLinkTool>
     <!--
       No warnings for:
        - CS0618: 'member' is obsolete: 'text'

--- a/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
+++ b/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
     <AssemblyName>Xamarin.AndroidX.AppCompat.Resources</AssemblyName>

--- a/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
+++ b/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/247

The first step in multi-targeting AndroidX with `net6` is to migrate to `Xamarin.Legacy.Sdk`, which runs on top of .NET 6 but can build `MonoAndroid9.0`.  We'll commit this first to help make it easier to run our diff logic on the resulting packages to make sure there are no regressions.  A future commit will then enable `net6`.

Changes made:
- CI - Install .NET 6 Preview 5
- CI - Install the Android workload
- Change Cake to use `DotNetCore` versions
- Update `Sdk` to `Xamarin.Legacy.Sdk`