### PR TITLE
Update AndroidX.Window to alpha10

### DIFF
--- a/config.json
+++ b/config.json
@@ -1094,8 +1094,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window",
-        "version": "1.0.0-alpha09",
-        "nugetVersion": "1.0.0.1-alpha09",
+        "version": "1.0.0-alpha10",
+        "nugetVersion": "1.0.0.1-alpha10",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1105,6 +1105,14 @@
         "version": "1.0.0-alpha01",
         "nugetVersion": "1.0.0.2-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.window",
+        "artifactId": "window-java",
+        "version": "1.0.0-alpha10",
+        "nugetVersion": "1.0.0.1-alpha10",
+        "nugetId": "Xamarin.AndroidX.WindowJava",
         "dependencyOnly": false
       },
       {

--- a/config.json
+++ b/config.json
@@ -1112,7 +1112,7 @@
         "artifactId": "window-java",
         "version": "1.0.0-alpha10",
         "nugetVersion": "1.0.0.1-alpha10",
-        "nugetId": "Xamarin.AndroidX.WindowJava",
+        "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },
       {

--- a/mappings/dependencies.json
+++ b/mappings/dependencies.json
@@ -858,10 +858,6 @@
       "dependencies": []
     },
     {
-      "id": "Xamarin.AndroidX.Migration.Tool",
-      "dependencies": []
-    },
-    {
       "id": "Xamarin.AndroidX.Navigation.Common",
       "dependencies": [
         "Xamarin.AndroidX.Annotation",

--- a/mappings/dependencies.json
+++ b/mappings/dependencies.json
@@ -858,6 +858,10 @@
       "dependencies": []
     },
     {
+      "id": "Xamarin.AndroidX.Migration.Tool",
+      "dependencies": []
+    },
+    {
       "id": "Xamarin.AndroidX.Navigation.Common",
       "dependencies": [
         "Xamarin.AndroidX.Annotation",
@@ -1189,6 +1193,15 @@
       "id": "Xamarin.AndroidX.Window.WindowExtensions",
       "dependencies": [
         "Xamarin.AndroidX.Annotation"
+      ]
+    },
+    {
+      "id": "Xamarin.AndroidX.WindowJava",
+      "dependencies": [
+        "Xamarin.AndroidX.Core",
+        "Xamarin.AndroidX.Window",
+        "Xamarin.Kotlin.StdLib",
+        "Xamarin.KotlinX.Coroutines.Core"
       ]
     },
     {

--- a/mappings/dependencies.json
+++ b/mappings/dependencies.json
@@ -1192,7 +1192,7 @@
       ]
     },
     {
-      "id": "Xamarin.AndroidX.WindowJava",
+      "id": "Xamarin.AndroidX.Window.WindowJava",
       "dependencies": [
         "Xamarin.AndroidX.Core",
         "Xamarin.AndroidX.Window",

--- a/source/androidx.window/window-java/Transforms/EnumFields.xml
+++ b/source/androidx.window/window-java/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/androidx.window/window-java/Transforms/EnumMethods.xml
+++ b/source/androidx.window/window-java/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/androidx.window/window-java/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.window/window-java/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+
+    <attr 
+        path="/api/package[@name='androidx.window.java.layout']"
+        name="managedName"
+        >
+        AndroidX.Window.Java.Layout
+    </attr>
+
+</metadata>

--- a/source/androidx.window/window-java/Transforms/Metadata.ParameterNames.xml
+++ b/source/androidx.window/window-java/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.window/window-java/Transforms/Metadata.xml
+++ b/source/androidx.window/window-java/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/androidx.window/window/Transforms/Metadata.Namespaces.xml
+++ b/source/androidx.window/window/Transforms/Metadata.Namespaces.xml
@@ -7,4 +7,11 @@
         AndroidX.Window
     </attr>
 
+    <attr 
+        path="/api/package[@name='androidx.window.layout']"
+        name="managedName"
+        >
+        AndroidX.Window.Layout
+    </attr>
+
 </metadata>

--- a/source/migration/BuildTasks/Xamarin.AndroidX.Migration.props
+++ b/source/migration/BuildTasks/Xamarin.AndroidX.Migration.props
@@ -312,6 +312,7 @@
         <_AndroidXMavenArtifact Include="androidx.webkit.webkit" />
         <_AndroidXMavenArtifact Include="androidx.window.window" />
         <_AndroidXMavenArtifact Include="androidx.window.window-extensions" />
+        <_AndroidXMavenArtifact Include="androidx.window.window-java" />
         <_AndroidXMavenArtifact Include="androidx.work.work-runtime" />
         <_AndroidXMavenArtifact Include="androidx.work.work-runtime-ktx" />
         <_AndroidXMavenArtifact Include="com.google.android.material.material" />

--- a/utilities.cake
+++ b/utilities.cake
@@ -113,6 +113,7 @@ Task ("spell-check")
                 "RxJava2",
                 "RxJava3",
                 "GoogleShortcuts",
+                "WindowJava",
             };
             var dictionary_custom = WeCantSpell.Hunspell.WordList.CreateFromWords(words);
 

--- a/utilities.cake
+++ b/utilities.cake
@@ -359,11 +359,64 @@ string ParseDiffLine(string line, string name)
                     ;
 }
 
+Task ("api-diff-analysis")
+    .Does 
+    (
+        () =>
+        {
+            using (StreamReader reader = System.IO.File.OpenText(@"./config.json"))
+            {
+                JsonTextReader jtr = new JsonTextReader(reader);
+                binderator_json_array = (JArray)JToken.ReadFrom(jtr);
+            }
+
+            DirectoryPathCollection directories = GetSubDirectories("./output/api-diff");
+            Dictionary<string, string>  nugets_modified = new Dictionary<string, string>();
+
+            foreach(DirectoryPath d in directories)
+            {
+                string d_name = d.GetDirectoryName();
+
+                Information( $"Directory    = {d}");
+                Information( $"     nugetId    = {d.GetDirectoryName()}");
+
+                string groupId      = null;
+                string artifactId   = null;
+                string nugetId      = null;
+                string nugetVersion = null;
+                // no guarantees thta config.json is sorted, so linear "search"
+                // TODO: sort + (LINQ or binary serch)
+                foreach(JObject jo in binderator_json_array[0]["artifacts"])
+                {
+                    groupId      = (string) jo["groupId"];
+                    artifactId   = (string) jo["artifactId"];
+                    nugetId      = (string) jo["nugetId"];
+                    nugetVersion = (string) jo["nugetVersion"];
+
+                    if (nugetId == d_name)
+                    {
+                        Information( $"     groupId                     = {groupId}");
+                        Information( $"     artifactId                  = {artifactId}");
+                        Information( $"     artifactId  fully qualified = {groupId}.{artifactId}");
+
+                        nugets_modified.Add(d_name, $"{groupId}.{artifactId}");
+                    }
+                }
+            }
+
+            string[] lines = nugets_modified.Select(kv => kv.Key + Environment.NewLine + "\t" + kv.Value).ToArray();
+            System.IO.File.WriteAllLines("./output/nugets-with-changed-APIs.md", lines);
+
+            return;
+        }
+    );
+
 Task ("read-analysis-files")
     .IsDependentOn ("binderate-diff")
     .IsDependentOn ("api-diff-markdown-info-pr")
     .IsDependentOn ("namespace-check")
     .IsDependentOn ("spell-check")
+    .IsDependentOn ("api-diff-analysis")    
     .Does 
     (
         () =>


### PR DESCRIPTION
## QUESTIONS

Should the new package be:

- `Xamarin.AndroidX.WindowJava` (in this PR) or 
- `Xamarin.AndroidX.Window.Java` or
- `Xamarin.AndroidX.Window.WindowJava`

I'm not sure what the standard/expectation is...

ALSO, why is the namespace `Androidx` and not `AndroidX` in the NuGet I pulled off the GitHub build system?

### Support Libraries Version (eg: 23.3.0):

AndroidX.Window-1.0.0-alpha10

### Does this change any of the generated binding API's?

Updates binding on NuGet `Xamarin.AndroidX.Window`
Adds new NuGet `Xamarin.AndroidX.WindowJava`

### Describe your contribution

Addresses https://github.com/xamarin/AndroidX/issues/356 **Update "AndroidX.Window" to "1.0.0-alpha10"** for Surface Duo and other foldable devices

### Updated artifacts

- androidx.window:window - 1.0.0-alpha09 -> 1.0.0-alpha10

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7037998/Xamarin.AndroidX.Window.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7037997/Xamarin.AndroidX.Window.dll.breaking.md.txt)

### New artifact bindings

- androidx.window:window-java -  -> 1.0.0-alpha10

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038004/Xamarin.AndroidX.Window.WindowJava.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7038003/Xamarin.AndroidX.Window.WindowJava.dll.breaking.md.txt)

### Changed, but not updated artifacts

 - androidx.databinding.databinding-runtime

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038013/Xamarin.AndroidX.DataBinding.DataBindingRuntime.dll.diff.md.txt)

