### PR TITLE
Disable Mac CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
       timeoutInMinutes: 120
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
-      macosImage: 'macOS-11'                                  # the name of the macOS VM image (BigSur)
+      macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
       windowsImage: windows-2022
       xcode: 13.1
       dotnet: '5.0.403'                                       # the version of .NET Core to use


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/470#issuecomment-1034009432

Previously, we began building our packages with `d17.0` releases.  However, there is no stable VSMac 2022 yet, so we are using preview packages of Xamarin.Android for this on Mac.  The build we are using contains a `Java.Interop.dll, 0.1.2.0` which is incorrect.

Both the Windows and Mac CI builds seem to copy the NuGets they created to the `nuget` archive folder when they complete building.  This is a "last man wins" situation, so if Windows CI takes longer, we release packages built on Windows.  If Mac CI takes longer, we release packages built on Mac (which are broken).

Until we have a stable XA for Mac that builds correct packages, we should disable the Mac lane so packages built on Mac are not published.

After merging this, we should likely bump and release all NuGet patch versions to ensure no packages with `Java.Interop.dll, 0.1.2.0` are listed as the newest packages on NuGet.org.