### PR TITLE
[ci] Update boots to fix vsix downgrade issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.3
   AndroidXMigrationVersion: 1.0.8
+  BootsVersion: 1.1.0.712-preview2
   DotNetVersion: 6.0.200
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
@@ -57,16 +58,14 @@ jobs:
 
       preBuildSteps:
         - pwsh: |
-            dotnet tool uninstall --global Cake.Tool
-            dotnet tool install --global Cake.Tool
-            dotnet tool install --global boots
+            dotnet tool update --global Cake.Tool
+            dotnet tool update --global boots --version $(BootsVersion)
             boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
-            dotnet tool uninstall --global Cake.Tool
-            dotnet tool install --global Cake.Tool
-            dotnet tool install --global boots
-            boots $(LegacyXamarinAndroidVsix)
+            dotnet tool update --global Cake.Tool
+            dotnet tool update --global boots --version $(BootsVersion)
+            boots --url $(LegacyXamarinAndroidVsix) --downgrade-first
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'


### PR DESCRIPTION
AndroidX/GooglePlayServices switched to using a private agent pool in order to meet the EO requirements. This pool is elastic, however agents can be reused if they become available while a job is waiting in the queue.

This means that the image may not always be fresh, and the image may contain a newer Xamarin.Android vsix than the one we want to use.  Unfortunately `vsixinstaller.exe` cannot downgrade an installed package, which causes us to build with the newer one instead of our intended one.

A new command was added to `boots` (`--downgrade-first`) which will first revert the installed Xamarin.Android vsix to the one that shipped with the target version of Visual Studio.

Update to the latest preview of `boots`, and call the new command.

Also switches to `dotnet tool update` which can handle both the case where the tool is not installed and if it is already installed.