### PR TITLE
[material] Fix a couple parameter names.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1111,7 +1111,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.Google.Android.Material",
         "dependencyOnly": false
       },

--- a/source/com.google.android.material/material/Additions/Additions.cs
+++ b/source/com.google.android.material/material/Additions/Additions.cs
@@ -174,6 +174,23 @@ namespace Google.Android.Material.TextField
     }
 }
 
+// Interface method parameter names were p0, fixing them would break these
+// property names, so add these so we have both property names.
+namespace Google.Android.Material.Navigation
+{
+    public partial class NavigationBarView
+    {
+        public partial class ItemSelectedEventArgs : EventArgs
+        {
+            public IMenuItem Item => P0;
+        }
+
+        public partial class ItemReselectedEventArgs : EventArgs
+        {
+            public IMenuItem Item => P0;
+        }
+    }
+}
 
 namespace Google.Android.Material.DatePicker
 {


### PR DESCRIPTION
Fixes https://github.com/xamarin/AndroidX/issues/349

Note that simply changing the parameter names with metadata on the interfaces would change the property names on the `EventArgs` class, which would be a source and binary breaking change.

Instead, I opted to simply add the additional `Item` properties to the `EventArgs` classes as aliases to avoid the breakage.