### PR TITLE
[update-config] Don't serialize "excludedRuntimeDependencies": null.

### DIFF
--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -16,6 +16,7 @@ using MavenNet;
 using MavenNet.Models;
 using Newtonsoft.Json;
 using NuGet.Versioning;
+using System.ComponentModel;
 
 // Parse the configuration file
 var config_file = Args[0];
@@ -29,6 +30,7 @@ var config_json = File.ReadAllText (config_file);
 var config = JsonConvert.DeserializeObject<List<MyArray>> (config_json);
 var should_update = Args.Count > 1 && Args[1].ToLowerInvariant () == "update";
 var should_minor_bump = Args.Count > 1 && Args[1].ToLowerInvariant () == "bump";
+var serializer_settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
 
 // Query Maven
 var repo = MavenRepository.FromGoogle ();
@@ -96,7 +98,7 @@ foreach (var art in config[0].Artifacts.Where(a => !a.DependencyOnly)) {
 	if (should_update || should_minor_bump)
 	{
 		// Write update config.json back to disk
-		var output = JsonConvert.SerializeObject (config, Formatting.Indented);
+		var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
 		File.WriteAllText (config_file, output + Environment.NewLine);
 	}
 }
@@ -182,6 +184,7 @@ public class ArtifactModel
 	[JsonProperty ("nugetId")]
 	public string NugetId { get; set; }
 
+	[DefaultValue ("")]
 	[JsonProperty ("dependencyOnly")]
 	public bool DependencyOnly { get; set; }
 

--- a/config.json
+++ b/config.json
@@ -33,8 +33,7 @@
         "version": "1.2.3",
         "nugetVersion": "1.2.3",
         "nugetId": "Xamarin.AndroidX.Activity",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.activity",
@@ -42,8 +41,7 @@
         "version": "1.2.3",
         "nugetVersion": "1.2.3",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.ads",
@@ -51,8 +49,7 @@
         "version": "1.0.0-alpha04",
         "nugetVersion": "1.0.0.5-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.ads",
@@ -60,8 +57,7 @@
         "version": "1.0.0-alpha04",
         "nugetVersion": "1.0.0.5-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.ads",
@@ -69,8 +65,7 @@
         "version": "1.0.0-alpha04",
         "nugetVersion": "1.0.0.5-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.annotation",
@@ -78,8 +73,7 @@
         "version": "1.2.0",
         "nugetVersion": "1.2.0",
         "nugetId": "Xamarin.AndroidX.Annotation",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.annotation",
@@ -87,8 +81,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.appcompat",
@@ -96,8 +89,7 @@
         "version": "1.3.0",
         "nugetVersion": "1.3.0",
         "nugetId": "Xamarin.AndroidX.AppCompat",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.appcompat",
@@ -105,8 +97,7 @@
         "version": "1.3.0",
         "nugetVersion": "1.3.0",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.arch.core",
@@ -114,8 +105,7 @@
         "version": "2.1.0",
         "nugetVersion": "2.1.0.8",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.arch.core",
@@ -123,8 +113,7 @@
         "version": "2.1.0",
         "nugetVersion": "2.1.0.8",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.asynclayoutinflater",
@@ -132,8 +121,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.autofill",
@@ -141,8 +129,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.AutoFill",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.biometric",
@@ -150,8 +137,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Biometric",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.browser",
@@ -159,8 +145,7 @@
         "version": "1.3.0",
         "nugetVersion": "1.3.0.5",
         "nugetId": "Xamarin.AndroidX.Browser",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
@@ -168,8 +153,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.5",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
@@ -177,8 +161,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.5",
         "nugetId": "Xamarin.AndroidX.Camera.Core",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.camera",
@@ -186,8 +169,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.5",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.car",
@@ -195,8 +177,7 @@
         "version": "1.0.0-alpha7",
         "nugetVersion": "1.0.0.5-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.car",
@@ -204,8 +185,7 @@
         "version": "1.0.0-alpha5",
         "nugetVersion": "1.0.0.5-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.car.app",
