### PR TITLE
[build] Update CI to .NET 6 RC1.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,11 @@
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
     <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>false</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
+    
+    <!-- .NET 6+ generates Resource.designer.cs files for bindings projects which we do not want -->
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    
+    <!-- .NET 6+ packages support back to API-21 -->
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.0
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100-preview.7.21379.14
+  DotNetVersion: 6.0.100-rc.1.21458.32
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
   LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
   BUILD_NUMBER: $(Build.BuildNumber)
@@ -41,6 +41,12 @@ jobs:
             version: $(DotNetVersion)
         - pwsh: |
             dotnet workload install android
+        - task: JavaToolInstaller@0
+          inputs:
+            versionSpec: '11'
+            jdkArchitectureOption: 'x64'
+            jdkSourceOption: 'PreInstalled'
+
       preBuildSteps:
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -94,9 +94,9 @@
 
   <ItemGroup>
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\monoandroid90" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\net6.0-android30.0" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\net6.0-android31.0" />
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\monoandroid90" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\net6.0-android30.0" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\net6.0-android31.0" />
     <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
   </ItemGroup>
 

--- a/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
+++ b/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid9.0;net6.0-android30.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;net6.0-android</TargetFrameworks>
     <AssemblyName>Xamarin.AndroidX.AppCompat.Resources</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>

--- a/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
+++ b/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid9.0;net6.0-android30.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;net6.0-android</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Google.Android.Material.Extensions</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>


### PR DESCRIPTION
Update our CI build to .NET 6 RC1.

Additional changes:
```
    <!-- .NET 6+ generates Resource.designer.cs files for bindings projects which we do not want -->
    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>

    <!-- .NET 6+ packages support back to API-21 -->
    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
```