### PR TITLE
Update AndroidX.Window and WindowJava to beta02

### DIFF
--- a/config.json
+++ b/config.json
@@ -1102,8 +1102,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window",
-        "version": "1.0.0-beta01",
-        "nugetVersion": "1.0.0.1-beta01",
+        "version": "1.0.0-beta02",
+        "nugetVersion": "1.0.0.1-beta02",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1118,8 +1118,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
-        "version": "1.0.0-beta01",
-        "nugetVersion": "1.0.0.1-beta01",
+        "version": "1.0.0-beta02",
+        "nugetVersion": "1.0.0.1-beta02",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },


### PR DESCRIPTION
fixes #368 cc @moljac @jpobst 

### Support Libraries Version (eg: 23.3.0):

AndroidX.Window-1.0.0-beta02
AndroidX.Window.WindowJava-1.0.0-beta02

### Does this change any of the generated binding API's?

No

### Describe your contribution

**Update "AndroidX.Window" to "1.0.0-beta02"** for Surface Duo and other foldable devices

### Testing

The Xamarin.Android dual-screen samples have been updated and tested with the NuGet generated by this PR build:
https://github.com/microsoft/surface-duo-sdk-xamarin-samples/pull/22