### PR TITLE
[kotlin] Ensure .targets file gets put into NuGet package.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,4 +16,12 @@
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
   </PropertyGroup>
+  
+  <!-- Folders that .targets files need to go into -->
+  <ItemGroup>
+    <AndroidXNuGetTargetFolders Include="build\monoandroid90" />
+    <AndroidXNuGetTargetFolders Include="build\net6.0-android31.0" />
+    <AndroidXNuGetTargetFolders Include="buildTransitive\monoandroid90" />
+    <AndroidXNuGetTargetFolders Include="buildTransitive\net6.0-android31.0" />
+  </ItemGroup>
 </Project>

--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.1",
+        "nugetVersion": "1.3.1.2",
         "nugetId": "Xamarin.AndroidX.Activity",
         "dependencyOnly": false
       },
@@ -38,7 +38,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.1",
+        "nugetVersion": "1.3.1.2",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx",
         "dependencyOnly": false
       },
@@ -46,7 +46,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.7-alpha04",
+        "nugetVersion": "1.0.0.8-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier",
         "dependencyOnly": false
       },
@@ -54,7 +54,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.7-alpha04",
+        "nugetVersion": "1.0.0.8-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon",
         "dependencyOnly": false
       },
@@ -62,7 +62,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha04",
-        "nugetVersion": "1.0.0.7-alpha04",
+        "nugetVersion": "1.0.0.8-alpha04",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider",
         "dependencyOnly": false
       },
@@ -70,7 +70,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "dependencyOnly": false
       },
@@ -78,7 +78,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental",
         "dependencyOnly": false
       },
@@ -86,7 +86,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.2",
+        "nugetVersion": "1.3.1.3",
         "nugetId": "Xamarin.AndroidX.AppCompat",
         "dependencyOnly": false
       },
@@ -94,7 +94,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.2",
+        "nugetVersion": "1.3.1.3",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
         "dependencyOnly": false
       },
@@ -102,7 +102,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.10",
+        "nugetVersion": "2.1.0.11",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common",
         "dependencyOnly": false
       },
@@ -110,7 +110,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.10",
+        "nugetVersion": "2.1.0.11",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime",
         "dependencyOnly": false
       },
@@ -118,7 +118,7 @@
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater",
         "dependencyOnly": false
       },
@@ -126,7 +126,7 @@
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.8",
+        "nugetVersion": "1.1.0.9",
         "nugetId": "Xamarin.AndroidX.AutoFill",
         "dependencyOnly": false
       },
@@ -134,7 +134,7 @@
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Biometric",
         "dependencyOnly": false
       },
@@ -142,7 +142,7 @@
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.7",
+        "nugetVersion": "1.3.0.8",
         "nugetId": "Xamarin.AndroidX.Browser",
         "dependencyOnly": false
       },
@@ -150,7 +150,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.2",
+        "nugetVersion": "1.0.1.3",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2",
         "dependencyOnly": false
       },
@@ -158,7 +158,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.2",
+        "nugetVersion": "1.0.1.3",
         "nugetId": "Xamarin.AndroidX.Camera.Core",
         "dependencyOnly": false
       },
@@ -166,7 +166,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.2",
+        "nugetVersion": "1.0.1.3",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle",
         "dependencyOnly": false
       },
@@ -174,7 +174,7 @@
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.7-alpha7",
+        "nugetVersion": "1.0.0.8-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car",
         "dependencyOnly": false
       },
@@ -182,7 +182,7 @@
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.7-alpha5",
+        "nugetVersion": "1.0.0.8-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster",
         "dependencyOnly": false
       },
@@ -190,7 +190,7 @@
         "groupId": "androidx.car.app",
         "artifactId": "app",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Car.App.App",
         "dependencyOnly": false
       },
@@ -198,7 +198,7 @@
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.10",
+        "nugetVersion": "1.0.0.11",
         "nugetId": "Xamarin.AndroidX.CardView",
         "dependencyOnly": false
       },
