### PR TITLE
[Directory.Build.props] Turn on NRT annotations.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,9 @@
     <!-- Mark .NET6+ packages as supporting trimming -->
     <IsTrimmable>true</IsTrimmable>
     
+    <!-- Generate NRT annotations -->
+    <Nullable Condition=" '$(Nullable)' == '' ">enable</Nullable>
+    
     <!-- Warnings we want to error on: -->
     <!-- NU5104: A stable release of a package should not have a prerelease dependency. -->
     <WarningsAsErrors>$(WarningsAsErrors);NU5104</WarningsAsErrors>

--- a/source/migration/Dummy/Xamarin.AndroidX.Migration.Dummy.csproj
+++ b/source/migration/Dummy/Xamarin.AndroidX.Migration.Dummy.csproj
@@ -5,6 +5,7 @@
     <PackageId>Xamarin.AndroidX.Migration</PackageId>
     <IsPackable>false</IsPackable>
     <PackageVersion>$(MigrationPackageVersion)</PackageVersion>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Use `<Nullable>enable</Nullable>` in `Directory.Build.props` to enable nullable reference type annotations for packages in this repo.

Note that NRT annotations are pulled from the `.jar` files we bind.  We will not make manual fixes to them if they are incorrect or missing.