### PR TITLE
Update AndroidX.Window and WindowJava to beta03

### DIFF
--- a/config.json
+++ b/config.json
@@ -1293,8 +1293,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window",
-        "version": "1.0.0-beta02",
-        "nugetVersion": "1.0.0.3-beta02",
+        "version": "1.0.0-beta03",
+        "nugetVersion": "1.0.0.3-beta03",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1309,8 +1309,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
-        "version": "1.0.0-beta02",
-        "nugetVersion": "1.0.0.3-beta02",
+        "version": "1.0.0-beta03",
+        "nugetVersion": "1.0.0.3-beta03",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },


### PR DESCRIPTION
fixes #417 - question for @moljac @jpobst : should the NuGet package version be bumped from `1.0.0.3-beta03` to `1.0.0.4-beta03`?

### Support Libraries Version (eg: 23.3.0):

AndroidX.Window-1.0.0-beta03
AndroidX.Window.WindowJava-1.0.0-beta03

### Does this change any of the generated binding API's?

- Removes `currentWindowMetrics`, but NuGet is still in preview so shouldn't be a big deal.
- Adds experimental Activity Embedding APIs, but these are not important for most Xamarin usages.

### Describe your contribution

Update "AndroidX.Window" to "1.0.0-beta03" for Surface Duo and other foldable devices

### Testing

The Xamarin.Android dual-screen samples can be tested with the projects in this repo:
https://github.com/microsoft/surface-duo-sdk-xamarin-samples/

**UPDATE** samples have been updated to point to the NuGet generated by this PR CI
https://github.com/microsoft/surface-duo-sdk-xamarin-samples/pull/32