@@ -206,7 +206,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.Collection",
         "dependencyOnly": false
       },
@@ -214,7 +214,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection-ktx",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx",
         "dependencyOnly": false
       },
@@ -222,7 +222,7 @@
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures",
         "dependencyOnly": false
       },
@@ -230,7 +230,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.1.1",
-        "nugetVersion": "2.1.1.1",
+        "nugetVersion": "2.1.1.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout",
         "dependencyOnly": false
       },
@@ -238,7 +238,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-core",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.1",
+        "nugetVersion": "1.0.1.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Core",
         "dependencyOnly": false
       },
@@ -246,7 +246,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.4",
+        "nugetVersion": "2.0.4.5",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver",
         "dependencyOnly": false
       },
@@ -254,7 +254,7 @@
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.ContentPager",
         "dependencyOnly": false
       },
@@ -262,7 +262,7 @@
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout",
         "dependencyOnly": false
       },
@@ -270,7 +270,7 @@
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Core",
         "dependencyOnly": false
       },
@@ -278,7 +278,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0-alpha02",
-        "nugetVersion": "1.0.0.7-alpha02",
+        "nugetVersion": "1.0.0.8-alpha02",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
@@ -286,7 +286,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
+        "nugetVersion": "1.0.0.2",
         "nugetId": "Xamarin.AndroidX.Core.GoogleShortcuts",
         "dependencyOnly": false
       },
@@ -294,7 +294,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx",
         "dependencyOnly": false
       },
@@ -302,7 +302,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.Core.Role",
         "dependencyOnly": false
       },
@@ -310,7 +310,7 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.CursorAdapter",
         "dependencyOnly": false
       },
@@ -318,7 +318,7 @@
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.8",
+        "nugetVersion": "1.1.0.9",
         "nugetId": "Xamarin.AndroidX.CustomView",
         "dependencyOnly": false
       },
@@ -326,7 +326,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-adapters",
         "version": "7.0.2",
-        "nugetVersion": "7.0.2.1",
+        "nugetVersion": "7.0.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters",
         "dependencyOnly": false
       },
@@ -334,7 +334,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-common",
         "version": "7.0.2",
-        "nugetVersion": "7.0.2.1",
+        "nugetVersion": "7.0.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon",
         "dependencyOnly": false
       },
@@ -342,7 +342,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-runtime",
         "version": "7.0.2",
-        "nugetVersion": "7.0.2.1",
+        "nugetVersion": "7.0.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime",
         "dependencyOnly": false
       },
@@ -350,7 +350,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "viewbinding",
         "version": "7.0.2",
-        "nugetVersion": "7.0.2.1",
+        "nugetVersion": "7.0.2.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding",
         "dependencyOnly": false
       },
@@ -358,7 +358,7 @@
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.9",
+        "nugetVersion": "1.0.1.10",
         "nugetId": "Xamarin.AndroidX.DocumentFile",
         "dependencyOnly": false
       },
@@ -366,7 +366,7 @@
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.4",
+        "nugetVersion": "1.1.1.5",
         "nugetId": "Xamarin.AndroidX.DrawerLayout",
         "dependencyOnly": false
       },
@@ -374,7 +374,7 @@
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation",
         "dependencyOnly": false
       },
@@ -382,7 +382,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji",
         "dependencyOnly": false
       },
@@ -390,7 +390,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat",
         "dependencyOnly": false
       },
@@ -398,7 +398,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled",
         "dependencyOnly": false
       },
@@ -406,7 +406,7 @@
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.3.3",
-        "nugetVersion": "1.3.3.1",
+        "nugetVersion": "1.3.3.2",
         "nugetId": "Xamarin.AndroidX.ExifInterface",
         "dependencyOnly": false
       },
