### PR TITLE
Use <PackageIcon> instead of deprecated <PackageIconUrl>.

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -52,7 +52,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2113238</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2099392</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageVersion>@(Model.NuGetVersion)$(PackageVersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
@@ -95,6 +95,7 @@
   <ItemGroup>
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
     <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+    <None Include="..\..\icons\Xamarin.AndroidX_nuget.png" Pack="True" PackagePath="icon.png" />
   </ItemGroup>
 
   @if (@Model.MavenArtifacts.Count > 0) {

--- a/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
+++ b/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
@@ -36,7 +36,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2113238</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2099392</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageVersion>1.1.0.1</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
@@ -54,6 +54,7 @@
 
   <ItemGroup>
     <None Include="..\..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+    <None Include="..\..\..\icons\Xamarin.AndroidX_nuget.png" Pack="True" PackagePath="icon.png" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
+++ b/source/com.google.android.material/Xamarin.Google.Android.Material.Extensions/Xamarin.Google.Android.Material.Extensions.csproj
@@ -37,7 +37,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2113238</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2099392</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageVersion>1.5.0-rc$(PackageVersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
@@ -53,6 +53,7 @@
     
   <ItemGroup>
     <None Include="..\..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+    <None Include="..\..\..\icons\Xamarin.AndroidX_nuget.png" Pack="True" PackagePath="icon.png" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/migration/Tool/Xamarin.AndroidX.Migration.Tool.csproj
+++ b/source/migration/Tool/Xamarin.AndroidX.Migration.Tool.csproj
@@ -16,7 +16,7 @@
     <Description>This package provides a set of tools and MSBuild tasks to aid in the migration from Android Support to Android X.</Description>
     <Summary>This package provides a set of tools and MSBuild tasks to aid in the migration from Android Support to Android X.</Summary>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2099353</PackageProjectUrl>
-    <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2099392</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageTags>Xamarin.AndroidX Xamarin Android Support AndroidX Migration</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Authors>Microsoft</Authors>
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <None Include="..\..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+    <None Include="..\..\..\icons\Xamarin.AndroidX_nuget.png" Pack="True" PackagePath="icon.png" />
   </ItemGroup>
 
 </Project>

--- a/templates/kotlin/Project.cshtml
+++ b/templates/kotlin/Project.cshtml
@@ -51,7 +51,6 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864997</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <!-- <PackageIconUrl></PackageIconUrl> -->
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes warning produced for each created package by using `<PackageIcon>` instead of deprecated `<PackageIconUrl>`:

```
C:\Program Files\dotnet\sdk\6.0.300\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(221,
5): warning NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' eleme
nt instead. Learn more at https://aka.ms/deprecateIconUrl [C:\code\AndroidX\generated\androidx.activity.activity\androi
dx.activity.activity.csproj]
```

Example:
![image](https://user-images.githubusercontent.com/179295/168627812-1990b15e-9ffb-4777-b1c6-de7dfeed975b.png)

