### PR TITLE
Import Guava to AndroidX repository

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -705,6 +705,9 @@ Task("samples-generate-all-targets")
         // Skip the migration packages as that is not meant forto be used here
         if (nupkg.FullPath.Contains("Xamarin.AndroidX.Migration"))
             continue;
+        // Skip Guava.ListenableFuture as it cannot be used in the same project as Guava itself
+        if (nupkg.FullPath.Contains("Xamarin.Google.Guava.ListenableFuture"))
+            continue;
 
         var filename = nupkg.GetFilenameWithoutExtension();
         var match = Regex.Match(filename.ToString(), @"(.+?)\.(\d+[\.0-9\-a-zA-Z]+)");
@@ -713,18 +716,6 @@ Task("samples-generate-all-targets")
             new XAttribute("Version", match.Groups[2])));
 
     }
-
-    // R8 ACW errors about missing classes
-    // TODO: could have been grabbed from config.json
-    itemGroup.Add(new XElement(xmlns + "PackageReference",
-        new XAttribute("Include", "Xamarin.Google.Guava"),
-        new XAttribute("Version", "27.1.0.4")));
-    itemGroup.Add(new XElement(xmlns + "PackageReference",
-        new XAttribute("Include", "Xamarin.Google.Guava.FailureAccess"),
-        new XAttribute("Version", "1.0.1.2")));
-    itemGroup.Add(new XElement(xmlns + "PackageReference",
-        new XAttribute("Include", "Xamarin.Google.Guava.ListenableFuture"),
-        new XAttribute("Version", "1.0.0.2")));
 
     var xdoc = new XDocument(new XElement(xmlns + "Project", itemGroup));
     xdoc.Save("./output/AllPackages.targets");