@@ -414,7 +414,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.3.6",
-        "nugetVersion": "1.3.6.2",
+        "nugetVersion": "1.3.6.3",
         "nugetId": "Xamarin.AndroidX.Fragment",
         "dependencyOnly": false
       },
@@ -422,7 +422,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment-ktx",
         "version": "1.3.6",
-        "nugetVersion": "1.3.6.2",
+        "nugetVersion": "1.3.6.3",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx",
         "dependencyOnly": false
       },
@@ -430,7 +430,7 @@
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.GridLayout",
         "dependencyOnly": false
       },
@@ -438,7 +438,7 @@
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.HeifWriter",
         "dependencyOnly": false
       },
@@ -446,7 +446,7 @@
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Interpolator",
         "dependencyOnly": false
       },
@@ -454,7 +454,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.Leanback",
         "dependencyOnly": false
       },
@@ -462,7 +462,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference",
         "dependencyOnly": false
       },
@@ -470,7 +470,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14",
         "dependencyOnly": false
       },
@@ -478,7 +478,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.10",
+        "nugetVersion": "1.0.0.11",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI",
         "dependencyOnly": false
       },
@@ -486,7 +486,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
         "dependencyOnly": false
       },
@@ -494,7 +494,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13",
         "dependencyOnly": false
       },
@@ -502,7 +502,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
         "dependencyOnly": false
       },
@@ -510,7 +510,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common",
         "dependencyOnly": false
       },
@@ -518,7 +518,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-java8",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8",
         "dependencyOnly": false
       },
@@ -526,7 +526,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.9",
+        "nugetVersion": "2.2.0.10",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
         "dependencyOnly": false
       },
@@ -534,7 +534,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData",
         "dependencyOnly": false
       },
@@ -542,7 +542,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core",
         "dependencyOnly": false
       },
@@ -550,7 +550,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx",
         "dependencyOnly": false
       },
@@ -558,7 +558,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.4",
+        "nugetVersion": "2.3.1.5",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
         "dependencyOnly": false
       },
@@ -566,7 +566,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process",
         "dependencyOnly": false
       },
@@ -574,7 +574,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams",
         "dependencyOnly": false
       },
@@ -582,7 +582,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx",
         "dependencyOnly": false
       },
@@ -590,7 +590,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.3",
+        "nugetVersion": "2.3.1.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime",
         "dependencyOnly": false
       },
@@ -598,7 +598,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -606,7 +606,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service",
         "dependencyOnly": false
       },
@@ -614,7 +614,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel",
         "dependencyOnly": false
       },
@@ -622,7 +622,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-ktx",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx",
         "dependencyOnly": false
       },
@@ -630,7 +630,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.3.1",
-        "nugetVersion": "2.3.1.2",
+        "nugetVersion": "2.3.1.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState",
         "dependencyOnly": false
       },
@@ -638,7 +638,7 @@
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.Loader",
         "dependencyOnly": false
       },
@@ -646,7 +646,7 @@
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
         "dependencyOnly": false
       },
@@ -654,7 +654,7 @@
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Media",
         "dependencyOnly": false
       },
@@ -662,7 +662,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Media2.Common",
         "dependencyOnly": false
       },
@@ -670,7 +670,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Media2.Session",
         "dependencyOnly": false
       },
@@ -678,7 +678,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Media2.Widget",
         "dependencyOnly": false
       },
@@ -686,7 +686,7 @@
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.2.5",
-        "nugetVersion": "1.2.5.1",
+        "nugetVersion": "1.2.5.2",
         "nugetId": "Xamarin.AndroidX.MediaRouter",
         "dependencyOnly": false
       },
@@ -694,7 +694,7 @@
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.9",
+        "nugetVersion": "2.0.1.10",
         "nugetId": "Xamarin.AndroidX.MultiDex",
         "dependencyOnly": false
       },
@@ -702,7 +702,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Common",
         "dependencyOnly": false
       },
