### PR TITLE
[build] Bump to binderator 0.5.0 to fix CI error due to 100 artifact MavenNet limit.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pr:
   - main
   
 variables:
-  AndroidBinderatorVersion: 0.4.9
+  AndroidBinderatorVersion: 0.5.0
   AndroidXMigrationVersion: 1.0.8
   DotNetVersion: 6.0.100-preview.7.21379.14
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos


### PR DESCRIPTION
We have hit an issue using MavenNet in `binderator` when we call `MavenRepository.Refresh ("org.jetbrains.kotlinx")`.  This group id contains 351 artifacts, and `Refresh` limits its search to 100 results.  Our desired artifacts are no longer in the first 100, so they are "not found" when we try to use them.  This has broken our AndroidX build.

This issue has been fixed in the latest MavenNet (https://github.com/Redth/MavenNet/pull/9), so update our binderator to pull in this new MavenNet.