### PR TITLE
Mark all assemblies as Trimmable via Directory.Build.props.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,9 @@
     
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    
+    <!-- Mark .NET6+ packages as supporting trimming -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   
   <!-- Folders that .targets files need to go into -->


### PR DESCRIPTION
Fixes: #519

In Xamarin.Android Classic we link all assemblies by default unless the user opts out.  In .NET6+, assemblies must opt-in to being linked by setting `$(IsTrimmable)`.

We already had this for packages using the default AndroidX template, but AndroidX dependencies (like Kotlin) bound in this repository use other templates that did not include trimming.

Enable trimming via `Directory.Build.targets` to ensure it affects *all* assemblies.

From CI build for `Xamarin.Kotlin.Stdlib.dll`:
![image](https://user-images.githubusercontent.com/179295/161110990-eaa56e81-3992-4c6a-9aa2-5d47040f4962.png)