@@ -710,7 +710,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-ktx",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx",
         "dependencyOnly": false
       },
@@ -718,7 +718,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment",
         "dependencyOnly": false
       },
@@ -726,7 +726,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment-ktx",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx",
         "dependencyOnly": false
       },
@@ -734,7 +734,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime",
         "dependencyOnly": false
       },
@@ -742,7 +742,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-ktx",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -750,7 +750,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.UI",
         "dependencyOnly": false
       },
@@ -758,7 +758,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui-ktx",
         "version": "2.3.5",
-        "nugetVersion": "2.3.5.2",
+        "nugetVersion": "2.3.5.3",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx",
         "dependencyOnly": false
       },
@@ -766,7 +766,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
         "dependencyOnly": false
       },
@@ -774,7 +774,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common-ktx",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx",
         "dependencyOnly": false
       },
@@ -782,7 +782,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime",
         "dependencyOnly": false
       },
@@ -790,7 +790,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime-ktx",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -798,7 +798,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2",
         "dependencyOnly": false
       },
@@ -806,7 +806,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2-ktx",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.2",
+        "nugetVersion": "3.0.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2.Ktx",
         "dependencyOnly": false
       },
@@ -814,7 +814,7 @@
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Palette",
         "dependencyOnly": false
       },
@@ -822,7 +822,7 @@
         "groupId": "androidx.palette",
         "artifactId": "palette-ktx",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx",
         "dependencyOnly": false
       },
@@ -830,7 +830,7 @@
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.10",
+        "nugetVersion": "1.0.0.11",
         "nugetId": "Xamarin.AndroidX.PercentLayout",
         "dependencyOnly": false
       },
@@ -838,7 +838,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.10",
+        "nugetVersion": "1.1.1.11",
         "nugetId": "Xamarin.AndroidX.Preference",
         "dependencyOnly": false
       },
@@ -846,7 +846,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference-ktx",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx",
         "dependencyOnly": false
       },
@@ -854,7 +854,7 @@
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Print",
         "dependencyOnly": false
       },
@@ -862,7 +862,7 @@
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Recommendation",
         "dependencyOnly": false
       },
@@ -870,7 +870,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.2",
+        "nugetVersion": "1.2.1.3",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
         "dependencyOnly": false
       },
@@ -878,7 +878,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection",
         "dependencyOnly": false
       },
@@ -886,7 +886,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Common",
         "dependencyOnly": false
       },
@@ -894,7 +894,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Guava",
         "dependencyOnly": false
       },
@@ -902,7 +902,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-ktx",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
         "dependencyOnly": false
       },
@@ -910,7 +910,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Runtime",
         "dependencyOnly": false
       },
@@ -918,7 +918,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-rxjava2",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2",
         "dependencyOnly": false
       },
@@ -926,7 +926,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-rxjava3",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3",
         "dependencyOnly": false
       },
@@ -934,7 +934,7 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.SavedState",
         "dependencyOnly": false
       },
@@ -942,7 +942,7 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-ktx",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx",
         "dependencyOnly": false
       },
@@ -950,7 +950,7 @@
         "groupId": "androidx.security",
         "artifactId": "security-crypto",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto",
         "dependencyOnly": false
       },
@@ -958,7 +958,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Slice.Builders",
         "dependencyOnly": false
       },
@@ -966,7 +966,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Slice.Core",
         "dependencyOnly": false
       },
@@ -974,7 +974,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.Slice.View",
         "dependencyOnly": false
       },
@@ -982,7 +982,7 @@
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout",
         "dependencyOnly": false
       },
@@ -990,7 +990,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.9",
+        "nugetVersion": "2.1.0.10",
         "nugetId": "Xamarin.AndroidX.Sqlite",
         "dependencyOnly": false
       },
@@ -998,7 +998,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.9",
+        "nugetVersion": "2.1.0.10",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework",
         "dependencyOnly": false
       },
