### PR TITLE
AndroidX Startup artifact

### DIFF
--- a/config.json
+++ b/config.json
@@ -1004,6 +1004,14 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "androidx.startup",
+        "artifactId": "startup-runtime",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Startup.Runtime",
+        "dependencyOnly": false
+      },
+      {
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",

--- a/config.json
+++ b/config.json
@@ -1008,7 +1008,7 @@
         "artifactId": "startup-runtime",
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
-        "nugetId": "Xamarin.AndroidX.Startup.Runtime",
+        "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime",
         "dependencyOnly": false
       },
       {

--- a/source/androidx.startup/startup-runtime/Additions/Additions.cs
+++ b/source/androidx.startup/startup-runtime/Additions/Additions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+
+namespace AndroidX.Startup.Runtime
+{
+    
+}

--- a/source/androidx.startup/startup-runtime/Additions/Additions.cs
+++ b/source/androidx.startup/startup-runtime/Additions/Additions.cs
@@ -3,7 +3,3 @@ using Android.Views;
 using Android.Widget;
 using Android.Graphics;
 
-namespace AndroidX.Startup.Runtime
-{
-    
-}

--- a/source/androidx.startup/startup-runtime/Transforms/EnumFields.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.startup/startup-runtime/Transforms/EnumMethods.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.startup/startup-runtime/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/androidx.startup/startup-runtime/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/Metadata.Namespaces.xml
@@ -1,3 +1,11 @@
 ﻿<metadata>
+    <attr 
+        path="/api/package[@name='androidx.startup']" 
+        name="managedName"
+        >
+        AndroidX.Startup
+    </attr>
+
+    
 
 </metadata>

--- a/source/androidx.startup/startup-runtime/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.startup/startup-runtime/Transforms/Metadata.xml
+++ b/source/androidx.startup/startup-runtime/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+<metadata>
+
+</metadata>

--- a/utilities.cake
+++ b/utilities.cake
@@ -114,6 +114,8 @@ Task ("spell-check")
                 "RxJava3",
                 "GoogleShortcuts",
                 "WindowJava",
+                "Startup",
+                "StartupRuntime",
             };
             var dictionary_custom = WeCantSpell.Hunspell.WordList.CreateFromWords(words);
 


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

AndroidX

androidx.startup:startup-runtime - 1.0.0

### Does this change any of the generated binding API's?

yes. New artifact.

### Describe your contribution

Bindings of new AndroidX Startup artifacts

https://github.com/xamarin/XamarinComponents/pull/1245

### Updated artifact bidnings

- androidx.window.window - 1.0.0-alpha10 -> 1.0.0-beta01

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045927/Xamarin.AndroidX.Window.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045926/Xamarin.AndroidX.Window.dll.breaking.md.txt)

### New artifact bindings

- androidx.startup:startup-runtime -  -> 1.0.0

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045882/Xamarin.AndroidX.Startup.StartupRuntime.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045881/Xamarin.AndroidX.Startup.StartupRuntime.dll.breaking.md.txt)

### Changed, but not updated

- appcompat resources
 
  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045913/Xamarin.AndroidX.AppCompat.Resources.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045912/Xamarin.AndroidX.AppCompat.Resources.dll.breaking.md.txt)


- androidx.paging.paging-common

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045918/Xamarin.AndroidX.Paging.Common.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045917/Xamarin.AndroidX.Paging.Common.dll.breaking.md.txt)

- androidx.paging.paging-runtime

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045920/Xamarin.AndroidX.Paging.Runtime.dll.diff.md.txt)

- androidx.paging.paging-rxjava2

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045922/Xamarin.AndroidX.Paging.RxJava2.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045921/Xamarin.AndroidX.Paging.RxJava2.dll.breaking.md.txt)

- androidx.savedstate.savedstate

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045924/Xamarin.AndroidX.SavedState.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7045923/Xamarin.AndroidX.SavedState.dll.breaking.md.txt)

- com.google.android.material.material

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7045942/Xamarin.Google.Android.Material.dll.diff.md.txt)


Checklist
- [x] Add any metadata needed to get PR to compile
- [x] Verify any new namespaces are properly renamed (utilities.cake)
- [x] Verify nuget/namespace spelling (utilities.cake)           
- [x] Locally generate diffs
- [x] Review any breaking changes
- [x] Attach diffs to PR