### PR TITLE
[ci] Bump to Xamarin.Android d17.1.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,9 +15,6 @@
     
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
-    
-    <!-- Hold off on JavaTypeSystem until d17-1 for needed bugfixes -->
-    <_AndroidUseJavaLegacyResolver>true</_AndroidUseJavaLegacyResolver>
   </PropertyGroup>
   
   <!-- Folders that .targets files need to go into -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
-  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-0-windows
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-1-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now


### PR DESCRIPTION
Update to Xamarin.Anrdoid d17.1.

Remove `<_AndroidUseJavaLegacyResolver>` which was used as a workaround until the d17.1 fixes were available.