### PR TITLE
Fix issue 504

### DIFF
--- a/mappings/androidx-assemblies.csv
+++ b/mappings/androidx-assemblies.csv
@@ -38,7 +38,7 @@ Xamarin.Android.Support.CustomView,Xamarin.AndroidX.CustomView,Xamarin.Android.S
 Xamarin.Android.Support.Design,Xamarin.Android.ReactiveX.RxJava,Xamarin.Android.Support.Design,Xamarin.Android.ReactiveX.RxJava,2.2.21.5
 Xamarin.Android.Support.Design,Xamarin.Android.ReactiveX.RxJava3.RxJava,Xamarin.Android.Support.Design,Xamarin.Android.ReactiveX.RxJava3.RxJava,3.1.3.2
 Xamarin.Android.Support.Design,Xamarin.AndroidX.Annotation.Experimental,Xamarin.Android.Support.Design,Xamarin.AndroidX.Annotation.Experimental,1.2.0
-Xamarin.Android.Support.Design,Xamarin.Google.Android.Material,Xamarin.Android.Support.Design,Xamarin.Google.Android.Material,1.5.0
+Xamarin.Android.Support.Design,Xamarin.Google.Android.Material,Xamarin.Android.Support.Design,Xamarin.Google.Android.Material,1.5.0.1
 Xamarin.Android.Support.Design,Xamarin.Kotlin.StdLib,Xamarin.Android.Support.Design,Xamarin.Kotlin.StdLib,1.6.10
 Xamarin.Android.Support.DocumentFile,Xamarin.AndroidX.DocumentFile,Xamarin.Android.Support.DocumentFile,Xamarin.AndroidX.DocumentFile,1.0.1.12
 Xamarin.Android.Support.DrawerLayout,Xamarin.AndroidX.DrawerLayout,Xamarin.Android.Support.DrawerLayout,Xamarin.AndroidX.DrawerLayout,1.1.1.7

--- a/mappings/dependencies.json
+++ b/mappings/dependencies.json
@@ -1150,17 +1150,7 @@
       ]
     },
     {
-      "id": "Xamarin.AndroidX.Migration",
-      "dependencies": [
-        "Xamarin.AndroidX.MultiDex"
-      ]
-    },
-    {
       "id": "Xamarin.AndroidX.MultiDex",
-      "dependencies": []
-    },
-    {
-      "id": "Xamarin.AndroidX.Migration.Tool",
       "dependencies": []
     },
     {

--- a/source/androidx.activity/activity/Additions/ActivityResultContracts.cs
+++ b/source/androidx.activity/activity/Additions/ActivityResultContracts.cs
@@ -180,7 +180,15 @@ namespace AndroidX.Activity.Result.Contract
 				}
 			}
 
-
+		}		
+		public partial class CreateDocument //: global::AndroidX.Activity.Result.Contract.ActivityResultContract 
+		{
+			public global::Android.Content.Intent CreateIntent (global::Android.Content.Context context, string input)
+			{
+				return CreateIntent (context, (Java.Lang.Object) input);
+			}
 		}
-	}   
+	}
+
+
 }


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Yes. Adds overloaded `CreateIntent` method with `string` parameter.



### Describe your contribution

CreateIntent parameter fix

```csharp
  public global::Android.Content.Intent CreateIntent (global::Android.Content.Context context, string input)
  {
    return CreateIntent (context, (Java.Lang.Object) input);
  }
```