### PR TITLE
Update workloads.json

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ variables:
   AndroidBinderatorVersion: 0.5.4
   AndroidXMigrationVersion: 1.0.10
   BootsVersion: 1.1.0.712-preview2
-  DotNetVersion: 6.0.400
+  DotNetVersion: 6.0.401
   XcodeVersion: 13.3.1
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   XamarinDotNetWorkloadSource: workloads.json   # or url (check for recent versions - redth)
-                                                # https://aka.ms/dotnet/maui/6.0.400.json
+                                                # https://aka.ms/dotnet/maui/6.0.401.json
   # matching builds
   LegacyXamarinAndroidPkg:  https://aka.ms/xamarin-android-commercial-d17-3-macos
   LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-3-windows

--- a/global.json
+++ b/global.json
@@ -9,6 +9,6 @@
         "MSBuild.Sdk.Extras": "3.0.44",
         "Microsoft.Build.Traversal": "3.1.6",
         "Microsoft.Build.NoTargets": "3.4.0",
-        "Xamarin.Legacy.Sdk": "0.1.2-alpha6"
+        "Xamarin.Legacy.Sdk": "0.2.0-alpha2"
     }
 }

--- a/workloads.json
+++ b/workloads.json
@@ -5,6 +5,6 @@
   "microsoft.net.sdk.macos": "12.3.454/6.0.400",
   "microsoft.net.sdk.tvos": "15.4.454/6.0.400",
   "microsoft.net.sdk.maui": "6.0.540/6.0.400",
-  "microsoft.net.workload.mono.toolchain": "6.0.7/6.0.300",
-  "microsoft.net.workload.emscripten": "6.0.4/6.0.300"
+  "microsoft.net.workload.mono.toolchain": "6.0.9/6.0.400",
+  "microsoft.net.workload.emscripten": "6.0.9/6.0.400"
 }

--- a/workloads.json
+++ b/workloads.json
@@ -1,10 +1,10 @@
 {
-  "microsoft.net.sdk.android": "32.0.448/6.0.400",
-  "microsoft.net.sdk.ios": "15.4.442/6.0.400",
-  "microsoft.net.sdk.maccatalyst": "15.4.442/6.0.400",
-  "microsoft.net.sdk.macos": "12.3.442/6.0.400",
-  "microsoft.net.sdk.maui": "6.0.424/6.0.400",
-  "microsoft.net.sdk.tvos": "15.4.442/6.0.400",
+  "microsoft.net.sdk.android": "32.0.465/6.0.400",
+  "microsoft.net.sdk.ios": "15.4.454/6.0.400",
+  "microsoft.net.sdk.maccatalyst": "15.4.454/6.0.400",
+  "microsoft.net.sdk.macos": "12.3.454/6.0.400",
+  "microsoft.net.sdk.tvos": "15.4.454/6.0.400",
+  "microsoft.net.sdk.maui": "6.0.540/6.0.400",
   "microsoft.net.workload.mono.toolchain": "6.0.7/6.0.300",
   "microsoft.net.workload.emscripten": "6.0.4/6.0.300"
 }


### PR DESCRIPTION

### Does this change any of the generated binding API's?

No.

### Describe your contribution

CI errors on windows:

```
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Invalid rollback definition. The manifest IDs in rollback definition workloads.json do not match installed manifest IDs (microsoft.net.sdk.android, 32.0.448, 6.0.400) (microsoft.net.sdk.ios, 15.4.442, 6.0.400) (microsoft.net.sdk.maccatalyst, 15.4.442, 6.0.400) (microsoft.net.sdk.macos, 12.3.442, 6.0.400) (microsoft.net.sdk.maui, 6.0.424, 6.0.400) (microsoft.net.sdk.tvos, 15.4.442, 6.0.400) (microsoft.net.workload.mono.toolchain, 6.0.7, 6.0.300) (microsoft.net.workload.emscripten, 6.0.4, 6.0.300).
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Garbage collecting for SDK feature band(s) ...
```

workloads file

```
{
  "microsoft.net.sdk.android": "32.0.448/6.0.400",
  "microsoft.net.sdk.ios": "15.4.442/6.0.400",
  "microsoft.net.sdk.maccatalyst": "15.4.442/6.0.400",
  "microsoft.net.sdk.macos": "12.3.442/6.0.400",
  "microsoft.net.sdk.maui": "6.0.424/6.0.400",
  "microsoft.net.sdk.tvos": "15.4.442/6.0.400",
  "microsoft.net.workload.mono.toolchain": "6.0.7/6.0.300",
  "microsoft.net.workload.emscripten": "6.0.4/6.0.300"
}
```

new:

```
{
  "microsoft.net.sdk.android": "32.0.465/6.0.400",
  "microsoft.net.sdk.ios": "15.4.454/6.0.400",
  "microsoft.net.sdk.maccatalyst": "15.4.454/6.0.400",
  "microsoft.net.sdk.macos": "12.3.454/6.0.400",
  "microsoft.net.sdk.tvos": "15.4.454/6.0.400",
  "microsoft.net.sdk.maui": "6.0.540/6.0.400",
  "microsoft.net.workload.mono.toolchain": "6.0.7/6.0.300",
  "microsoft.net.workload.emscripten": "6.0.4/6.0.300"
}
```

