### PR TITLE
Bump packages to be higher than previously released unlisted packages.

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.Activity",
         "dependencyOnly": false
       },
@@ -38,7 +38,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx",
         "dependencyOnly": false
       },
@@ -422,7 +422,7 @@
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.1",
+        "nugetVersion": "1.7.0.2",
         "nugetId": "Xamarin.AndroidX.Core",
         "dependencyOnly": false
       },
@@ -446,7 +446,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.1",
+        "nugetVersion": "1.7.0.2",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx",
         "dependencyOnly": false
       },


### PR DESCRIPTION
Before we realized the issues caused by `AndroidX.Core` 1.7.0, we published packages using that version, including `1.7.0.1`.  After we realized the issue, we reverted our package versions back to `1.6.x` and delisted the packages from NuGet.

https://github.com/xamarin/AndroidX/issues/439

However, now that we are back on a fixed `1.7.0`, we are trying to release packages that have the same versions (ie: `1.7.0.1`) as the delisted packages on NuGet, which is not permitted.

Therefore we need to bump these packages again to be "newer" versions than the delisted packages instead of conflicting with them.