@@ -1006,7 +1006,7 @@
         "groupId": "androidx.startup",
         "artifactId": "startup-runtime",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime",
         "dependencyOnly": false
       },
@@ -1014,7 +1014,7 @@
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout",
         "dependencyOnly": false
       },
@@ -1022,7 +1022,7 @@
         "groupId": "androidx.tracing",
         "artifactId": "tracing",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing",
         "dependencyOnly": false
       },
@@ -1030,7 +1030,7 @@
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.2",
+        "nugetVersion": "1.4.1.3",
         "nugetId": "Xamarin.AndroidX.Transition",
         "dependencyOnly": false
       },
@@ -1038,7 +1038,7 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.TvProvider",
         "dependencyOnly": false
       },
@@ -1046,7 +1046,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },
@@ -1054,7 +1054,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated",
         "dependencyOnly": false
       },
@@ -1062,7 +1062,7 @@
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.9",
+        "nugetVersion": "1.1.1.10",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable",
         "dependencyOnly": false
       },
@@ -1070,7 +1070,7 @@
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.9",
+        "nugetVersion": "1.0.0.10",
         "nugetId": "Xamarin.AndroidX.ViewPager",
         "dependencyOnly": false
       },
@@ -1078,7 +1078,7 @@
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.ViewPager2",
         "dependencyOnly": false
       },
@@ -1086,7 +1086,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Wear",
         "dependencyOnly": false
       },
@@ -1094,7 +1094,7 @@
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.3",
+        "nugetVersion": "1.4.0.4",
         "nugetId": "Xamarin.AndroidX.WebKit",
         "dependencyOnly": false
       },
@@ -1102,7 +1102,7 @@
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.0.0-beta02",
-        "nugetVersion": "1.0.0.2-beta02",
+        "nugetVersion": "1.0.0.3-beta02",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1110,7 +1110,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.3-alpha01",
+        "nugetVersion": "1.0.0.4-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions",
         "dependencyOnly": false
       },
@@ -1118,7 +1118,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-java",
         "version": "1.0.0-beta02",
-        "nugetVersion": "1.0.0.2-beta02",
+        "nugetVersion": "1.0.0.3-beta02",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },
@@ -1126,7 +1126,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0.1",
+        "nugetVersion": "2.6.0.2",
         "nugetId": "Xamarin.AndroidX.Work.Runtime",
         "dependencyOnly": false
       },
@@ -1134,7 +1134,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime-ktx",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0.1",
+        "nugetVersion": "2.6.0.2",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -1142,7 +1142,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.3",
+        "nugetVersion": "1.4.0.4",
         "nugetId": "Xamarin.Google.Android.Material",
         "dependencyOnly": false
       },
@@ -1150,7 +1150,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value-annotations",
         "version": "1.8.2",
-        "nugetVersion": "1.8.2.1",
+        "nugetVersion": "1.8.2.2",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "dependencyOnly": false,
         "templateSet": "auto-value"
@@ -1159,7 +1159,7 @@
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.8.8",
-        "nugetVersion": "2.8.8.1",
+        "nugetVersion": "2.8.8.2",
         "nugetId": "GoogleGson",
         "dependencyOnly": false,
         "templateSet": "gson"
@@ -1168,7 +1168,7 @@
         "groupId": "com.google.crypto.tink",
         "artifactId": "tink-android",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
         "dependencyOnly": false,
         "templateSet": "tink"
@@ -1177,7 +1177,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxjava",
         "version": "2.2.21",
-        "nugetVersion": "2.2.21.1",
+        "nugetVersion": "2.2.21.2",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -1186,7 +1186,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxjava",
         "version": "3.1.1",
-        "nugetVersion": "3.1.1.1",
+        "nugetVersion": "3.1.1.2",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -1195,7 +1195,7 @@
         "groupId": "org.jetbrains",
         "artifactId": "annotations",
         "version": "22.0.0",
