### PR TITLE
Use parent POM to support Guava dependencies.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pr:
   - main
   
 variables:
-  AndroidBinderatorVersion: 0.5.3
+  AndroidBinderatorVersion: 0.5.4
   AndroidXMigrationVersion: 1.0.8
   BootsVersion: 1.1.0.712-preview2
   DotNetVersion: 6.0.200

--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -6,12 +6,13 @@
 
 // Usage:
 //   dotnet tool install -g dotnet-script
-//   dotnet script update-config.csx -- ../../config.json <update|bump|published>
+//   dotnet script update-config.csx -- ../../config.json <update|bump|published|sort>
 // This script compares the versions of Java packages we are currently binding to the
 // stable versions available in Google's Maven repository.  
 // update - Automatically update the specified configuration file
 // bump - Apply NuGet revision bump to *all* packages
 // published - Display which NuGet package versions are already published on NuGet.org
+// sort - Sort the provided config.json without making any updates
 
 using MavenNet;
 using MavenNet.Models;
@@ -32,6 +33,7 @@ var config_json = File.ReadAllText (config_file);
 var config = JsonConvert.DeserializeObject<List<MyArray>> (config_json);
 var should_update = Args.Count > 1 && Args[1].ToLowerInvariant () == "update";
 var should_minor_bump = Args.Count > 1 && Args[1].ToLowerInvariant () == "bump";
+var should_sort = Args.Count > 1 && Args[1].ToLowerInvariant () == "sort";
 var check_published = Args.Count > 1 && Args[1].ToLowerInvariant () == "published";
 var serializer_settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
 serializer_settings.Converters.Add (new Newtonsoft.Json.Converters.StringEnumConverter ());
@@ -110,13 +112,13 @@ foreach (var art in config[0].Artifacts.Where (a => !a.DependencyOnly)) {
   } else {
 	  Console.WriteLine ($"| {package_name.PadRight (58)} | {current_version.PadRight (17)} | {(GetLatestVersion (a)?.ToString () ?? string.Empty).PadRight (15)} |");  
   }
+}
 
-	if (should_update || should_minor_bump)
-	{
-		// Write updated config.json back to disk
-		var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
-		File.WriteAllText (config_file, output + Environment.NewLine);
-	}
+if (should_update || should_minor_bump || should_sort)
+{
+	// Write updated config.json back to disk
+	var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
+	File.WriteAllText (config_file, output + Environment.NewLine);
 }
 
 static Artifact FindMavenArtifact (List<MyArray> config, ArtifactModel artifact)

