### PR TITLE
[guava] update Guava dependencies

### DIFF
--- a/config.json
+++ b/config.json
@@ -1549,7 +1549,7 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.4",
+        "nugetVersion": "1.0.1.5",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "dependencyOnly": true
       },
@@ -1565,7 +1565,7 @@
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.4",
+        "nugetVersion": "1.0.0.5",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "dependencyOnly": true
       },


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/issues/1312
Context: https://github.com/xamarin/XamarinComponents/commit/0874b321e45a400da665f005c46aa54510d13664
Context: https://www.nuget.org/packages/Xamarin.Google.Guava.FailureAccess/1.0.1.5
Context: https://www.nuget.org/packages/Xamarin.Google.Guava.ListenableFuture/1.0.0.5

If you do:

    $ mkdir foo ; cd foo
    $ dotnet new mauilib
    $ dotnet pack

You end up redistributing `com.google.common.util.concurrent.ListenableFuture`
in your MAUI class library NuGet package:

* `foo.1.0.0.nupkg`
    * `lib\net6.0-android31.0\foo.aar`
        * `libs\78C2212B1AE12Ed.jar`
            * `com\google\common\util\concurrent\ListenableFuture.class`

This was fixed in XamarinComponents and pushed to NuGet.org, but we
need to update the AndroidX dependencies for the new versions.