### PR TITLE
Move Kotlin Coroutines to this repository from XamarinComponents.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pr:
   - main
   
 variables:
-  AndroidBinderatorVersion: 0.4.8
+  AndroidBinderatorVersion: 0.4.9
   AndroidXMigrationVersion: 1.0.8
   DotNetVersion: 6.0.100-preview.7.21379.14
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos

--- a/config.json
+++ b/config.json
@@ -1256,34 +1256,56 @@
       {
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
-        "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
-        "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
-        "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
-        "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
+      },
+      {
+        "groupId": "org.jetbrains.kotlinx",
+        "artifactId": "kotlinx-coroutines-jdk8",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
+        "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
+      },
+      {
+        "groupId": "org.jetbrains.kotlinx",
+        "artifactId": "kotlinx-coroutines-reactive",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
+        "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
+        "dependencyOnly": false,
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "io.reactivex.rxjava2",
@@ -1334,6 +1356,28 @@
           {
             "templateFile": "templates/kotlin/Pom.cshtml",
             "outputFileRule": "generated/{groupid}.{artifactid}/dependencies.pom"
+          },
+          {
+            "templateFile": "source/AndroidXSolutionFilter.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
+          }
+        ]
+      },
+      {
+        "name": "kotlinx",
+        "mavenRepositoryType": "MavenCentral",
+        "templates": [
+          {
+            "templateFile": "templates/kotlinx/Project.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
+          },
+          {
+            "templateFile": "templates/kotlinx/Targets.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{nugetid}.targets"
+          },
+          {
+            "templateFile": "source/AndroidXSolutionFilter.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
           }
         ]
       }

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-android/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-android/Transforms/Metadata.xml
@@ -1,0 +1,6 @@
+﻿<metadata>
+
+    <attr path="/api/package[@name='kotlinx.coroutines.android']" name="managedName">Xamarin.KotlinX.Coroutines.CoroutinesAndroid</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.android']/class[@name='HandlerDispatcher']/method[@name='getImmediate' and count(parameter)=0]" name="managedReturn">Xamarin.KotlinX.Coroutines.MainCoroutineDispatcher</attr>
+
+</metadata>

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/Transforms/Metadata.xml
@@ -1,0 +1,40 @@
+﻿<metadata>
+
+      <!-- namespaces -->
+      <attr path="/api/package[@name='kotlinx.coroutines']" name="managedName">Xamarin.KotlinX.Coroutines</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.channels']" name="managedName">Xamarin.KotlinX.Coroutines.Channels</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.debug']" name="managedName">Xamarin.KotlinX.Coroutines.Debug</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.flow']" name="managedName">Xamarin.KotlinX.Coroutines.Flow</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.intrinsics']" name="managedName">Xamarin.KotlinX.Coroutines.Intrinsics</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.scheduling']" name="managedName">Xamarin.KotlinX.Coroutines.Scheduling</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.selects']" name="managedName">Xamarin.KotlinX.Coroutines.Selects</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.sync']" name="managedName">Xamarin.KotlinX.Coroutines.Sync</attr>
+      <attr path="/api/package[@name='kotlinx.coroutines.test']" name="managedName">Xamarin.KotlinX.Coroutines.Test</attr>
+    
+      <!-- remove the internal, internal classes -->
+      <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.internal')]" />
+      <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.debug.internal')]" />
+      <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.jvm.internal')]" />
+      <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.flow.internal')]" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines']/class[@name='AbstractCoroutine']" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines.flow']/class[@name='AbstractFlow']" />
+
+      <!-- remove experimental classes -->
+      <remove-node path="/api/package[@name='kotlinx.coroutines']/class[@name='DelayKt']/method[starts-with(@name,'delay-')]" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines.flow']/class[@name='FlowKt']/method[starts-with(@name,'debounce-')]" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines.flow']/class[@name='FlowKt']/method[starts-with(@name,'sample-')]" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines']/class[@name='TimeoutKt']/method[starts-with(@name,'withTimeout-')]" />
+      <remove-node path="/api/package[@name='kotlinx.coroutines']/class[@name='TimeoutKt']/method[starts-with(@name,'withTimeoutOrNull-')]" />
+
+    <attr
+        path="/api/package[@name='kotlinx.coroutines']/class[@name='SchedulerTaskKt']/method[@name='getTaskContext' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+
+    <remove-node
+        path="/api/package[@name='kotlin.coroutines.jvm.internal']"
+        />
+
+</metadata>

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-core/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-core/Transforms/Metadata.xml
@@ -1,0 +1,28 @@
+﻿<metadata>
+    <!-- namespaces -->
+    <attr path="/api/package[@name='kotlinx.coroutines']" name="managedName">Xamarin.KotlinX.Coroutines</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.channels']" name="managedName">Xamarin.KotlinX.Coroutines.Channels</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.debug']" name="managedName">Xamarin.KotlinX.Coroutines.Debug</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.flow']" name="managedName">Xamarin.KotlinX.Coroutines.Flow</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.intrinsics']" name="managedName">Xamarin.KotlinX.Coroutines.Intrinsics</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.scheduling']" name="managedName">Xamarin.KotlinX.Coroutines.Scheduling</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.selects']" name="managedName">Xamarin.KotlinX.Coroutines.Selects</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.sync']" name="managedName">Xamarin.KotlinX.Coroutines.Sync</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.test']" name="managedName">Xamarin.KotlinX.Coroutines.Test</attr>
+    
+    <!-- remove the internal, internal classes -->
+    <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.internal')]" />
+    <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.debug.internal')]" />
+    <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.jvm.internal')]" />
+    <remove-node path="/api/package[starts-with(@name,'kotlinx.coroutines.flow.internal')]" />
+    <remove-node path="/api/package[@name='kotlinx.coroutines']/class[@name='AbstractCoroutine']" />
+    <remove-node path="/api/package[@name='kotlinx.coroutines.flow']/class[@name='AbstractFlow']" />
+
+    <attr
+        path="/api/package[@name='kotlinx.coroutines']/class[@name='SchedulerTaskKt']/method[@name='getTaskContext' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+
+</metadata>

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/Transforms/Metadata.xml
@@ -1,0 +1,6 @@
+﻿<metadata>
+
+    <attr path="/api/package[@name='kotlinx.coroutines.future']" name="managedName">Xamarin.KotlinX.Coroutines.Future</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.stream']" name="managedName">Xamarin.KotlinX.Coroutines.Stream</attr>
+    <attr path="/api/package[@name='kotlinx.coroutines.time']" name="managedName">Xamarin.KotlinX.Coroutines.Time</attr>
+</metadata>

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/Transforms/Metadata.xml
@@ -1,0 +1,4 @@
+﻿<metadata>
+
+    <attr path="/api/package[@name='kotlinx.coroutines.reactive']" name="managedName">Xamarin.KotlinX.Coroutines.Reactive</attr>
+</metadata>

