### PR TITLE
Bump `androidx.core.core-splashscreen` NuGet version to `1.0.0.1`

### DIFF
--- a/config.json
+++ b/config.json
@@ -517,7 +517,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-splashscreen",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0",
+        "nugetVersion": "1.0.0.1",
         "nugetId": "Xamarin.AndroidX.Core.SplashScreen",
         "dependencyOnly": false
       },


### PR DESCRIPTION
We released a [preview version](https://www.nuget.org/packages/Xamarin.AndroidX.Core.SplashScreen/1.0.0.1-rc01) of `androidx.core.core-splashscreen` as version `1.0.0.1-rc01`.

However, we released the final version as `1.0.0`, which is considered *before* `1.0.0.1-rc01`, and thus the preview version is listed as the "highest" available version on NuGet:

![image](https://user-images.githubusercontent.com/179295/189990588-1e6816f0-fb72-42de-8bdc-acda89f0cee6.png)

Bumping the stable version to `1.0.0.1` will make it the "best" version.