@@ -213,8 +193,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.AndroidX.Car.App.App",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.cardview",
@@ -222,8 +201,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.CardView",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.collection",
@@ -231,8 +209,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.Collection",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.collection",
@@ -240,8 +217,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.concurrent",
@@ -249,8 +225,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.constraintlayout",
@@ -258,8 +233,7 @@
         "version": "2.0.4",
         "nugetVersion": "2.0.4.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.constraintlayout",
@@ -267,8 +241,7 @@
         "version": "2.0.4",
         "nugetVersion": "2.0.4.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.contentpager",
@@ -276,8 +249,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.ContentPager",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.coordinatorlayout",
@@ -285,8 +257,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.core",
@@ -294,8 +265,7 @@
         "version": "1.6.0",
         "nugetVersion": "1.6.0",
         "nugetId": "Xamarin.AndroidX.Core",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.core",
@@ -303,8 +273,7 @@
         "version": "1.6.0",
         "nugetVersion": "1.6.0",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.core",
@@ -312,8 +281,7 @@
         "version": "1.0.0-alpha02",
         "nugetVersion": "1.0.0.5-alpha02",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.core",
@@ -321,8 +289,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.5",
         "nugetId": "Xamarin.AndroidX.Core.Role",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.cursoradapter",
@@ -330,8 +297,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.CursorAdapter",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.customview",
@@ -339,8 +305,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.CustomView",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.databinding",
@@ -348,8 +313,7 @@
         "version": "4.2.2",
         "nugetVersion": "4.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.databinding",
@@ -357,8 +321,7 @@
         "version": "4.2.2",
         "nugetVersion": "4.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.databinding",
@@ -366,8 +329,7 @@
         "version": "4.2.2",
         "nugetVersion": "4.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.databinding",
@@ -375,8 +337,7 @@
         "version": "4.2.2",
         "nugetVersion": "4.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.documentfile",
@@ -384,8 +345,7 @@
         "version": "1.0.1",
         "nugetVersion": "1.0.1.7",
         "nugetId": "Xamarin.AndroidX.DocumentFile",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.drawerlayout",
@@ -393,8 +353,7 @@
         "version": "1.1.1",
         "nugetVersion": "1.1.1.2",
         "nugetId": "Xamarin.AndroidX.DrawerLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.dynamicanimation",
@@ -402,8 +361,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.emoji",
@@ -411,8 +369,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Emoji",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.emoji",
@@ -420,8 +377,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.emoji",
@@ -429,8 +385,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.exifinterface",
@@ -438,8 +393,7 @@
         "version": "1.3.2",
         "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.ExifInterface",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.fragment",
@@ -447,8 +401,7 @@
         "version": "1.3.5",
         "nugetVersion": "1.3.5",
         "nugetId": "Xamarin.AndroidX.Fragment",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.fragment",
@@ -456,8 +409,7 @@
         "version": "1.3.5",
         "nugetVersion": "1.3.5",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.gridlayout",
@@ -465,8 +417,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.GridLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.heifwriter",
@@ -474,8 +425,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.HeifWriter",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.interpolator",
@@ -483,8 +433,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Interpolator",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.leanback",
@@ -492,8 +441,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AndroidX.Leanback",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.leanback",
@@ -501,8 +449,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.legacy",
@@ -510,8 +457,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.legacy",
@@ -519,8 +465,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.legacy",
@@ -528,8 +473,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.legacy",
@@ -537,8 +481,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.legacy",
@@ -546,8 +489,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -555,8 +497,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -564,8 +505,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -573,8 +513,7 @@
         "version": "2.2.0",
         "nugetVersion": "2.2.0.7",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -582,8 +521,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -591,8 +529,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1.2",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -600,8 +537,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -609,8 +545,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -618,8 +553,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -627,8 +561,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -636,8 +569,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -645,8 +577,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -654,8 +585,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -663,8 +593,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -672,8 +601,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -681,8 +609,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.lifecycle",
@@ -690,8 +617,7 @@
         "version": "2.3.1",
         "nugetVersion": "2.3.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.loader",
