### PR TITLE
Update .NET 6 RC 1 version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.0
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100-rc.1.21458.32
+  DotNetVersion: 6.0.100-rc.1.21463.6
   # NOTE: there wasn't a public release of 16.11 for macOS
   LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
   LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix


### PR DESCRIPTION
The old version seems to be gone, and replaced with `6.0.100-rc.1.21463.6`.  🤷‍♂️