### PR TITLE
Update Xamarin.Android to d17.0.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,9 @@
     
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    
+    <!-- Hold off on JavaTypeSystem until d17-1 for needed bugfixes -->
+    <_AndroidUseJavaLegacyResolver>true</_AndroidUseJavaLegacyResolver>
   </PropertyGroup>
   
   <!-- Folders that .targets files need to go into -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,8 @@ variables:
   DotNetVersion: 6.0.100
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
-  # NOTE: there wasn't a public release of 16.11 for macOS
-  LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
-  LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-0-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now
@@ -37,8 +36,7 @@ jobs:
       timeoutInMinutes: 120
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
-      macosImage: 'macOS-11'                                  # the name of the macOS VM image
-                                                              # BigSur 20211120
+      macosImage: 'macOS-11'                                  # the name of the macOS VM image (BigSur)
       xcode: 13.1
       dotnet: '5.0.403'                                       # the version of .NET Core to use
       dotnetStable: '3.1.415'                                 # the stable version of .NET Core to use


### PR DESCRIPTION
Use Xamarin.Android 12.0 for "classic" bindings.  This should match our .NET 6.0.100 version.

The diffs on this look good.  All the changes are related to more accurate detection of `virtual` vs `override` in `generator`.

Example:
#### Type Changed: Google.Android.Material.AppBar.HeaderBehavior

Modified methods:

```diff
-public virtual bool OnInterceptTouchEvent (AndroidX.CoordinatorLayout.Widget.CoordinatorLayout parent, Java.Lang.Object child, Android.Views.MotionEvent ev)
+public override bool OnInterceptTouchEvent (AndroidX.CoordinatorLayout.Widget.CoordinatorLayout parent, Java.Lang.Object child, Android.Views.MotionEvent ev)
-public virtual bool OnTouchEvent (AndroidX.CoordinatorLayout.Widget.CoordinatorLayout parent, Java.Lang.Object child, Android.Views.MotionEvent ev)
+public override bool OnTouchEvent (AndroidX.CoordinatorLayout.Widget.CoordinatorLayout parent, Java.Lang.Object child, Android.Views.MotionEvent ev)
```