### PR TITLE
[update-config.csx] Update MavenNet to support kotlinx-coroutines.

### DIFF
--- a/config.json
+++ b/config.json
@@ -277,6 +277,14 @@
       },
       {
         "groupId": "androidx.core",
+        "artifactId": "core-animation",
+        "version": "1.0.0-alpha02",
+        "nugetVersion": "1.0.0.6-alpha02",
+        "nugetId": "Xamarin.AndroidX.Core.Animation",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
@@ -289,14 +297,6 @@
         "version": "1.6.0",
         "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx",
-        "dependencyOnly": false
-      },
-      {
-        "groupId": "androidx.core",
-        "artifactId": "core-animation",
-        "version": "1.0.0-alpha02",
-        "nugetVersion": "1.0.0.6-alpha02",
-        "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
       {
@@ -541,14 +541,6 @@
       },
       {
         "groupId": "androidx.lifecycle",
-        "artifactId": "lifecycle-livedata-ktx",
-        "version": "2.3.1",
-        "nugetVersion": "2.3.1.3",
-        "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
-        "dependencyOnly": false
-      },
-      {
-        "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.3.1",
         "nugetVersion": "2.3.1.1",
@@ -565,6 +557,14 @@
       },
       {
         "groupId": "androidx.lifecycle",
+        "artifactId": "lifecycle-livedata-ktx",
+        "version": "2.3.1",
+        "nugetVersion": "2.3.1.3",
+        "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.3.1",
         "nugetVersion": "2.3.1.1",
@@ -573,18 +573,18 @@
       },
       {
         "groupId": "androidx.lifecycle",
-        "artifactId": "lifecycle-reactivestreams-ktx",
-        "version": "2.3.1",
-        "nugetVersion": "2.3.1.1",
-        "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx",
-        "dependencyOnly": false
-      },
-      {
-        "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.3.1",
         "nugetVersion": "2.3.1.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.lifecycle",
+        "artifactId": "lifecycle-reactivestreams-ktx",
+        "version": "2.3.1",
+        "nugetVersion": "2.3.1.1",
+        "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx",
         "dependencyOnly": false
       },
       {
@@ -893,18 +893,18 @@
       },
       {
         "groupId": "androidx.room",
-        "artifactId": "room-ktx",
-        "version": "2.3.0",
-        "nugetVersion": "2.3.0.2",
-        "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
-        "dependencyOnly": false
-      },
-      {
-        "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.3.0",
         "nugetVersion": "2.3.0.2",
         "nugetId": "Xamarin.AndroidX.Room.Guava",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.room",
+        "artifactId": "room-ktx",
+        "version": "2.3.0",
+        "nugetVersion": "2.3.0.2",
+        "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
         "dependencyOnly": false
       },
       {
@@ -1157,36 +1157,52 @@
         "templateSet": "auto-value"
       },
       {
-        "groupId": "com.google.guava",
-        "artifactId": "guava",
-        "version": "28.2.0",
-        "nugetVersion": "28.2.0",
-        "nugetId": "Xamarin.Google.Guava",
-        "dependencyOnly": true
+        "groupId": "com.google.code.gson",
+        "artifactId": "gson",
+        "version": "2.8.8",
+        "nugetVersion": "2.8.8",
+        "nugetId": "GoogleGson",
+        "dependencyOnly": false,
+        "templateSet": "gson"
       },
       {
-        "groupId": "com.google.guava",
-        "artifactId": "failureaccess",
-        "version": "1.0.1",
-        "nugetVersion": "1.0.1.2",
-        "nugetId": "Xamarin.Google.Guava.FailureAccess",
-        "dependencyOnly": true
+        "groupId": "io.reactivex.rxjava2",
+        "artifactId": "rxjava",
+        "version": "2.2.10",
+        "nugetVersion": "2.2.10.1",
+        "nugetId": "Xamarin.Android.ReactiveX.RxJava",
+        "dependencyOnly": false,
+        "templateSet": "rxjava"
       },
       {
-        "groupId": "com.google.guava",
-        "artifactId": "listenablefuture",
-        "version": "1.0",
-        "nugetVersion": "1.0.0.2",
-        "nugetId": "Xamarin.Google.Guava.ListenableFuture",
-        "dependencyOnly": true
+        "groupId": "io.reactivex.rxjava3",
+        "artifactId": "rxjava",
+        "version": "3.0.1",
+        "nugetVersion": "3.0.1.1",
+        "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
+        "dependencyOnly": false,
+        "templateSet": "rxjava"
       },
       {
-        "groupId": "com.xamarin.androidx",
-        "artifactId": "migration",
-        "version": "1.0",
-        "nugetVersion": "1.0.8",
-        "nugetId": "Xamarin.AndroidX.Migration",
-        "dependencyOnly": true
+        "groupId": "org.jetbrains",
+        "artifactId": "annotations",
+        "version": "22.0.0",
+        "nugetVersion": "22.0.0",
+        "nugetId": "Xamarin.Jetbrains.Annotations",
+        "dependencyOnly": false,
+        "templateSet": "kotlin"
+      },
+      {
+        "groupId": "org.jetbrains.kotlin",
+        "artifactId": "kotlin-reflect",
+        "version": "1.5.31",
+        "nugetVersion": "1.5.31",
+        "nugetId": "Xamarin.Kotlin.Reflect",
+        "dependencyOnly": false,
+        "templateSet": "kotlin",
+        "metadata": {
+          "friendlyName": "Reflect"
+        }
       },
       {
         "groupId": "org.jetbrains.kotlin",
@@ -1207,18 +1223,6 @@
         "templateSet": "kotlin",
         "metadata": {
           "friendlyName": "Common"
-        }
-      },
-      {
-        "groupId": "org.jetbrains.kotlin",
-        "artifactId": "kotlin-reflect",
-        "version": "1.5.31",
-        "nugetVersion": "1.5.31",
-        "nugetId": "Xamarin.Kotlin.Reflect",
-        "dependencyOnly": false,
-        "templateSet": "kotlin",
-        "metadata": {
-          "friendlyName": "Reflect"
         }
       },
       {
@@ -1246,13 +1250,13 @@
         }
       },
       {
-        "groupId": "org.jetbrains",
-        "artifactId": "annotations",
-        "version": "22.0.0",
-        "nugetVersion": "22.0.0",
-        "nugetId": "Xamarin.Jetbrains.Annotations",
+        "groupId": "org.jetbrains.kotlinx",
+        "artifactId": "kotlinx-coroutines-android",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
+        "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "dependencyOnly": false,
-        "templateSet": "kotlin"
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "org.jetbrains.kotlinx",
@@ -1269,24 +1273,6 @@
         "version": "1.5.1",
         "nugetVersion": "1.5.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
-        "dependencyOnly": false,
-        "templateSet": "kotlinx"
-      },
-      {
-        "groupId": "org.jetbrains.kotlinx",
-        "artifactId": "kotlinx-coroutines-android",
-        "version": "1.5.1",
-        "nugetVersion": "1.5.1",
-        "nugetId": "Xamarin.KotlinX.Coroutines.Android",
-        "dependencyOnly": false,
-        "templateSet": "kotlinx"
-      },
-      {
-        "groupId": "org.jetbrains.kotlinx",
-        "artifactId": "kotlinx-coroutines-rx2",
-        "version": "1.5.1",
-        "nugetVersion": "1.5.1",
-        "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
       },
