### PR TITLE
Update Xamarin.AndroidX.Window to 1.0.0.7 so it shows as the latest.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1318,7 +1318,7 @@
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
+        "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },


### PR DESCRIPTION
Our latest package for `Xamarin.AndroidX.Window` is `1.0.0.1`, but there are other packages that appear newer due an incorrect versioning strategy:

![image](https://user-images.githubusercontent.com/179295/156236286-63c1364a-81a9-4483-8c40-e83a6ca47fc7.png)

Update to `1.0.0.7` so the latest package is on top.