### PR TITLE
[update-config.csx] Add ability to "freeze" updates for an artifact.

### DIFF
--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -77,6 +77,9 @@ foreach (var art in config[0].Artifacts.Where (a => !a.DependencyOnly)) {
 		}
 	}
 
+	if (art.Frozen)
+		package_name = "# " + package_name;
+  
 	// Bump the revision version of all NuGet versions
 	// If there isn't currently a revision version, make it ".1"
 	if (should_minor_bump)
@@ -131,6 +134,10 @@ static Artifact FindMavenArtifact (List<MyArray> config, ArtifactModel artifact)
 
 static bool NeedsUpdate (ArtifactModel model, Artifact artifact)
 {
+	// Don't update package if it's "Frozen"
+	if (model.Frozen)
+		return false;
+    
 	// Get latest stable version
 	var latest = GetLatestVersion (artifact);
 
@@ -305,6 +312,9 @@ public class ArtifactModel
 	[DefaultValue ("")]
 	[JsonProperty ("dependencyOnly")]
 	public bool DependencyOnly { get; set; }
+
+	[JsonProperty ("frozen")]
+	public bool Frozen { get; set; }
 
 	[JsonProperty ("excludedRuntimeDependencies")]
 	public string ExcludedRuntimeDependencies { get; set; }

--- a/config.json
+++ b/config.json
@@ -1761,6 +1761,7 @@
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "dependencyOnly": false,
+        "frozen": true,
         "templateSet": "installreferrer"
       },
       {


### PR DESCRIPTION
We recently [added](https://github.com/xamarin/AndroidX/pull/556) a binding for `Xamarin.Google.Android.InstallReferrer`.  However, we only bound version `1.0.0` because it was `Apache 2.0` licensed.  Newer versions of this package are licensed as 	`Android Software Development Kit License` and thus we cannot bind them without reworking the package to use XBD.

However, our update script is going to see the newer version every week and attempt to automatically update it.  Eventually we will forget and approve it, which will put us out of license compliance.

As a fix, add a new feature to the update script where an artifact can be marked as `"frozen": true`.  When an artifact is marked like this the update script will not attempt to update the package.  Additionally, the package will be marked with a `#` in the output to indicate it is frozen:

```
| # com.android.installreferrer.installreferrer              | 1.0               | 2.2.0           |
```

This feature may also come in handy if there is a package update that will require substantial manual intervention.  We could mark that package as frozen so we can continue to automatically update other packages while we do the needed manual work.


