### PR TITLE
[global.json] Use `"rollForward": "patch"`.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,13 @@ jobs:
       dotnetStable: $(DotNetVersion)                          # the stable version of .NET Core to use
       initSteps:
         - pwsh: |
-            dotnet workload update --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload install android --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload install maui --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload update
+            dotnet workload install maui --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+                Write-Host "##vso[task.complete result=Failed;]"
+                exit 0
+            }
+          displayName: Install .NET Workloads
 
         - task: JavaToolInstaller@0
           inputs:

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
     "sdk": 
     {
         "version": "6.0.401",
-        "rollForward": "latestMinor"
+        "rollForward": "patch"
     },
     "msbuild-sdks": 
     {


### PR DESCRIPTION
I _think_ I've figured out what breaks our CI every month...

We explicitly install a specific version of .NET in our CI pipeline:

```
DotNetVersion: 6.0.401
```

We also explicitly request versions of the workloads that are designed to work with that .NET version:
```json
{
  "microsoft.net.sdk.android": "32.0.465/6.0.400",
  "microsoft.net.sdk.ios": "15.4.454/6.0.400",
  "microsoft.net.sdk.maccatalyst": "15.4.454/6.0.400",
  "microsoft.net.sdk.macos": "12.3.454/6.0.400",
  "microsoft.net.sdk.tvos": "15.4.454/6.0.400",
  "microsoft.net.sdk.maui": "6.0.540/6.0.400",
  "microsoft.net.workload.mono.toolchain": "6.0.9/6.0.400",
  "microsoft.net.workload.emscripten": "6.0.9/6.0.400"
}
```

However our `global.json` contains `"rollForward": "latestMinor"`:

```json
"sdk": 
{
    "version": "6.0.401",
    "rollForward": "latestMinor"
}
```

When our CI images are updated ~monthly with a new minor version, like `6.0.402`, it will get used instead of the version we explicitly installed.  This means when we actually try to install/update our workloads it uses `6.0.402` and fails:

```
Welcome to .NET 6.0!
---------------------
SDK Version: 6.0.402

No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Invalid rollback definition. The manifest IDs in rollback definition workloads.json do not match installed manifest IDs (microsoft.net.sdk.android, 32.0.465, 6.0.400) (microsoft.net.sdk.ios, 15.4.454, 6.0.400) (microsoft.net.sdk.maccatalyst, 15.4.454, 6.0.400) (microsoft.net.sdk.macos, 12.3.454, 6.0.400) (microsoft.net.sdk.tvos, 15.4.454, 6.0.400) (microsoft.net.sdk.maui, 6.0.540, 6.0.400) (microsoft.net.workload.mono.toolchain, 6.0.9, 6.0.400) (microsoft.net.workload.emscripten, 6.0.9, 6.0.400).
No workloads installed for this feature band. To update workloads installed with earlier SDK versions, include the --from-previous-sdk option.
Garbage collecting for SDK feature band(s) ...

Successfully updated workload(s): .

Workload ID maui is not recognized.
```

This failure seems to be caused by a conflict by installing an older version on top of a newer version.  The "newer" version is broken and only the most recent installed version can be used.

We could force the CI to use our requested `6.0.401` by removing the `rollForward` from the `global.json`.  However, this presents a frustrating local development environment because Visual Studio manages the .NET version, and installing a VS update will remove `6.0.401` and install `6.0.402`.  We would no longer be able to build locally.

Instead, let's use `"rollForward": "patch"`.  This means:
- Use the exact version I asked for if it exists (`6.0.401`).
  - On CI, we ensure that the exact version exists.
- If the exact version doesn't exist, use a newer patch version (ie: `.402` instead of `.401`)
  - Locally, if VS has replaced .NET with `.402` it will be used instead.

Additionally, remove extraneous `dotnet workload update` command which undoes our version pinning and updates everything from latest.  🤦 