### PR TITLE
[ci] Generate a Software Bill of Materials

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,3 +76,12 @@ jobs:
       parameters:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        #dependsOn: signing
+        #condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+        #artifactNames: [ nuget-signed ]
+        artifactNames: [ nuget ]
+        packageName: androidx
+        packageFilter: '*.nupkg'


### PR DESCRIPTION
Context: https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/softwarebillofmaterials
Context: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
Context: https://github.com/xamarin/yaml-templates/blob/3a4be9e8fa257a139cec3014eb89a0fd5cd60b56/compliance/sbom/job.v1.yml

A new job has been added to generate a Software Bill of Materials using
shared yaml templates.