@@ -1309,22 +1295,13 @@
         "templateSet": "kotlinx"
       },
       {
-        "groupId": "io.reactivex.rxjava2",
-        "artifactId": "rxjava",
-        "version": "2.2.10",
-        "nugetVersion": "2.2.10.1",
-        "nugetId": "Xamarin.Android.ReactiveX.RxJava",
+        "groupId": "org.jetbrains.kotlinx",
+        "artifactId": "kotlinx-coroutines-rx2",
+        "version": "1.5.1",
+        "nugetVersion": "1.5.1",
+        "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "dependencyOnly": false,
-        "templateSet": "rxjava"
-      },
-      {
-        "groupId": "io.reactivex.rxjava3",
-        "artifactId": "rxjava",
-        "version": "3.0.1",
-        "nugetVersion": "3.0.1.1",
-        "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
-        "dependencyOnly": false,
-        "templateSet": "rxjava"
+        "templateSet": "kotlinx"
       },
       {
         "groupId": "org.reactivestreams",
@@ -1344,13 +1321,36 @@
         "dependencyOnly": true
       },
       {
-        "groupId": "com.google.code.gson",
-        "artifactId": "gson",
-        "version": "2.8.8",
-        "nugetVersion": "2.8.8",
-        "nugetId": "GoogleGson",
-        "dependencyOnly": false,
-        "templateSet": "gson"
+        "groupId": "com.google.guava",
+        "artifactId": "failureaccess",
+        "version": "1.0.1",
+        "nugetVersion": "1.0.1.2",
+        "nugetId": "Xamarin.Google.Guava.FailureAccess",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.guava",
+        "artifactId": "guava",
+        "version": "28.2.0",
+        "nugetVersion": "28.2.0",
+        "nugetId": "Xamarin.Google.Guava",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.guava",
+        "artifactId": "listenablefuture",
+        "version": "1.0",
+        "nugetVersion": "1.0.0.2",
+        "nugetId": "Xamarin.Google.Guava.ListenableFuture",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.xamarin.androidx",
+        "artifactId": "migration",
+        "version": "1.0",
+        "nugetVersion": "1.0.8",
+        "nugetId": "Xamarin.AndroidX.Migration",
+        "dependencyOnly": true
       }
     ],
     "templateSets": [


### PR DESCRIPTION
Update `update-config.csx` with the latest MavenNet that fixed support for `kotlinx-coroutines`, allowing this script to find new versions and mark them as needing updates.

The script will also now apply a consistent sort to the artifacts in `config.json`.

This PR sorts the `config.json` to this new sort.  There should be no changes to the `config.json`, just now sorted alphabetically.