--- a/config.json
+++ b/config.json
@@ -1581,25 +1581,29 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.5",
+        "nugetVersion": "1.0.1.6",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "guava"
       },
       {
         "groupId": "com.google.guava",
         "artifactId": "guava",
-        "version": "29.0.0",
-        "nugetVersion": "29.0.0",
+        "version": "31.1-android",
+        "nugetVersion": "31.1.0.2",
         "nugetId": "Xamarin.Google.Guava",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "excludedRuntimeDependencies": "com.google.code.findbugs.jsr305,org.checkerframework.checker-qual,org.checkerframework.checker-compat-qual,com.google.errorprone.error_prone_annotations,com.google.j2objc.j2objc-annotations,com.google.guava.listenablefuture",
+        "templateSet": "guava"
       },
       {
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "guava"
       },
       {
         "groupId": "com.xamarin.androidx",
@@ -1611,6 +1615,20 @@
       }
     ],
     "templateSets": [
+      {
+        "name": "guava",
+        "mavenRepositoryType": "MavenCentral",
+        "templates": [
+          {
+            "templateFile": "templates/guava/Project.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
+          },
+          {
+            "templateFile": "source/AndroidXSolutionFilter.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
+          }
+        ]
+      },
       {
         "name": "kotlin",
         "mavenRepositoryType": "MavenCentral",

--- a/source/com.google.guava/failureaccess/Transforms/Transforms.xml
+++ b/source/com.google.guava/failureaccess/Transforms/Transforms.xml
@@ -1,0 +1,19 @@
+<metadata>
+  <!-- Rename Namespaces -->
+  <attr path="/api/package[@name='com.google.common.util.concurrent.internal']" name="managedName">Google.Common.Util.Concurrent.Internal</attr>
+
+  <attr 
+    path="/api/package[@name='com.google.common.util.concurrent']" 
+    name="managedName"
+    >
+    Google.Common.Util.Concurrent
+  </attr>
+  <attr 
+    path="/api/package[@name='com.google.common.util.concurrent.internal']"
+    name="managedName"
+    >
+    Google.Common.Util.Concurrent.Internal
+  </attr>
+
+
+</metadata>

--- a/source/com.google.guava/failureaccess/Xamarin.Google.Guava.FailureAccess.targets
+++ b/source/com.google.guava/failureaccess/Xamarin.Google.Guava.FailureAccess.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
+  </ItemGroup>
+</Project>

--- a/source/com.google.guava/guava/Transforms/Transforms.xml
+++ b/source/com.google.guava/guava/Transforms/Transforms.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<metadata>
+	<remove-node path="/api/package" />
+</metadata>

--- a/source/com.google.guava/guava/Xamarin.Google.Guava.targets
+++ b/source/com.google.guava/guava/Xamarin.Google.Guava.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' And '$(XamarinGoogleGuavaOptOut)' != 'true' ">
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
+  </ItemGroup>
+</Project>

--- a/source/com.google.guava/listenablefuture/Transforms/Transforms.xml
+++ b/source/com.google.guava/listenablefuture/Transforms/Transforms.xml
@@ -1,0 +1,13 @@
+<metadata>
+  <!-- Rename Namespaces -->
+  <attr path="/api/package[@name='com.google.common.util.concurrent']" name="managedName">Google.Common.Util.Concurrent</attr>
+
+
+  <attr 
+    path="/api/package[@name='com.google.common.util.concurrent']"
+    name="managedName"
+    >
+    Google.Common.Util.Concurrent
+  </attr>
+
+</metadata>

--- a/source/com.google.guava/listenablefuture/Xamarin.Google.Guava.ListenableFuture.targets
+++ b/source/com.google.guava/listenablefuture/Xamarin.Google.Guava.ListenableFuture.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' And '$(XamarinGoogleGuavaListenableFutureOptOut)' != 'true' ">
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
+  </ItemGroup>
+</Project>

--- a/templates/guava/External-Dependency-Info.txt
+++ b/templates/guava/External-Dependency-Info.txt
@@ -1,0 +1,216 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Components for Glide incorporates 
+third party material from the projects listed below. The original copyright 
+notice and the license under which Microsoft received such third party 
+material are set forth below.  Microsoft reserves all other rights not 
+expressly granted, whether by implication, estoppel or otherwise.
+
+########################################
+# Guava
+# https://github.com/google/guava
+########################################
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/templates/guava/License.md
+++ b/templates/guava/License.md
@@ -1,0 +1,18 @@
+**Xamarin is not responsible for, nor does it grant any licenses to, third-party packages. Some packages may require or install dependencies which are governed by additional licenses.**
+
+Note: This component depends on [Guava](https://github.com/google/guava), which is subject to the [Apache 2.0](https://github.com/google/guava/blob/master/COPYING)
+
+### Xamarin Component for Guava for Xamarin.Android
+
+**The MIT License (MIT)**
+
+Copyright (c) .NET Foundation Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+20160601
+

--- a/templates/guava/Project.cshtml
+++ b/templates/guava/Project.cshtml
@@ -1,0 +1,138 @@
+<Project Sdk="Xamarin.Legacy.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <IsBindingProject>true</IsBindingProject>
+    <!--
+      No warnings for:
+       - CS0618: 'member' is obsolete: 'text'
+       - CS0109: The member 'member' does not hide an inherited member. The new keyword is not required
+       - CS0114: 'function1' hides inherited member 'function2'. To make the current method override that implementation, add the override keyword. Otherwise add the new keyword.
+       - CS0628: 'member' : new protected member declared in sealed class
+       - CS0108: 'member1' hides inherited member 'member2'. Use the new keyword if hiding was intended.
+       - CS0809: Obsolete member 'member' overrides non-obsolete member 'member'
+       - CS1572: XML comment has a param tag for '', but there is no parameter by that name  
+       - CS1574: XML comment has cref attribute 'Observer' that could not be resolved
+    -->
+    <NoWarn>0618;0109;0114;0628;0108;0809;1572;1574</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AndroidClassParser>class-parse</AndroidClassParser>
+    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865435</PackageProjectUrl>
+    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865373</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    @foreach (var art in @Model.MavenArtifacts) 
+    {
+      <PackageId>@Model.NuGetPackageId</PackageId>
+      <AssemblyName>@Model.NuGetPackageId</AssemblyName>
+      switch(@Model.NuGetPackageId)
+      {
+          case "Xamarin.Google.Guava":
+            <Title>Xamarin.Google.Guava</Title>
+            <Title>Google Guava reference library for Xamarin.Android</Title>
+            <PackageDescription>
+            Xamarin.Android bindings for Google Guava
+
+            NOTE: This package is meant to be used as a reference only for other binding projects that depend on Guava.
+            This package does not expose any useful API's in the .dll itself.
+
+            Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, functional types, an in-memory cache, and APIs/utilities for concurrency, I/O, hashing, primitives, reflection, string processing, and much more!
+            </PackageDescription>
+            <AssemblyName>Xamarin.Google.Guava</AssemblyName>
+            <RootNamespace>Guava</RootNamespace>
+            <NuGetJarName>guava.jar</NuGetJarName>
+            break; 
+          case "Xamarin.Google.Guava.FailureAccess":
+            <Title>Xamarin.Google.Guava.FailureAccess</Title>
+            <Title>Google Guava FailureAccess reference library for Xamarin.Android</Title>
+            <PackageDescription>
+            Xamarin.Android bindings for Google Guava FailureAccess
+
+            NOTE: This package is meant to be used as a reference only for other binding projects that depend on Guava.
+            This package does not expose any useful API's in the .dll itself.
+
+            Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, functional types, an in-memory cache, and APIs/utilities for concurrency, I/O, hashing, primitives, reflection, string processing, and much more!
+            </PackageDescription>
+            <AssemblyName>Xamarin.Google.Guava.FailureAccess</AssemblyName>
+            <RootNamespace>Guava.FailureAccess</RootNamespace>
+            <NuGetJarName>guava-failureaccess.jar</NuGetJarName>
+            break; 
+          case "Xamarin.Google.Guava.ListenableFuture":
+            <Title>Xamarin.Google.Guava.ListenableFuture</Title>
+            <Title>Google Guava ListenableFuture reference library for Xamarin.Android</Title>
+            <PackageDescription>
+            Xamarin.Android bindings for Google Guava ListenableFuture
+
+            NOTE: This package is meant to be used as a reference only for other binding projects that depend on Guava.
+            This package does not expose any useful API's in the .dll itself.
+
+            Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, functional types, an in-memory cache, and APIs/utilities for concurrency, I/O, hashing, primitives, reflection, string processing, and much more!
+            </PackageDescription>
+            <AssemblyName>Xamarin.Google.Guava.ListenableFuture</AssemblyName>
+            <RootNamespace>Guava.ListenableFuture</RootNamespace>
+            <NuGetJarName>guava-listenablefuture.jar</NuGetJarName>
+            break; 
+          default:
+            break; 
+      }
+      <PackageVersion>@(Model.NuGetVersion)</PackageVersion>
+    }
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+    
+  <ItemGroup>
+    <None Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Additions\*.cs" Link="Additions\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var art in @Model.MavenArtifacts) 
+    {
+        <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="jar\$(NuGetJarName)" Visible="false" />
+        <InputJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Link="Jars\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" />
+    }
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var dep in @Model.NuGetDependencies) {
+      if (dep.IsProjectReference) {
+    <ProjectReference Include="..\..\generated\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId)\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId).csproj" PrivateAssets="none" />
+      } else {
+    <PackageReference Include="@(dep.NuGetPackageId)" Version="@(dep.NuGetVersion)" />
+      }
+    }
+  </ItemGroup>
+
+  @if(Model.NuGetPackageId == "Xamarin.Google.Guava") {
+  <ItemGroup>
+    <!-- Temporarily handle these here instead of through binderator because they require parent POM dependency support -->
+    <PackageReference Include="Xamarin.CheckerFramework.CheckerCompatQual" Version="2.5.5" />
+    <PackageReference Include="Xamarin.Google.Code.FindBugs.JSR305" Version="3.0.2.2" />
+    <PackageReference Include="Xamarin.Google.ErrorProne.Annotations" Version="2.4.0.1" />
+    <PackageReference Include="Xamarin.Google.J2Objc.Annotations" Version="1.3.0" />
+    <!-- Reference a version of ListenableFuture that does not contain 'listenablefuture.jar' -->
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="9999.0.0" />
+  </ItemGroup>
+  }
+
+  <ItemGroup>
+    <None Include="..\..\templates\guava\License.md" Pack="true" PackagePath="License.md" />
+    <None Include="..\..\templates\guava\External-Dependency-Info.txt" Pack="true" PackagePath="THIRD-PARTY-NOTICES.txt" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This incorporates some stuff from https://github.com/xamarin/AndroidX/pull/395 in order to complete migrating Guava from XamarinComponents to the AndroidX repository.

Some notes:
- We use `excludedRuntimeDependencies` to ignore Guava's dependencies.  They use the "parent POM" pattern which we currently do not support, which causes `binderator` to throw an `NRE`.  We use explicit `<PackageReference>`'s for now to incorporate these dependencies.
- Removes `Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations` as a Guava dependency, as this is not present in the POM.
- To simplify PR (and because we can't use `binderator` for dependency management currently), does not import `Xamarin.Google.J2Objc.Annotations` or `Xamarin.CheckerFramework.CheckerCompatQual` to this repo yet.
  - Note `CheckerCompatQual` is no longer the correct dependency anyways, it now uses `CheckerQual`.
- Updated to target `MonoAndroid12.0` to match the rest of AndroidX.
- We cannot build both Guava and Guava.ListenableFuture in `BuildAll.csproj` because they both contain the same `ListenableFuture.class`.  We choose to only build Guava.
- Guava now depends on ListenableFuture `9999.0.0` instead of `1.0.0.7`.  (Context: https://github.com/xamarin/XamarinComponents/pull/1366)
- This only moves the existing bindings to this repo.  It does not attempt to fix existing problems like `31.0-jre`.

Future tasks:
- Move the Guava dependency `Xamarin.Google.J2Objc.Annotations` to this repository.
- Bind the Guava dependency `Xamarin.CheckerFramework.CheckerQual`.
- Add `binderator` support for "parent POM" so we can use automatic dependency management.

## CI Packages (Left is NuGet, right is CI)

**Xamarin.Google.Guava**

![image](https://user-images.githubusercontent.com/179295/166516234-2fc33892-0c92-4f2f-9487-ec3b964f34ba.png)

**Xamarin.Google.Guava.ListenableFuture**

![image](https://user-images.githubusercontent.com/179295/166516553-43b7b8e1-edad-48ba-afa6-44e4bf61921d.png)

**Xamarin.Google.Guava.FailureAccess**

![image](https://user-images.githubusercontent.com/179295/166516898-67454d9f-1c38-4057-b7a5-e96f0ff4975c.png)
