### PR TITLE
Manual update 20220401 `androidx.core.core-splashscreen` 1.0.0-beta02 added

### DIFF
--- a/config.json
+++ b/config.json
@@ -459,6 +459,14 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "androidx.core",
+        "artifactId": "core-splashscreen",
+        "version": "1.0.0-beta02",
+        "nugetVersion": "1.0.0-beta02",
+        "nugetId": "Xamarin.AndroidX.Core.SplashScreen",
+        "dependencyOnly": false
+      },
+      {
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",


### PR DESCRIPTION
### Does this change any of the generated binding API's?

yes - new bindings

### Describe your contribution

* `androidx.core.core-splashscreen` 1.0.0-beta02