### PR TITLE
AndroidX.Work.Runtime: Bind WorkRequest.Builder.SetExpedited.

### DIFF
--- a/source/androidx.work/work-runtime/Transforms/Metadata.xml
+++ b/source/androidx.work/work-runtime/Transforms/Metadata.xml
@@ -7,6 +7,7 @@
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='keepResultsForAtLeast']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setBackoffCriteria']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setConstraints']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
+    <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setExpedited']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setInitialRunAttemptCount']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setInitialState']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
     <attr path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setInputData']" name="managedReturn">AndroidX.Work.WorkRequest.Builder</attr>
@@ -135,6 +136,12 @@
         androidx.work.WorkRequest.Builder        
     </attr>
     <attr
+        path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setExpedited']"
+        name="return"
+        >
+        androidx.work.WorkRequest.Builder
+    </attr>
+    <attr
         path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setInitialRunAttemptCount']"
         name="return"
         >
@@ -157,6 +164,12 @@
         name="return"
         >
         androidx.work.WorkRequest.Builder        
+    </attr>
+    <attr
+        path="/api/package[@name='androidx.work']/class[@name='WorkRequest.Builder']/method[@name='setScheduleRequestedAt']"
+        name="return"
+        >
+        androidx.work.WorkRequest.Builder
     </attr>
     
     <add-node


### PR DESCRIPTION
Fixes #424.

Use metadata to fix `WorkRequest.Builder.SetExpedited (...)` so it gets bound:

```
Warning BG8700 Unknown return type 'B' for member 'AndroidX.Work.WorkRequest.Builder.SetExpedited (OutOfQuotaPolicy)'.	
```

CI Built:
![image](https://user-images.githubusercontent.com/179295/146047271-46a3b5b6-ea0b-46a3-a1ba-9fba3c36eb27.png)