--- a/config.json
+++ b/config.json
@@ -1413,7 +1413,7 @@
         "nugetVersion": "31.1.0.2",
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": false,
-        "excludedRuntimeDependencies": "com.google.code.findbugs.jsr305,org.checkerframework.checker-qual,org.checkerframework.checker-compat-qual,com.google.errorprone.error_prone_annotations,com.google.j2objc.j2objc-annotations,com.google.guava.listenablefuture",
+        "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
         "templateSet": "guava"
       },
       {
@@ -1424,6 +1424,15 @@
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "dependencyOnly": false,
         "templateSet": "guava"
+      },
+      {
+        "groupId": "com.google.j2objc",
+        "artifactId": "j2objc-annotations",
+        "version": "1.3",
+        "nugetVersion": "1.3.0",
+        "nugetId": "Xamarin.Google.J2Objc.Annotations",
+        "dependencyOnly": false,
+        "templateSet": "no-bindings"
       },
       {
         "groupId": "io.reactivex.rxjava2",
@@ -1442,6 +1451,15 @@
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "dependencyOnly": false,
         "templateSet": "rxjava"
+      },
+      {
+        "groupId": "org.checkerframework",
+        "artifactId": "checker-qual",
+        "version": "3.22.0",
+        "nugetVersion": "3.22.0",
+        "nugetId": "Xamarin.CheckerFramework.CheckerQual",
+        "dependencyOnly": false,
+        "templateSet": "no-bindings"
       },
       {
         "groupId": "org.jetbrains",
@@ -1598,6 +1616,22 @@
         "dependencyOnly": true
       },
       {
+        "groupId": "com.google.code.findbugs",
+        "artifactId": "jsr305",
+        "version": "3.0.2",
+        "nugetVersion": "3.0.2.4",
+        "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.errorprone",
+        "artifactId": "error_prone_annotations",
+        "version": "2.11.0",
+        "nugetVersion": "2.4.0.3",
+        "nugetId": "Xamarin.Google.ErrorProne.Annotations",
+        "dependencyOnly": true
+      },
+      {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
@@ -1622,6 +1656,24 @@
           {
             "templateFile": "templates/guava/Project.cshtml",
             "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
+          },
+          {
+            "templateFile": "source/AndroidXSolutionFilter.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
+          }
+        ]
+      },
+      {
+        "name": "no-bindings",
+        "mavenRepositoryType": "MavenCentral",
+        "templates": [
+          {
+            "templateFile": "templates/no-bindings/Project.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
+          },
+          {
+            "templateFile": "templates/no-bindings/Targets.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{nugetid}.targets"
           },
           {
             "templateFile": "source/AndroidXSolutionFilter.cshtml",

--- a/source/com.google.j2objc/j2objc-annotations/External-Dependency-Info.txt
+++ b/source/com.google.j2objc/j2objc-annotations/External-Dependency-Info.txt
@@ -1,0 +1,215 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+This package incorporates third party material from the projects listed 
+below. The original copyright notice and the license under which Microsoft 
+received such third party material are set forth below.  Microsoft reserves 
+all other rights not expressly granted, whether by implication, estoppel or otherwise.
+
+########################################
+# J2ObjC: Java to Objective-C Translator and Runtime
+# https://github.com/google/j2objc
+########################################
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/source/com.google.j2objc/j2objc-annotations/License.md
+++ b/source/com.google.j2objc/j2objc-annotations/License.md
@@ -1,0 +1,15 @@
+**Xamarin is not responsible for, nor does it grant any licenses to, third-party packages. Some packages may require or install dependencies which are governed by additional licenses.**
+
+Note: This component depends on [J2ObjC: Java to Objective-C Translator and Runtime](https://github.com/google/j2objc), which is subject to the [Apache 2.0](https://github.com/google/j2objc/blob/master/LICENSE)
+
+### Xamarin Component for J2ObjC for Xamarin.Android
+
+**The MIT License (MIT)**
+
+Copyright (c) .NET Foundation Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/source/org.checkerframework/checker-qual/External-Dependency-Info.txt
+++ b/source/org.checkerframework/checker-qual/External-Dependency-Info.txt
@@ -1,0 +1,35 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+This package incorporates third party material from the projects listed 
+below. The original copyright notice and the license under which Microsoft 
+received such third party material are set forth below.  Microsoft reserves 
+all other rights not expressly granted, whether by implication, estoppel or otherwise.
+
+########################################
+# The Checker Framework
+# https://checkerframework.org/
+########################################
+
+Checker Framework qualifiers
+Copyright 2004-present by the Checker Framework developers
+
+MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/source/org.checkerframework/checker-qual/License.md
+++ b/source/org.checkerframework/checker-qual/License.md
@@ -1,0 +1,15 @@
+**Xamarin is not responsible for, nor does it grant any licenses to, third-party packages. Some packages may require or install dependencies which are governed by additional licenses.**
+
+Note: This component depends on [Checker Framework qualifiers](https://github.com/typetools/checker-framework/tree/master/checker-qual), which is subject to the [MIT License](https://github.com/typetools/checker-framework/blob/master/checker-qual/LICENSE.txt)
+
+### Xamarin Component for 'Checker Framework qualifiers' for Xamarin.Android
+
+**The MIT License (MIT)**
+
+Copyright (c) .NET Foundation Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/guava/Project.cshtml
+++ b/templates/guava/Project.cshtml
@@ -120,11 +120,6 @@
 
   @if(Model.NuGetPackageId == "Xamarin.Google.Guava") {
   <ItemGroup>
-    <!-- Temporarily handle these here instead of through binderator because they require parent POM dependency support -->
-    <PackageReference Include="Xamarin.CheckerFramework.CheckerCompatQual" Version="2.5.5" />
-    <PackageReference Include="Xamarin.Google.Code.FindBugs.JSR305" Version="3.0.2.2" />
-    <PackageReference Include="Xamarin.Google.ErrorProne.Annotations" Version="2.4.0.1" />
-    <PackageReference Include="Xamarin.Google.J2Objc.Annotations" Version="1.3.0" />
     <!-- Reference a version of ListenableFuture that does not contain 'listenablefuture.jar' -->
     <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="9999.0.0" />
   </ItemGroup>

--- a/templates/no-bindings/Project.cshtml
+++ b/templates/no-bindings/Project.cshtml
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Xamarin.Legacy.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <IsBindingProject>true</IsBindingProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>@Model.NuGetPackageId</PackageId>
+    <Title>@Model.NuGetPackageId</Title>
+    <PackageVersion>@Model.NuGetVersion</PackageVersion>
+    <PackageDescription>@Model.NuGetPackageId</PackageDescription>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://aka.ms/androidx</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    
+    @switch(@Model.NuGetPackageId)
+    {
+        case "Xamarin.CheckerFramework.CheckerQual":
+          <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        break;
+        
+        default:
+          <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        break;
+    }
+  </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    @foreach (var art in @Model.MavenArtifacts) 
+    {
+        <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="jar\$(NuGetJarName)" Visible="false" />
+    }
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\License.md" Pack="true" PackagePath="License.md" />
+    <None Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\External-Dependency-Info.txt" Pack="true" PackagePath="THIRD-PARTY-NOTICES.txt" />
+  </ItemGroup>
+
+</Project>

--- a/templates/no-bindings/Targets.cshtml
+++ b/templates/no-bindings/Targets.cshtml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Switches dependencies for `Xamarin.Google.Guava` from being manually managed with `<PackageReference>` in `.csproj`, to being automatically generated from `config.json`.  This will help ensure its dependencies are kept updated and correct with its `.pom` file.

Status:

- ✅ Uses parent POM dependencies instead of manual dependencies
- ✅ `Xamarin.Google.Code.FindBugs.JSR305` is in GPS (eventually should probably move here)
- ✅ `Xamarin.Google.ErrorProne.Annotations` is in GPS (eventually should probably move here)
- ✅ `Xamarin.Google.J2Objc.Annotations` is moved from XamarinComponents (updated to `MonoAndroid12.0`)
- ✅ `org.checkerframework.checker-qual` has been bound
  - Note that Guava was previously incorrectly depending on `checker-compat-qual` rather than `checker-qual`, thus `Xamarin.CheckerFramework.CheckerQual` is a new package.

A new generic `no-binding` template has been added to support packages which should only contain a `.jar` file and a `.targets` file.  This template omits any `<InputJar>` references, and thus does not create any binding `.cs` files.  It still creates an empty `.dll` file, which is excluded from the NuGet package using `<IncludeBuildOutput>` set to `false`.

This template should be quicker for us to build, and quicker for users to consume, as no `.dll` will need to be included and eventually Linked.

## Guava Dependency Changes

![image](https://user-images.githubusercontent.com/179295/167708929-886ca838-2532-4299-a310-02b5abff1e0e.png)

## Updated J2Objc Package

![image](https://user-images.githubusercontent.com/179295/167709263-f32d3480-e716-43a4-a9e5-418f8e93edab.png)

## New CheckerQual Package

![image](https://user-images.githubusercontent.com/179295/167709422-67c57194-37ce-4c06-90c2-13fddea9dedb.png)
