### PR TITLE
[ci] Move CI builds to 1ES's hardened images.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
       macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
-      windowsImage: windows-2022
+      windowsAgentPoolName: android-win-2022
       xcode: 13.1
       dotnet: '5.0.405'                                       # the version of .NET Core to use
       dotnetStable: '3.1.416'                                 # the stable version of .NET Core to use


### PR DESCRIPTION
Attempting to move to the "public" hardened images in `AzurePipelines-EO` has proved problematic because it require non-standard syntax that is not supported on Mac agents, and the `matrix` strategy used by the XamarinComponents templates we use doesn't allow it to only be specified for Windows.

We could bypass this entirely if we had an agent pool that only has a single VM image that is EO compliant.  And we do!  We use `android-win-2022` as a custom pool in Xamarin.Android, and we can reuse it here instead of the "public" images.

Update this repository to use `android-win-2022` pool.

![image](https://user-images.githubusercontent.com/179295/156063010-0daf9410-fc0e-49cd-ad0c-53f1a27347f0.png)
