### PR TITLE
[ci] Bump legacy build package version to 16.11.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,9 @@ variables:
   AndroidBinderatorVersion: 0.5.0
   AndroidXMigrationVersion: 1.0.8
   DotNetVersion: 6.0.100-rc.1.21458.32
-  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
-  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
+  # NOTE: there wasn't a public release of 16.11 for macOS
+  LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
+  LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now


### PR DESCRIPTION
#378 is failing because we currently build with d16.10, which does not contain https://github.com/xamarin/java.interop/commit/95c9b79d20791d4f89842564c5e9f0237b516014.

Unfortunately there is no release of d8.11 for VSMac, so there is no officially released version with this fix.  Instead we will pull down matching d16.11/d8.11 CI builds and use them until d17.0 is released.