### PR TITLE
[ci] Verify published namespaces after api-diff has run.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,9 +69,10 @@ jobs:
             boots --url $(LegacyXamarinAndroidVsix) --downgrade-first
           condition: eq(variables['System.JobName'], 'windows')
           
-      postBuildSteps:
+      postDiffBuildSteps:
         - pwsh: |
             dotnet cake utilities.cake -t=verify-namespace-file
+          displayName: Verify published namespaces
       tools:
         - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'
         - 'xamarin.androidx.migration.tool': '$(AndroidXMigrationVersion)'


### PR DESCRIPTION
Because the "verify published namespaces" step currently runs before the "api-diff" step, if there are new namespaces the build will error and not produce the api diffs.  These diffs can be useful to help determine where the new namespaces are coming from.

By running the verification after api-diff, we can have information from both steps available for review.