### PR TITLE
Fix proguard.txt being put in invalid path when built on Mac.

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -101,7 +101,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <None Include="..\..\@(art.ProguardFile)" Pack="True" PackagePath="proguard\" />
+    <None Include="..\..\@(art.ProguardFile)" Pack="True" PackagePath="proguard/" />
       }
     }
   </ItemGroup>


### PR DESCRIPTION
The `proguard.txt` gets put into an invalid directory when built on the Mac CI.  I assume this is because of directory separator issues:

![image](https://user-images.githubusercontent.com/179295/150821965-6ecc456b-7d1e-4c61-a1cf-87555ced12c9.png)

(Trying to expand this folder in NuGet Package Explorer crashes the program.)

Mac CI build for this PR:

![image](https://user-images.githubusercontent.com/179295/150851899-3df3f8a3-01f3-4a9e-890f-186a42c5cb96.png)
