### PR TITLE
Build with 'windows-2022'.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
       macosImage: 'macOS-11'                                  # the name of the macOS VM image (BigSur)
+      windowsImage: windows-2022
       xcode: 13.1
       dotnet: '5.0.403'                                       # the version of .NET Core to use
       dotnetStable: '3.1.415'                                 # the stable version of .NET Core to use

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "MSBuild.Sdk.Extras": "3.0.23",
         "Microsoft.Build.Traversal": "2.1.1",
         "Microsoft.Build.NoTargets": "2.0.1",
-        "Xamarin.Legacy.Sdk": "0.1.0-alpha2"
+        "Xamarin.Legacy.Sdk": "0.1.2-alpha6"
     }
 }


### PR DESCRIPTION
Update to build agents with VS2022 instead of VS2019.

This requires a newer version of `Android.Sdk.Legacy` that supports VS2022.