### PR TITLE
Do not automatically pull in Xamarin.AndroidX.Migration for NET6.

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -226,7 +226,7 @@
   @if (@Model.NuGetPackageId == "Xamarin.AndroidX.Annotation")
   {
     <ItemGroup>
-      <ProjectReference Include="..\..\source\migration\Dummy\Xamarin.AndroidX.Migration.Dummy.csproj" PrivateAssets="none" />
+      <ProjectReference Include="..\..\source\migration\Dummy\Xamarin.AndroidX.Migration.Dummy.csproj" PrivateAssets="none" Condition=" '$(TargetFramework)' == 'MonoAndroid9.0' " />
     </ItemGroup>
   }
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/AndroidX/issues/222

The AndroidX package `Xamarin.AndroidX.Annotation` has a dependency on `Xamarin.AndroidX.Migration`.  This means that ~all AndroidX packages have a dependency on Migration, which was crucial during the transition period from AndroidSupportLibraries.

However that transition period is largely over, and we feel we it no longer makes sense to place this package on all AndroidX users.  We cannot remove the dependency for `MonoAndroid90` because it would cause a breakage for many people who rely on it when they upgrade their NuGet versions, but `net6.0-android` is a natural opportunity to make that change.  

Thus, the `net6.0-android` version of `Xamarin.AndroidX.Annotation` no longer has a dependency on `Xamarin.AndroidX.Migration`.  

Note users can still explicitly add the Migration Nuget to their project and it will function exactly like today, the only difference is now it is opt-in.

![image](https://user-images.githubusercontent.com/179295/128066000-a300b910-45b3-4bd1-9df6-a379ca716704.png)

This PR does not bump Nuget version numbers, it will take effect next time we release this package.