--- a/source/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/Transforms/Metadata.xml
+++ b/source/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/Transforms/Metadata.xml
@@ -1,0 +1,4 @@
+﻿<metadata>
+
+    <attr path="/api/package[@name='kotlinx.coroutines.rx2']" name="managedName">Xamarin.KotlinX.Coroutines.Rx2</attr>
+</metadata>

--- a/templates/kotlinx/External-Dependency-Info.txt
+++ b/templates/kotlinx/External-Dependency-Info.txt
@@ -1,0 +1,213 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Components for Kotlinx Coroutines incorporates 
+third party material from the projects listed below. The original copyright 
+notice and the license under which Microsoft received such third party 
+material are set forth below.  Microsoft reserves all other rights not 
+expressly granted, whether by implication, estoppel or otherwise.
+
+########################################
+# Kotlinx Coroutines
+# https://github.com/Kotlin/kotlinx.coroutines
+########################################
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/templates/kotlinx/LICENSE.md
+++ b/templates/kotlinx/LICENSE.md
@@ -1,0 +1,16 @@
+**Xamarin is not responsible for, nor does it grant any licenses to, third-party packages. Some packages may require or install dependencies which are governed by additional licenses.**
+
+Note: This component depends on 
+Kotlinx Coroutines [kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) which is subject to the [Apache 2.0](https://github.com/Kotlin/kotlinx.coroutines/blob/master/LICENSE.txt)
+
+### Xamarin Component for Kotlinx Coroutines for Xamarin.Android
+
+**The MIT License (MIT)**
+
+Copyright (c) .NET Foundation Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/kotlinx/Project.cshtml
+++ b/templates/kotlinx/Project.cshtml
@@ -1,0 +1,72 @@
+@{
+  var friendlyName = "Xamarin.KotlinX.Coroutines";
+  if (Model.Metadata.TryGetValue("friendlyName", out string name)) {
+    friendlyName += " " + name;
+  }
+}
+<Project Sdk="Xamarin.Legacy.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>MonoAndroid9.0</TargetFramework>
+    <IsBindingProject>true</IsBindingProject>
+    <RootNamespace>Xamarin.KotlinX.Coroutines.Core</RootNamespace>
+    @if (!string.IsNullOrEmpty(Model.AssemblyName)) {
+    <AssemblyName>@(Model.AssemblyName)</AssemblyName>
+    } else {
+    <AssemblyName>@(Model.NuGetPackageId)</AssemblyName>
+    }
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AndroidClassParser>class-parse</AndroidClassParser>
+    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>@(Model.NuGetPackageId)</PackageId>
+    <Title>@(Model.NuGetPackageId) reference library for Xamarin.Android</Title>
+    <PackageDescription>Xamarin.Android binding for @(Model.NuGetPackageId.Replace("Xamarin", ""))</PackageDescription>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageVersion>@(Model.NuGetVersion)</PackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework);buildTransitive\$(TargetFramework)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Additions\*.cs" Link="Additions\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var art in @Model.MavenArtifacts) {
+    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="jar\@(art.MavenArtifactId)-@(art.MavenArtifactVersion).jar" Visible="false" />
+    <InputJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Link="Jars\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" />
+    }
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var dep in @Model.NuGetDependencies) {
+      if (dep.IsProjectReference) {
+    <ProjectReference Include="..\..\generated\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId)\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId).csproj" PrivateAssets="none" />
+      } else {
+    <PackageReference Include="@(dep.NuGetPackageId)" Version="@(dep.NuGetVersion)" />
+      }
+    }
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\templates\kotlinx\License.md" Pack="true" PackagePath="LICENSE.md" />
+    <None Include="..\..\templates\kotlinx\External-Dependency-Info.txt" Pack="true" PackagePath="THIRD-PARTY-NOTICES.txt" />
+  </ItemGroup>
+
+</Project>