@@ -699,8 +625,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.Loader",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.localbroadcastmanager",
@@ -708,8 +633,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.media",
@@ -717,8 +641,7 @@
         "version": "1.3.1",
         "nugetVersion": "1.3.1",
         "nugetId": "Xamarin.AndroidX.Media",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.media2",
@@ -726,8 +649,7 @@
         "version": "1.1.3",
         "nugetVersion": "1.1.3",
         "nugetId": "Xamarin.AndroidX.Media2.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.media2",
@@ -735,8 +657,7 @@
         "version": "1.1.3",
         "nugetVersion": "1.1.3",
         "nugetId": "Xamarin.AndroidX.Media2.Session",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.media2",
@@ -744,8 +665,7 @@
         "version": "1.1.3",
         "nugetVersion": "1.1.3",
         "nugetId": "Xamarin.AndroidX.Media2.Widget",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.mediarouter",
@@ -753,8 +673,7 @@
         "version": "1.2.4",
         "nugetVersion": "1.2.4",
         "nugetId": "Xamarin.AndroidX.MediaRouter",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.multidex",
@@ -762,8 +681,7 @@
         "version": "2.0.1",
         "nugetVersion": "2.0.1.7",
         "nugetId": "Xamarin.AndroidX.MultiDex",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -771,8 +689,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -780,8 +697,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -789,8 +705,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -798,8 +713,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -807,8 +721,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -816,8 +729,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -825,8 +737,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.UI",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.navigation",
@@ -834,8 +745,7 @@
         "version": "2.3.5",
         "nugetVersion": "2.3.5",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -843,8 +753,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.2",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -852,8 +761,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -861,8 +769,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.2",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -870,8 +777,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -879,8 +785,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.paging",
@@ -888,8 +793,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.palette",
@@ -897,8 +801,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Palette",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.palette",
@@ -906,8 +809,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.percentlayout",
@@ -915,8 +817,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.PercentLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.preference",
@@ -924,8 +825,7 @@
         "version": "1.1.1",
         "nugetVersion": "1.1.1.8",
         "nugetId": "Xamarin.AndroidX.Preference",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.preference",
@@ -933,8 +833,7 @@
         "version": "1.1.1",
         "nugetVersion": "1.1.1",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.print",
@@ -942,8 +841,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Print",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.recommendation",
@@ -951,8 +849,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Recommendation",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.recyclerview",
@@ -960,8 +857,7 @@
         "version": "1.2.1",
         "nugetVersion": "1.2.1",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.recyclerview",
@@ -969,8 +865,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -978,8 +873,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Common",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -987,8 +881,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -996,8 +889,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Guava",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -1005,8 +897,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -1014,8 +905,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.room",
@@ -1023,8 +913,7 @@
         "version": "2.3.0",
         "nugetVersion": "2.3.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.savedstate",
@@ -1032,8 +921,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.savedstate",
@@ -1041,8 +929,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.security",
@@ -1050,8 +937,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.slice",
@@ -1059,8 +945,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Slice.Builders",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.slice",
@@ -1068,8 +953,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Slice.Core",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.slice",
@@ -1077,8 +961,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Slice.View",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.slidingpanelayout",
@@ -1086,8 +969,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.sqlite",
@@ -1095,8 +977,7 @@
         "version": "2.1.0",
         "nugetVersion": "2.1.0.7",
         "nugetId": "Xamarin.AndroidX.Sqlite",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.sqlite",
@@ -1104,8 +985,7 @@
         "version": "2.1.0",
         "nugetVersion": "2.1.0.7",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.swiperefreshlayout",
@@ -1113,8 +993,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.tracing",
@@ -1122,8 +1001,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.transition",
@@ -1131,8 +1009,7 @@
         "version": "1.4.1",
         "nugetVersion": "1.4.1",
         "nugetId": "Xamarin.AndroidX.Transition",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.tvprovider",
@@ -1140,8 +1017,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AndroidX.TvProvider",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.vectordrawable",
@@ -1149,8 +1025,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.vectordrawable",
@@ -1158,8 +1033,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.versionedparcelable",
@@ -1167,8 +1041,7 @@
         "version": "1.1.1",
         "nugetVersion": "1.1.1.7",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.viewpager",