-        "nugetVersion": "22.0.0.1",
+        "nugetVersion": "22.0.0.2",
         "nugetId": "Xamarin.Jetbrains.Annotations",
         "dependencyOnly": false,
         "templateSet": "kotlin"
@@ -1204,7 +1204,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
         "version": "1.5.31",
-        "nugetVersion": "1.5.31.1",
+        "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -1216,7 +1216,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
         "version": "1.5.31",
-        "nugetVersion": "1.5.31.1",
+        "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "dependencyOnly": false,
         "templateSet": "kotlin"
@@ -1225,7 +1225,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
         "version": "1.5.31",
-        "nugetVersion": "1.5.31.1",
+        "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -1237,7 +1237,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
         "version": "1.5.31",
-        "nugetVersion": "1.5.31.1",
+        "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -1249,7 +1249,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
         "version": "1.5.31",
-        "nugetVersion": "1.5.31.1",
+        "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -1261,7 +1261,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1270,7 +1270,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1279,7 +1279,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1288,7 +1288,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-jdk8",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1297,7 +1297,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-reactive",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1306,7 +1306,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
         "version": "1.5.2",
-        "nugetVersion": "1.5.2.1",
+        "nugetVersion": "1.5.2.2",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -1315,7 +1315,7 @@
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.3",
-        "nugetVersion": "1.0.3.1",
+        "nugetVersion": "1.0.3.2",
         "nugetId": "Xamarin.Android.ReactiveStreams",
         "dependencyOnly": false,
         "templateSet": "reactive-streams"

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -93,10 +93,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\monoandroid90" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\net6.0-android31.0" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\monoandroid90" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\net6.0-android31.0" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
     <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
   </ItemGroup>
 

--- a/templates/kotlin/Project.cshtml
+++ b/templates/kotlin/Project.cshtml
@@ -56,7 +56,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework);buildTransitive\$(TargetFramework)" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/kotlinx/Project.cshtml
+++ b/templates/kotlinx/Project.cshtml
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework);buildTransitive\$(TargetFramework)" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/6333

In order to put the `.targets` file into Kotlin packages, we use:

```xml
<None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework);buildTransitive\$(TargetFramework)" />
```

Unfortunately, when we switched to multi-targeting `net6.0-android` using `<TargetFrameworks>` instead of `<TargetFramework>`, `$(TargetFramework)` is now empty when doing the `Pack`.  This means our `.targets` are not getting added to the NuGet, which means the `.jar` file isn't added to users' projects, which results in `Java.Lang.NoClassDefFoundError` errors at runtime.

This means we have to hardcode the desired NuGet directories.  By using a `Directory.Build.props`, we only need to specify them in one place, and can reference it in the needed templates.  This will likely be helpful when we start adding things like `net7.0-android` and `net6.0-android32.0`.

```xml
<ItemGroup>
  <NuGetTargetFolders Include="build\monoandroid90" />
  <NuGetTargetFolders Include="build\net6.0-android31.0" />
  <NuGetTargetFolders Include="buildTransitive\monoandroid90" />
  <NuGetTargetFolders Include="buildTransitive\net6.0-android31.0" />
</ItemGroup>
```

```xml
<None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@(NuGetTargetFolders)" />
```

Additionally, we need to bump and re-release all packages because NuGet will resolve the lowest transitive dependency it can, which will be `1.5.31.1` which is missing the `.targets` files.

## CI Built Packages:

### AndroidX:
![image](https://user-images.githubusercontent.com/179295/135653546-f7cb9175-f780-4e30-9f94-cec657929603.png)

### Kotlin:
![image](https://user-images.githubusercontent.com/179295/135653675-db8d1748-3c12-4d79-9df4-9667e1db59c3.png)

### Kotlin Coroutines:
![image](https://user-images.githubusercontent.com/179295/135653768-56303244-86cc-415b-8c65-cf8e5d0f2315.png)
