### PR TITLE
Revert "[ci] Build against 1ES's hardened images."

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,7 @@ jobs:
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
       macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
-      windowsAgentPoolName: AzurePipelines-EO
-      windowsImageOverride: AzurePipelinesWindows2022compliant
+      windowsImage: windows-2022
       xcode: 13.1
       dotnet: '5.0.405'                                       # the version of .NET Core to use
       dotnetStable: '3.1.416'                                 # the stable version of .NET Core to use


### PR DESCRIPTION
I implemented this poorly in XamarinComponents and it breaks other consumers.  It is being worked on but it doesn't currently work.  Revert this for now so that AndroidX is not blocked.

Reverts xamarin/AndroidX#490