- androidx.paging.paging-common

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038018/Xamarin.AndroidX.Paging.Common.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7038015/Xamarin.AndroidX.Paging.Common.dll.breaking.md.txt)

- androidx.paging.paging-runtime

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038027/Xamarin.AndroidX.Paging.Runtime.dll.diff.md.txt)

- androidx.paging.paging-rxjava2

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038031/Xamarin.AndroidX.Paging.RxJava2.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7038030/Xamarin.AndroidX.Paging.RxJava2.dll.breaking.md.txt)

- androidx.savedstate.savedstate

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038034/Xamarin.AndroidX.SavedState.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7038033/Xamarin.AndroidX.SavedState.dll.breaking.md.txt)

- com.google.android.material.material

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038036/Xamarin.Google.Android.Material.dll.diff.md.txt)

- resources

  - [diff.md.txt](https://github.com/xamarin/AndroidX/files/7038011/Xamarin.AndroidX.AppCompat.Resources.dll.diff.md.txt)

  - [breaking.md.txt](https://github.com/xamarin/AndroidX/files/7038010/Xamarin.AndroidX.AppCompat.Resources.dll.breaking.md.txt)





Checklist
- [x] Add any metadata needed to get PR to compile
- [x] Verify any new namespaces are properly renamed (utilities.cake)
- [x] Verify nuget/namespace spelling (utilities.cake)           
- [x] Locally generate diffs
- [x] Review any breaking changes
- [x] Attach diffs to PR