### PR TITLE
[ci] Update to Classic 17.2 / .NET 6 RC3.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ variables:
   AndroidBinderatorVersion: 0.5.3
   AndroidXMigrationVersion: 1.0.8
   BootsVersion: 1.1.0.712-preview2
-  DotNetVersion: 6.0.200
+  DotNetVersion: 6.0.300
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
-  XamarinDotNetWorkloadSource: https://aka.ms/dotnet/maui/preview.13.json
+  XamarinDotNetWorkloadSource: https://aka.ms/dotnet/maui/rc.3.json
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
-  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-1-windows
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-2-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   PRE_RESTORE_PROJECTS: true  # Windows is having an issue on CI right now

--- a/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.xml
+++ b/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.xml
@@ -256,58 +256,30 @@
       >
     </method>
   </add-node>
-
+  <!-- Temporary fix for https://github.com/xamarin/java.interop/issues/984 -->
   <attr
-    path="/api/package[@name='kotlin']/class[@name='UByteArray']/method[@name='set-VurrAj0' and count(parameter)=3 and parameter[1][@type='byte[]'] and parameter[2][@type='int'] and parameter[3][@type='byte']]/parameter[3]"
+    path="/api/package[@name='kotlin']/class[@name='UByteArray']/method[@name='contains-7apg3OU' and count(parameter)=1 and parameter[1][@type='byte']]/parameter[1]"
     name="type"
     >
     ubyte
   </attr>
   <attr
-    path="/api/package[@name='kotlin']/class[@name='UByteArray']/method[@name='get-w2LRezQ' and count(parameter)=2 and parameter[1][@type='byte[]'] and parameter[2][@type='int']]"
-    name="return"
-    >
-    ubyte
-  </attr>
-  <attr
-    path="/api/package[@name='kotlin']/class[@name='UIntArray']/method[@name='set-VXSXFK8' and count(parameter)=3 and parameter[1][@type='int[]'] and parameter[2][@type='int'] and parameter[3][@type='int']]/parameter[3]"
+    path="/api/package[@name='kotlin']/class[@name='UIntArray']/method[@name='contains-WZ4Q5Ns' and count(parameter)=1 and parameter[1][@type='int']]/parameter[1]"
     name="type"
     >
     uint
   </attr>
-
   <attr
-    path="/api/package[@name='kotlin']/class[@name='UIntArray']/method[@name='get-pVg5ArA' and count(parameter)=2 and parameter[1][@type='int[]'] and parameter[2][@type='int']]"
-    name="return"
-    >
-    uint
-  </attr>
-  <attr
-    path="/api/package[@name='kotlin']/class[@name='ULongArray']/method[@name='set-k8EXiF4' and count(parameter)=3 and parameter[1][@type='long[]'] and parameter[2][@type='int'] and parameter[3][@type='long']]/parameter[3]"
+    path="/api/package[@name='kotlin']/class[@name='ULongArray']/method[@name='contains-VKZWuLQ' and count(parameter)=1 and parameter[1][@type='long']]/parameter[1]"
     name="type"
     >
     ulong
   </attr>
-
   <attr
-    path="/api/package[@name='kotlin']/class[@name='ULongArray']/method[@name='get-s-VKNKU' and count(parameter)=2 and parameter[1][@type='long[]'] and parameter[2][@type='int']]"
-    name="return"
-    >
-    ulong
-  </attr>
-  <attr
-    path="/api/package[@name='kotlin']/class[@name='UShortArray']/method[@name='set-01HTLdE' and count(parameter)=3 and parameter[1][@type='short[]'] and parameter[2][@type='int'] and parameter[3][@type='short']]/parameter[3]"
+    path="/api/package[@name='kotlin']/class[@name='UShortArray']/method[@name='contains-xj2QHRw' and count(parameter)=1 and parameter[1][@type='short']]/parameter[1]"
     name="type"
     >
     ushort
   </attr>
-
-  <attr
-    path="/api/package[@name='kotlin']/class[@name='UShortArray']/method[@name='get-Mh2AYeg' and count(parameter)=2 and parameter[1][@type='short[]'] and parameter[2][@type='int']]"
-    name="return"
-    >
-    ushort
-  </attr>
-
 
 </metadata>


### PR DESCRIPTION
Updates CI to build with:
- Classic: VS2022 17.2
- .NET 6: Maui RC3

Types of reported API differences:

## Fixed accuracy of unsigned Kotlin types due to https://github.com/xamarin/java.interop/pull/946

(Previously needed Metadata.xml to fix this issue has been removed.)

Example:
```
#### Type Changed: Kotlin.UIntArray

Removed method:
public static bool Contains (int[] arg0, int element);

Added method:
public static bool Contains (int[] arg0, uint element);
```

## Removed internal Kotlin methods from better metadata matching

Example:
```
#### Type Changed: Kotlin.Random.RandomKt

Removed method:

public static int TakeUpperBits (int obj, int bitCount);
```

[Kotlin source](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/src/kotlin/random/Random.kt#L374-L376)
```
internal fun Int.takeUpperBits(bitCount: Int): Int =
    this.ushr(32 - bitCount) and (-bitCount).shr(31)
```

## Better method parameter names from better Kotlin metadata matching

Example:
```
#### Type Changed: Kotlin.Sequences.SequenceScope

Modified methods:

-public abstract Java.Lang.Object Yield (Java.Lang.Object p0, Kotlin.Coroutines.IContinuation p1)
+public abstract Java.Lang.Object Yield (Java.Lang.Object value, Kotlin.Coroutines.IContinuation p1)
-public abstract Java.Lang.Object YieldAll (Java.Util.IIterator p0, Kotlin.Coroutines.IContinuation p1)
+public abstract Java.Lang.Object YieldAll (Java.Util.IIterator iterator, Kotlin.Coroutines.IContinuation p1)
```

## New Metadata.xml

There seems to be a regression in the Kotlin metadata matching that resulted in 4 overloaded methods being incorrectly matched.

Example:
```
#### Type Changed: Kotlin.UIntArray

Removed methods:

public bool Contains (uint element);

Added methods:

public bool Contains (int element);
```

This has been filed as https://github.com/xamarin/java.interop/issues/984.  Metadata has been added in this PR to fix up the 4 cases.