### PR TITLE
firebase-appindexing net6 dependency update

### DIFF
--- a/config.json
+++ b/config.json
@@ -1324,7 +1324,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.1",
+        "nugetVersion": "120.0.0.2",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "dependencyOnly": true
       },


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):

no.

### Does this change any of the generated binding API's?


### Describe your contribution

`net6` dependency update
