### PR TITLE
Update AndroidX.Window and WindowJava to rc01

### DIFF
--- a/config.json
+++ b/config.json
@@ -1293,8 +1293,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window",
-        "version": "1.0.0-beta04",
-        "nugetVersion": "1.0.0.5-beta04",
+        "version": "1.0.0-rc01",
+        "nugetVersion": "1.0.0.6-rc01",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1309,8 +1309,8 @@
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
-        "version": "1.0.0-beta04",
-        "nugetVersion": "1.0.0.5-beta04",
+        "version": "1.0.0-rc01",
+        "nugetVersion": "1.0.0.6-rc01",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },


### PR DESCRIPTION
for #446

### Support Libraries Version (eg: 23.3.0):

- AndroidX.Window-1.0.0-rc01
- AndroidX.Window.WindowJava-1.0.0-rc01

### Does this change any of the generated binding API's?

Does not change any of the APIs that are used by Xamarin clients.

### Describe your contribution

Update "AndroidX.Window" to "1.0.0-rc01" for Surface Duo and other foldable devices