### PR TITLE
[ci] Fail build if .NET android/maui workloads cannot be installed.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,27 @@ jobs:
       dotnetStable: $(DotNetVersion)                          # the stable version of .NET Core to use
       initSteps:
         - pwsh: |
-            dotnet workload update --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload install android --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            dotnet workload install maui --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+                Write-Host "##vso[task.complete result=Failed;]"
+                exit 0
+            }
+
             dotnet workload install maui --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+                Write-Host "##vso[task.complete result=Failed;]"
+                exit 0
+            }
+
             dotnet workload update
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "##vso[task.logissue type=error]Failed to update workloads."
+                Write-Host "##vso[task.complete result=Failed;]"
+                exit 0
+            }
+          displayName: Install .NET Workloads
 
         - task: JavaToolInstaller@0
           inputs:


### PR DESCRIPTION
When calling commands sequentially in Powershell, the exit code for the script is the exit code for the last called command.  Thus when installing our `android`/`maui` workloads with these 3 commands:

```
dotnet workload update --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
dotnet workload install maui --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
dotnet workload update
```

The `dotnet workload install maui` command fails, but the final command succeeds, thus the CI step is marked as success and the build continues:
```
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Invalid rollback definition. The manifest IDs in rollback definition workloads.json do not match installed manifest IDs (microsoft.net.sdk.android, 32.0.465, 6.0.400) (microsoft.net.sdk.ios, 15.4.454, 6.0.400) (microsoft.net.sdk.maccatalyst, 15.4.454, 6.0.400) (microsoft.net.sdk.macos, 12.3.454, 6.0.400) (microsoft.net.sdk.tvos, 15.4.454, 6.0.400) (microsoft.net.sdk.maui, 6.0.540, 6.0.400) (microsoft.net.workload.mono.toolchain, 6.0.9, 6.0.400) (microsoft.net.workload.emscripten, 6.0.9, 6.0.400).
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Garbage collecting for SDK feature band(s) ...

Successfully updated workload(s): .

Workload ID maui is not recognized.

No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Garbage collecting for SDK feature band(s) ...

Successfully updated workload(s): .
```

This can cause hard to diagnose build failures, like the "wildcard the entire drive if the android workload isn't installed" error in `Xamarin.Legacy.Sdk` that simply appears as a hang in a future step.

This PR checks the error code after each command and exits the step with an error if any command fails.