@@ -1176,8 +1049,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.ViewPager",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.viewpager2",
@@ -1185,8 +1057,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AndroidX.ViewPager2",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.wear",
@@ -1194,8 +1065,7 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Wear",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.webkit",
@@ -1203,8 +1073,7 @@
         "version": "1.4.0",
         "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.WebKit",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.window",
@@ -1212,8 +1081,7 @@
         "version": "1.0.0-alpha09",
         "nugetVersion": "1.0.0.0-alpha09",
         "nugetId": "Xamarin.AndroidX.Window",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.window",
@@ -1221,8 +1089,7 @@
         "version": "1.0.0-alpha01",
         "nugetVersion": "1.0.0.1-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.work",
@@ -1230,8 +1097,7 @@
         "version": "2.5.0",
         "nugetVersion": "2.5.0.2",
         "nugetId": "Xamarin.AndroidX.Work.Runtime",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "androidx.work",
@@ -1239,8 +1105,7 @@
         "version": "2.5.0",
         "nugetVersion": "2.5.0.1",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "com.google.android.material",
@@ -1248,8 +1113,7 @@
         "version": "1.4.0",
         "nugetVersion": "1.4.0",
         "nugetId": "Xamarin.Google.Android.Material",
-        "dependencyOnly": false,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": false
       },
       {
         "groupId": "com.google.auto.value",
@@ -1257,8 +1121,7 @@
         "version": "1.6.6",
         "nugetVersion": "1.6.6",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "com.google.guava",
@@ -1266,8 +1129,7 @@
         "version": "28.2.0",
         "nugetVersion": "28.2.0",
         "nugetId": "Xamarin.Google.Guava",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "com.google.guava",
@@ -1275,8 +1137,7 @@
         "version": "1.0.1",
         "nugetVersion": "1.0.1.2",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "com.google.guava",
@@ -1284,8 +1145,7 @@
         "version": "1.0",
         "nugetVersion": "1.0.0.2",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "com.xamarin.androidx",
@@ -1293,8 +1153,7 @@
         "version": "1.0",
         "nugetVersion": "1.0.8",
         "nugetId": "Xamarin.AndroidX.Migration",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains.kotlin",
@@ -1302,8 +1161,7 @@
         "version": "1.5.10",
         "nugetVersion": "1.5.10",
         "nugetId": "Xamarin.Kotlin.StdLib",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains",
@@ -1311,8 +1169,7 @@
         "version": "13.0",
         "nugetVersion": "13.0.0.4",
         "nugetId": "Xamarin.Jetbrains.Annotations",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains.kotlinx",
@@ -1320,8 +1177,7 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains.kotlinx",
@@ -1329,8 +1185,7 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains.kotlinx",
@@ -1338,8 +1193,7 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.jetbrains.kotlinx",
@@ -1347,8 +1201,7 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "io.reactivex.rxjava2",
@@ -1356,8 +1209,7 @@
         "version": "2.2.10.1",
         "nugetVersion": "2.2.10.1",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "io.reactivex.rxjava3",
@@ -1365,8 +1217,7 @@
         "version": "3.0.0",
         "nugetVersion": "3.0.0",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       },
       {
         "groupId": "org.reactivestreams",
@@ -1374,8 +1225,7 @@
         "version": "1.0.0",
         "nugetVersion": "1.0.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
-        "dependencyOnly": true,
-        "excludedRuntimeDependencies": null
+        "dependencyOnly": true
       }
     ]
   }


### PR DESCRIPTION
Adding `"excludedRuntimeDependencies": null` to every artifact isn't needed and clutters an already large file.  We can update the `update-config.csx` script to simply omit it when it is the default value (`null`).

```xml
{
  "groupId": "androidx.ads",
  "artifactId": "ads-identifier",
  "version": "1.0.0-alpha04",
  "nugetVersion": "1.0.0.5-alpha04",
  "nugetId": "Xamarin.AndroidX.Ads.Identifier",
  "dependencyOnly": false,
  "excludedRuntimeDependencies": null
}
```