--- a/templates/kotlinx/Targets.cshtml
+++ b/templates/kotlinx/Targets.cshtml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    @foreach (var art in @Model.MavenArtifacts) {
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\@(art.MavenArtifactId)-@(art.MavenArtifactVersion).jar" />
+    }
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Updates Kotlin Coroutines to use `binderator`, and moves them to this repository as they are required dependencies of AndroidX and need to be supported by Microsoft.

Notes:
- Fixes the `build`/`buildTransitive` error like was done for Kotlin: https://github.com/xamarin/XamarinComponents/pull/1260
- The dependencies are different.  This is because they changed in Maven, but the old way was manual so they were never updated.  `binderator` automatically populates the dependencies from Maven, so they stay updated.

**Xamarin.KotlinX.Coroutines.Android** (NuGet.org version on left, PR version on right)
![image](https://user-images.githubusercontent.com/179295/132361006-318804f2-85cf-4eb9-a854-2f9a9dd7878d.png)

**Xamarin.KotlinX.Coroutines.Core**
![image](https://user-images.githubusercontent.com/179295/132361969-a6caf002-55cf-45e7-bf86-79fa9512a656.png)

**Xamarin.KotlinX.Coroutines.Core.Jvm**
![image](https://user-images.githubusercontent.com/179295/132362206-b5dc14d6-cb9a-4330-82d1-567c1880f84b.png)

**Xamarin.KotlinX.Coroutines.Jdk8**
![image](https://user-images.githubusercontent.com/179295/132362456-774c7d8a-4978-4350-9f1f-a4e2ec7a6c47.png)

**Xamarin.KotlinX.Coroutines.Reactive**
![image](https://user-images.githubusercontent.com/179295/132362728-7dc70f56-e741-41e5-9833-ecaf1968fba4.png)

**Xamarin.KotlinX.Coroutines.Rx2**
![image](https://user-images.githubusercontent.com/179295/132362955-bbd13212-6376-4f4b-9b86-3c7dbecb3138.png)
