### PR TITLE
Re-enable Mac CI builds.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   XamarinDotNetWorkloadSource: https://aka.ms/dotnet/maui/rc.3.json
-  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-2-macos
   LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-2-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
@@ -38,9 +38,8 @@ jobs:
       timeoutInMinutes: 120
       validPackagePrefixes: [ 'Xamarin', 'GoogleGson' ]
       areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
-      macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
+      macosImage: macOS-11                                    # the name of the macOS VM image (BigSur)
       windowsAgentPoolName: android-win-2022
-      xcode: 13.3.1
       dotnet: '6.0.300'                                       # the version of .NET Core to use
       dotnetStable: '6.0.300'                                 # the stable version of .NET Core to use
       initSteps:

--- a/build.cake
+++ b/build.cake
@@ -743,6 +743,35 @@ Task("samples")
     MSBuild("./samples/BuildAll/BuildAll.sln", settings);
 });
 
+Task("samples-dotnet")
+    .IsDependentOn("nuget")
+    .IsDependentOn("samples-generate-all-targets")
+    .Does(() =>
+{
+    // clear the packages folder so we always use the latest
+    var packagesPath = MakeAbsolute((DirectoryPath)"./samples/packages-dotnet").FullPath;
+    EnsureDirectoryExists(packagesPath);
+    CleanDirectories(packagesPath);
+
+    var settings = new DotNetMSBuildSettings()
+        .SetConfiguration(CONFIGURATION)
+        .SetMaxCpuCount(0)
+        .EnableBinaryLogger($"./output/samples-dotnet.{CONFIGURATION}.binlog")
+        .WithProperty("RestorePackagesPath", packagesPath)
+        .WithProperty("DesignTimeBuild", "false")
+        .WithProperty("AndroidSdkBuildToolsVersion", $"{AndroidSdkBuildTools}");
+
+    if (!string.IsNullOrEmpty(ANDROID_HOME))
+        settings.WithProperty("AndroidSdkDirectory", $"{ANDROID_HOME}");
+
+    DotNetRestore("./samples/BuildAll/BuildAllDotNet.sln", new DotNetRestoreSettings
+    {
+        MSBuildSettings = settings.EnableBinaryLogger("./output/samples-dotnet-restore.binlog")
+    });
+
+    DotNetMSBuild("./samples/BuildAll/BuildAllDotNet.sln", settings);
+});
+
 Task("api-diff")
     .Does
     (
@@ -895,14 +924,16 @@ Task ("packages")
 Task ("full-run")
     .IsDependentOn ("binderate")
     .IsDependentOn ("nuget")
-    .IsDependentOn ("samples");
+    .IsDependentOn ("samples")
+    .IsDependentOn ("samples-dotnet");
 
 Task ("ci")
     .IsDependentOn ("check-tools")
     .IsDependentOn ("inject-variables")
     .IsDependentOn ("binderate")
     .IsDependentOn ("nuget")
-    .IsDependentOn ("samples");
+    .IsDependentOn ("samples")
+    .IsDependentOn ("samples-dotnet");
 
 // for local builds, conditionally do the first binderate
 if (FileExists ("./generated/AndroidX.sln")) {

--- a/samples/BuildAll/BuildAll.sln
+++ b/samples/BuildAll/BuildAll.sln
@@ -7,8 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildAll", "BuildAll\BuildA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{49B04B11-434E-4579-AB17-D636343568AC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildAllDotNet", "BuildAllDotNet\BuildAllDotNet.csproj", "{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,12 +23,6 @@ Global
 		{49B04B11-434E-4579-AB17-D636343568AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49B04B11-434E-4579-AB17-D636343568AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49B04B11-434E-4579-AB17-D636343568AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/BuildAll/BuildAllDotNet.sln
+++ b/samples/BuildAll/BuildAllDotNet.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28606.126
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildAllDotNet", "BuildAllDotNet\BuildAllDotNet.csproj", "{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CA41D33-5A33-4968-AEBD-9A76B7E83BB7}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {47AA0B75-DCFB-4D55-AFC5-DB072FDDCCB1}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Re-enables Mac CI builds, which were previously disabled due to lack of VSMac 2022 stable releases.

Adding `BuildAllDotNet.csproj` to `BuildAll.sln` does not seem to work on Mac, as Mono cannot build the .NET 6 project:

```
/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/NuGet.targets(131,5): 
error : Invalid framework identifier ''.
```

Fix by creating a separate `BuildAllDotNet.sln` which is built with `dotnet build`.  Add this step to cake.