### PR TITLE
Move Xamarin.Build.Download to this repository.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,12 @@ jobs:
         - pwsh: |
             dotnet cake utilities.cake -t=verify-namespace-file
           displayName: Verify published namespaces
+        - task: DotNetCoreCLI@2
+          displayName: Run unit tests
+          inputs:
+            command: test
+            projects: util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
+            arguments: '-c Release'
       tools:
         - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'
         - 'xamarin.androidx.migration.tool': '$(AndroidXMigrationVersion)'

--- a/build.cake
+++ b/build.cake
@@ -700,6 +700,9 @@ Task("samples-generate-all-targets")
         // Skip Guava.ListenableFuture as it cannot be used in the same project as Guava itself
         if (nupkg.FullPath.Contains("Xamarin.Google.Guava.ListenableFuture"))
             continue;
+        // Skip XBD because packages do not automatically reference the in-tree version
+        if (nupkg.FullPath.Contains("Xamarin.Build.Download"))
+            continue;
 
         var filename = nupkg.GetFilenameWithoutExtension();
         var match = Regex.Match(filename.ToString(), @"(.+?)\.(\d+[\.0-9\-a-zA-Z]+)");

--- a/config.json
+++ b/config.json
@@ -4,7 +4,8 @@
     "slnFile": "generated/AndroidX.sln",
     "strictRuntimeDependencies": true,
     "additionalProjects": [
-      "source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj"
+      "source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj",
+      "util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj"
     ],
     "templates": [
       {

--- a/util/Xamarin.Build.Download/External-Dependency-Info.txt
+++ b/util/Xamarin.Build.Download/External-Dependency-Info.txt
@@ -1,0 +1,40 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Build Download incorporates third party 
+material from the projects listed below. The original copyright notice and 
+the license under which Microsoft received such third party material are set 
+forth below.  Microsoft reserves all other rights not expressly granted, 
+whether by implication, estoppel or otherwise.
+
+############################################
+# Newtonsoft.Json
+# https://github.com/JamesNK/Newtonsoft.Json
+############################################
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining 
+a copy of this software and associated documentation files 
+(the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, 
+publish, distribute, sublicense, and/or sell copies of the Software, 
+and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be 
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+############################################
+# end - Newtonsoft.Json
+############################################

--- a/util/Xamarin.Build.Download/LICENSE
+++ b/util/Xamarin.Build.Download/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Xamarin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/util/Xamarin.Build.Download/README.md
+++ b/util/Xamarin.Build.Download/README.md
@@ -1,0 +1,98 @@
+# Xamarin.Build.Download
+
+The Xamarin.Build.Download NuGet is intended to be consumed from MSBuild targets in other NuGets in order to download
+third-party native library archives automatically and inject them into the build process.
+
+## USAGE
+
+Add a dependency on the Xamarin.Build.Download NuGet. When it is installed into a project, its targets will
+be imported into the project. You can then use their functionality from your NuGet's build targets as follows.
+
+Use `XamarinBuildDownload` items to specify archives to download and unpack. They must specify a unique versioned id
+for the ItemSpec (Include attribute). This will be used as the global download cache key so must be unique to the
+archive. However, multiple NuGets may refer to the the same archive using the same key.
+
+The download URL must be specified in the `Url` metadata. A SHA1 hash may optionally be specified in the `Sha1`
+metadata, and will be verified if provided. The archive kind must be specified in the `Kind` metadata, if it cannot
+be inferred from the filename. Valid values are `Zip` or `Tgz`.  Download Url's must be `https` unless you set the `XamarinBuildDownloadAllowUnsecure` msbuild property to `true`.
+
+```xml
+<ItemGroup>
+	<XamarinBuildDownload Include="foo-1.2.3">
+		<Url>https://example.com/foo-1.2.3.tgz</Url>
+		<Kind>Tgz</Kind>
+		<Sha1>0c4a8a9c12305e8d41e8e3c8a3a2ce066c508f68</Sha1>
+	</XamarinBuildDownload>
+</ItemGroup>
+```
+
+Other NuGets may download the same library, and should use the same key to prevent it being downloaded and
+unpacked multiple times.
+
+Define a new build target with a name unique to your NuGet. It should insert items into the build process that refer
+to files from the unpacked archive, which will be in subdirectories of the `$(XamarinBuildDownloadDir)` directory
+corresponding to the `Id` metadata for each archive:
+
+```xml
+<Target Name="_AddMyNugetIdDownloadedItems">
+	<ItemGroup>
+		<BundleResource Include="$(XamarinBuildDownloadDir)foo-1.2.3\media\bar.png">
+			<LogicalName>bar.png</LogicalName>
+		</BundleResource>
+		<NativeReference Include="$(XamarinBuildDownloadDir)foo-1.2.3\lib\baz.a">
+			<Kind>Static</Kind>
+			<ForceLoad>True</ForceLoad>
+		</NativeReference>
+	</ItemGroup>
+</Target>
+```
+
+Add your target as an `XamarinIncludeDownloadedItemsTarget` item so that it is called at the appropriate place
+in the build process:
+
+```xml
+<ItemGroup>
+	<XamarinBuildMergeDownloads Include="_AddMyNugetIdDownloadedItems"/>
+</ItemGroup>
+```
+
+## EXAMPLE
+
+In this example, the download is only performed if the project is a Xamarin.iOS executable project.
+
+```xml
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Condition="'$(OutputType)'!='Library' And '$(TargetFramework)'=='Xamarin.iOS'">
+		<XamarinBuildDownload Include="foo-1.2.3">
+			<Url>https://example.com/foo-1.2.3.tgz</Url>
+			<Kind>Tgz</Kind>
+			<Sha1>0c4a8a9c12305e8d41e8e3c8a3a2ce066c508f68</Sha1>
+		</XamarinBuildDownload>
+		<XamarinBuildRestoreResources Include="_AddMyNugetIdDownloadedItems"/>
+	</ItemGroup>
+
+	<Target Name="_AddMyNugetIdDownloadedItems">
+		<ItemGroup>
+			<BundleResource Include="$(XamarinBuildDownloadDir)foo-1.2.3\media\bar.png">
+				<LogicalName>bar.png</LogicalName>
+			</BundleResource>
+			<BundleResource Include="$(XamarinBuildDownloadDir)foo-1.2.3\media\bav.png">
+				<LogicalName>bav.png</LogicalName>
+				<!-- This image will not be optimized even if "Optimize PNG images" option is checked -->
+				<Optimize>False</Optimize> 
+			</BundleResource>
+			<NativeReference Include="$(XamarinBuildDownloadDir)foo-1.2.3\lib\baz.a">
+				<Kind>Static</Kind>
+				<ForceLoad>True</ForceLoad>
+			</NativeReference>
+		</ItemGroup>
+	</Target>
+</Project>
+```
+
+## TODO
+
+* Implement download cache pruning
+* Reference counting for cleaning up old unpacked archives
+* Remove iOSReferenceMerge once Xamarin.iOS supports all the NativeReference metadata
+

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/HashTests.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/HashTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xamarin.Build.Download;
+using Xunit;
+
+namespace NativeLibraryDownloaderTests
+{
+	public class HashTests
+	{
+		[Theory]
+		[InlineData("C:\\path\\to\\file.aar")]
+		[InlineData ("/path/to/file.aar")]
+		public void Test_CRC64_Safety(string value)
+		{
+			var crc = DownloadUtils.Crc64(value);
+
+			Assert.Matches("^[0-9a-zA-Z]+$", crc);
+		}
+		
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/MSBuildExtensions.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/MSBuildExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) 2015-2016 Xamarin Inc.
+
+using System.Linq;
+using Microsoft.Build.Construction;
+
+namespace Xamarin.ContentPipeline.Tests
+{
+	//workaround for missing MSBuild API in Mono. Project.AddItem explodes,
+	//so we use ProjectRootElement, which doesn't have SetProperty/GetPropertyValue
+	public static class MSBuildExtensions
+	{
+		public static void SetProperty (this ProjectRootElement prel, string name, string value)
+		{
+			var existing = prel.PropertyGroups.SelectMany (g => g.Properties).FirstOrDefault (p => p.Name == name);
+			if (existing != null)
+				existing.Value = value;
+			else
+				prel.AddProperty (name, value);
+		}
+
+		public static string GetPropertyValue (this ProjectRootElement prel, string name)
+		{
+			var existing = prel.Properties.FirstOrDefault (p => p.Name == name);
+			if (existing != null)
+				return existing.Value;
+			return null;
+		}
+
+		public static void RemoveItems (this ProjectRootElement prel, ProjectItemElement pel)
+		{
+			pel.Parent.RemoveChild (pel);
+		}
+
+		public static void SetMetadataValue (this ProjectItemElement pel, string name, string value)
+		{
+			var existing = pel.Metadata.FirstOrDefault (p => p.Name == name);
+			if (existing != null)
+				existing.Value = value;
+			else
+				pel.AddMetadata (name, value);
+		}
+
+		public static void RemoveMetadata (this ProjectItemElement pel, string name)
+		{
+			var existing = pel.Metadata.FirstOrDefault (p => p.Name == name);
+			if (existing != null)
+				pel.RemoveChild (existing);
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/MSBuildTestLogger.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/MSBuildTestLogger.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2015-2016 Xamarin Inc.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.ContentPipeline.Tests
+{
+	public class MSBuildTestLogger : ILogger
+	{
+		IEventSource eventSource;
+
+		public void Initialize (IEventSource eventSource)
+		{
+			this.eventSource = eventSource;
+			Events = new List<BuildEventArgs> ();
+			eventSource.AnyEventRaised += EventRaised;
+			Verbosity = LoggerVerbosity.Normal;
+		}
+
+		public void Shutdown ()
+		{
+			eventSource.AnyEventRaised -= EventRaised;
+		}
+
+		void EventRaised (object sender, BuildEventArgs e)
+		{
+			Events.Add (e);
+			System.Console.WriteLine (e.Message);
+		}
+
+		public List<BuildEventArgs> Events { get; private set; }
+
+		public IEnumerable<BuildErrorEventArgs> Errors {
+			get {
+				return Events.OfType<BuildErrorEventArgs> ();
+			}
+		}
+
+		public IEnumerable<BuildWarningEventArgs> Warnings {
+			get {
+				return Events.OfType<BuildWarningEventArgs> ();
+			}
+		}
+
+		public LoggerVerbosity Verbosity { get; set; }
+		public string Parameters { get; set; }
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/TestsBase.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/TestsBase.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2015-2016 Xamarin Inc.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
+using Xunit;
+
+namespace Xamarin.ContentPipeline.Tests
+{
+	public class TestsBase : IDisposable
+	{
+		string originalWorkingDir;
+		string tempDir;
+
+		public TestsBase ()
+		{
+			originalWorkingDir = Environment.CurrentDirectory;
+			tempDir = Path.GetTempFileName ();
+			File.Delete (tempDir);
+			Directory.CreateDirectory (tempDir);
+			Environment.CurrentDirectory = tempDir;
+		}
+
+		public bool IsWindows
+			=> System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+
+		public void Dispose ()
+		{
+			Environment.CurrentDirectory = originalWorkingDir;
+			Directory.Delete (tempDir, true);
+
+			//HACK: touching BuildManager causes Mono to initialize its DefaultBuildManagerand never shut it down
+			StopMonoBuildManager (BuildManager.DefaultBuildManager);
+		}
+
+		public string TempDir { get { return tempDir; } }
+
+		protected string GetTempPath (params string [] components)
+		{
+			return Path.Combine (tempDir, Path.Combine (components));
+		}
+
+		protected static void AssertNoMessagesOrWarnings (MSBuildTestLogger logger, params string[] ignorePatterns)
+		{
+			// Skip some msbuild test harness warnings that we truly don't care about
+			var errors = logger.Errors.ToList();
+			errors.RemoveAll(e => ignorePatterns.Any(p => e.Message.Contains(p)));
+			var warnings = logger.Warnings.ToList();
+			warnings.RemoveAll(w => ignorePatterns.Any(p => w.Message.Contains(p)));
+
+			BuildEventArgs err = errors.FirstOrDefault ();
+
+			if (err == null) {
+				err = warnings.FirstOrDefault ();
+				if (err == null) {
+					return;
+				}
+			}
+			throw new Exception (err.Message);
+		}
+
+		// work around Mono's ProjectInstance.Build using a separate BuildManager and not shutting it down
+		// Mono's BuildManager has a non-background worker thread and doesn't shut it down automatically
+		protected bool BuildProject (
+			ProjectCollection projects, ProjectInstance project, string [] targets, IEnumerable<ILogger> loggers,
+			IEnumerable<ForwardingLoggerRecord> remoteLoggers, out IDictionary<string, TargetResult> targetOutputs)
+		{
+			var parameters = new BuildParameters (projects) {
+				Loggers = loggers,
+				ForwardingLoggers = remoteLoggers,
+				DefaultToolsVersion = projects.DefaultToolsVersion,
+			};
+			var data = new BuildRequestData (project, targets ?? project.DefaultTargets.ToArray ());
+			var result = BuildManager.DefaultBuildManager.Build (parameters, data);
+			targetOutputs = result.ResultsByTarget;
+			return result.OverallResult == BuildResultCode.Success;
+		}
+
+		static void StopMonoBuildManager (BuildManager buildManager)
+		{
+			try {
+				const BindingFlags instanceFlags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
+				PropertyInfo nodeManagerProp = typeof (BuildManager).GetProperty ("BuildNodeManager", instanceFlags);
+				var nodeManager = nodeManagerProp.GetValue (buildManager);
+				var stopMeth = nodeManager.GetType ().GetMethod ("Stop", instanceFlags);
+				stopMeth.Invoke (nodeManager, new object[0]);
+			} catch {
+			}
+		}
+
+		protected bool BuildProject (
+			ProjectCollection projects, ProjectInstance project, string target, ILogger logger)
+		{
+			IDictionary<string, TargetResult> targetOutputs;
+			return BuildProject (projects, project, new [] { target }, new [] { logger }, new ForwardingLoggerRecord[0], out targetOutputs);
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -1,0 +1,730 @@
+// Copyright (c) 2015-2016 Xamarin Inc.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Mono.Cecil;
+using Xamarin.ContentPipeline.Tests;
+using Xamarin.MacDev;
+using Xunit;
+
+namespace NativeLibraryDownloaderTests
+{
+	public class Test : TestsBase
+	{
+		public static string Configuration = "Release";
+		public static readonly string[] DEFAULT_IGNORE_PATTERNS = { "*.overridetasks", "*.tasks" };
+
+		void AddCoreTargets (ProjectRootElement el)
+		{
+			var baseDir = new Uri(System.Reflection.Assembly.GetExecutingAssembly().CodeBase).LocalPath;
+
+			var props = Path.Combine (baseDir, "..", "..", "source", "Xamarin.Build.Download", "bin", Configuration, "netstandard20", "Xamarin.Build.Download.props");
+
+			if (!File.Exists(props))
+				props = Path.Combine(baseDir, "..", "Xamarin.Build.Download.props");
+
+			el.AddImport (props);
+			var targets = Path.Combine (baseDir, "..", "..", "source", "Xamarin.Build.Download", "bin", Configuration, "netstandard20", "Xamarin.Build.Download.targets");
+			if (!File.Exists(targets))
+				targets = Path.Combine(baseDir, "..", "Xamarin.Build.Download.targets");
+
+			el.AddImport (targets);
+
+		}
+
+		[Fact]
+		public void NoArchivesOrTargets ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+
+			var log = new MSBuildTestLogger ();
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log);
+			Assert.True (success);
+		}
+
+		[Fact]
+		public void InvalidArchiveMetadata ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem ("XamarinBuildDownload", "-----");
+
+			prel.AddItem (
+				"XamarinBuildDownload", "foo-1.2", new Dictionary<string, string> {
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownload", "bar-1.9", new Dictionary<string, string> {
+					{ "Url", "https://www.example.com/bar.zip" },
+					{ "Kind", "Cabbage" }
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownload", "baz-1.9", new Dictionary<string, string> {
+					{ "Url", "https://www.example.com/bar.unknown" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			var errors = log.Errors.Select (e => e.Message).ToList ();
+			Assert.Equal (4, errors.Count);
+			Assert.Equal ("Invalid item ID -----", errors[0]);
+			Assert.Equal ("Unknown archive kind 'Cabbage' for 'https://www.example.com/bar.zip'", errors[1]);
+			Assert.Equal ("Unknown archive kind '' for 'https://www.example.com/bar.unknown'", errors[2]);
+			Assert.Equal ("Missing required Url metadata on item foo-1.2", errors[3]);
+
+			Assert.False (success);
+		}
+
+		[Fact]
+		public void TestZipDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "ILRepack-2.0.10", new Dictionary<string, string> {
+					{ "Url", "https://www.nuget.org/api/v2/package/ILRepack/2.0.10" },
+					{ "Kind", "Zip" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "ILRepack-2.0.10", "ILRepack.nuspec")));
+		}
+
+		[Fact]
+		public void TestTgzDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "GoogleSymbolUtilities-1.0.3", new Dictionary<string, string> {
+					{ "Url", "https://www.gstatic.com/cpdc/a060f37adbad54ea-GoogleSymbolUtilities-1.0.3.tar.gz" },
+					{ "Kind", "Tgz" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "GoogleSymbolUtilities-1.0.3", "Libraries", "libGSDK_Overload.a")));
+		}
+
+		[Fact]
+		public void TestUncompressedNamedDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar" },
+					{ "Kind", "Uncompressed" },
+					{ "ToFile", "facebook-android-sdk.aar" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "FacebookAndroid-4.17.0", "facebook-android-sdk.aar")));
+		}
+
+		[Fact]
+		public void TestUncompressedUnnamedDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar" },
+					{ "Kind", "Uncompressed" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "FacebookAndroid-4.17.0", "FacebookAndroid-4.17.0.uncompressed")));
+		}
+
+		//in google maps, the tar inside the tgz doesn't match the tgz name
+		[Fact]
+		public void TestGMapsDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "GMaps-1.11.1", new Dictionary<string, string> {
+					{ "Url", "https://www.gstatic.com/cpdc/c0e534927c0c955e-GoogleMaps-1.11.1.tar.gz" },
+					{ "Kind", "Tgz" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "GMaps-1.11.1", "CHANGELOG")));
+		}
+
+		[Fact]
+		public void TestCastAssemblyResources ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var asm = AssemblyDefinition.CreateAssembly (
+				new AssemblyNameDefinition ("Foo", new Version (1, 0, 0, 0)),
+				"Main",
+				ModuleKind.Dll
+			);
+			var dll = Path.Combine (TempDir, "Foo.dll");
+			asm.Write (dll);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+			prel.SetProperty ("TargetFrameworkIdentifier", "Xamarin.iOS");
+			prel.SetProperty ("OutputType", "Exe");
+			prel.SetProperty ("IntermediateOutputPath", Path.Combine (TempDir, "obj"));
+
+			prel.AddItem (
+				"XamarinBuildDownload", "AppInvites-1.0.2", new Dictionary<string, string> {
+					{ "Url", "https://www.gstatic.com/cpdc/278f79fcd3b365e3-AppInvites-1.0.2.tar.gz" },
+					{ "Kind", "Tgz" }
+				});
+
+			prel.AddItem (
+				"ReferencePath",
+				dll
+			);
+
+			var bundlePath = Path.Combine (unpackDir, "AppInvites-1.0.2", "Frameworks", "GINInvite.framework", "Versions", "A", "Resources", "GINInviteResources.bundle");
+
+			var plist = Path.Combine (bundlePath, "Info.plist");
+			string resourceName = "__monotouch_content_GINInviteResources.bundle_fInfo.plist";
+			prel.AddItem (
+				"RestoreAssemblyResource",
+				plist,
+				new Dictionary<string,string> {
+					{ "AssemblyName", "Foo" },
+					{ "LogicalName", resourceName }
+				}
+			);
+
+			var image = Path.Combine (bundlePath, "ic_sms_24@3x.png");
+			resourceName = "__monotouch_content_GINInviteResources.bundle_fic__sms__24%403x.png";
+			prel.AddItem (
+				"RestoreAssemblyResource",
+				image,
+				new Dictionary<string, string> {
+					{ "AssemblyName", "Foo" },
+					{ "LogicalName", resourceName }
+				}
+			);
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildCastAssemblyResources", log);
+
+			var ignoreMessages = new List<string> { "Enumeration yielded no results" };
+			ignoreMessages.AddRange (DEFAULT_IGNORE_PATTERNS);
+			AssertNoMessagesOrWarnings (log, ignoreMessages.ToArray());
+			Assert.True (success);
+
+			var plistExists = File.Exists (plist);
+			Assert.True (plistExists);
+
+			var imageExists = File.Exists (image);
+			Assert.True (imageExists);
+
+			// Check if BundleResources were generated correctly.
+			var bundleResources = project.GetItems ("BundleResource");
+			Assert.True (bundleResources != null);
+
+			// Check if Optimize metadata was generated correctly.
+			var imageResource = bundleResources.Single (b => b.GetMetadataValue ("Identity").ToLower ().EndsWith (".png"));
+			Assert.True (imageResource.GetMetadataValue ("Optimize") == "False");
+		}
+
+		[Fact]
+		public void TestAndroidAarAdded()
+		{
+			var unpackDir = GetTempPath("unpacked");
+			var artifactXbdId = "gpsbasement-16.2.0";
+
+			var r = AndroidAarAdd(unpackDir, artifactXbdId, "https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar", true);
+
+			AssertNoMessagesOrWarnings(r.logs, DEFAULT_IGNORE_PATTERNS);
+			Assert.True(r.success);
+
+			var aarPath = Path.Combine(unpackDir, artifactXbdId, artifactXbdId + ".aar");
+			Assert.True(File.Exists(aarPath));
+
+			Assert.Contains(r.project.Items, i => i.ItemType == "AndroidAarLibrary" && i.EvaluatedInclude == aarPath);
+		}
+
+		[Fact]
+		public void TestAndroidAarIdeTooOld()
+		{
+			var unpackDir = GetTempPath("unpacked");
+			var artifactXbdId = "gpsbasement-16.2.0";
+
+			var r = AndroidAarAdd(unpackDir, artifactXbdId, "https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar", false);
+
+			// Check for the error
+			Assert.NotEmpty(r.logs.Errors);
+
+			Assert.False(r.success);
+		}
+
+		(bool success, ProjectInstance project, MSBuildTestLogger logs) AndroidAarAdd(string unpackDir, string artifactXbdId, string url, bool androidAarLibraryAvailableItem)
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+			prel.SetProperty ("TargetFrameworkIdentifier", "MonoAndroid");
+			prel.SetProperty ("TargetFrameworkVersion", "v9.0");
+			prel.SetProperty ("OutputType", "Exe");
+			prel.SetProperty ("IntermediateOutputPath", Path.Combine (TempDir, "obj"));
+
+			if (androidAarLibraryAvailableItem)
+				prel.AddItem("AvailableItemName", "AndroidAarLibrary");
+
+
+			var item = prel.AddItem (
+				"XamarinBuildDownload", artifactXbdId, new Dictionary<string, string> {
+					{ "Url", url },
+					{ "Kind", "Uncompressed" },
+					{ "ToFile", artifactXbdId + ".aar" }
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownloadAndroidAarLibrary",
+				"$(XamarinBuildDownloadDir)" + artifactXbdId + "\\" + artifactXbdId + ".aar",
+				new Dictionary<string, string> { }
+			);
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+			log.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownloadAarInclude", log);
+
+			return (success, project, log);
+		}
+
+		[Fact]
+		public void TestDisallowUnsafeGetItemsToDownload ()
+		{
+			var itemUrl = "http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var zipUrl = "http://dl-ssl.google.com/android/repository/android_m2repository_r40.zip";
+
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "Kind", "Uncompressed" },
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/cardview.v7", new Dictionary<string, string> {
+					{ "Url", zipUrl },
+					{ "ToFile", "cardview.v7.aar" },
+					{ "RangeStart", "196438127" },
+					{ "RangeEnd", "196460160" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "XamarinBuildDownloadGetItemsToDownload", log);
+
+			var itemToDownload = project.GetItems ("XamarinBuildDownloadItemToDownload");
+
+			Assert.Empty (itemToDownload);
+		}
+
+		[Fact]
+		public void TestAllowUnsafeGetItemsToDownload ()
+		{
+			var itemUrl = "http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var zipUrl = "http://dl-ssl.google.com/android/repository/android_m2repository_r40.zip";
+
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+			prel.SetProperty ("XamarinBuildDownloadAllowUnsecure", "true");
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "Kind", "Uncompressed" },
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/cardview.v7", new Dictionary<string, string> {
+					{ "Url", zipUrl },
+					{ "ToFile", "cardview.v7.aar" },
+					{ "RangeStart", "196438127" },
+					{ "RangeEnd", "196460160" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "XamarinBuildDownloadGetItemsToDownload", log);
+
+			var itemToDownload = project.GetItems ("XamarinBuildDownloadItemToDownload");
+
+			Assert.Equal (2, itemToDownload.Count);
+			Assert.Contains(itemToDownload, i => i.GetMetadata ("Url").EvaluatedValue == itemUrl);
+			Assert.Contains(itemToDownload, i => i.GetMetadata ("Url").EvaluatedValue == zipUrl);
+		}
+
+		[Fact]
+		public void TestGetItemsToDownload ()
+		{
+			var itemUrl = "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "Kind", "Uncompressed" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "XamarinBuildDownloadGetItemsToDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			var itemToDownload = project.GetItems ("XamarinBuildDownloadItemToDownload");
+
+			Assert.Equal (1, itemToDownload.Count);
+			Assert.True (itemToDownload.First ().GetMetadata ("Url").EvaluatedValue == itemUrl);
+		}
+
+		[Fact]
+		public void TestDeduplicateGetItemsToDownload ()
+		{
+			var itemUrl = "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "Kind", "Uncompressed" },
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "Kind", "Uncompressed" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "XamarinBuildDownloadGetItemsToDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			var itemToDownload = project.GetItems ("XamarinBuildDownloadItemToDownload");
+
+			Assert.Equal (1, itemToDownload.Count);
+			Assert.True (itemToDownload.First ().GetMetadata ("Url").EvaluatedValue == itemUrl);
+		}
+
+		[Fact]
+		public void TestTimesOutWaitingOnExclusiveLock ()
+		{
+			var unpackDir = GetTempPath ("unpacked");
+			System.IO.Directory.CreateDirectory (unpackDir);
+
+			var lockFile = Path.Combine(unpackDir, "GMaps-1.11.1.locked");
+			using (var lockStream = File.Open (lockFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)) {
+
+				var engine = new ProjectCollection ();
+				var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+				prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+				prel.AddItem (
+					"XamarinBuildDownload", "GMaps-1.11.1", new Dictionary<string, string> {
+					{ "Url", "https://www.gstatic.com/cpdc/c0e534927c0c955e-GoogleMaps-1.11.1.tar.gz" },
+					{ "Kind", "Tgz" },
+					{ "ExclusiveLockTimeout", "1" }
+					});
+
+				AddCoreTargets (prel);
+
+				var project = new ProjectInstance (prel);
+				var log = new MSBuildTestLogger ();
+
+				var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+				Assert.False (success);
+				Assert.Null (log.Errors.FirstOrDefault (err => err.Code == "XBD005"));
+			}
+		}
+
+		[Fact]
+		public void TestAndroidSupportSinglePartialZipDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/cardview.v7", new Dictionary<string, string> {
+					{ "Url", "https://dl-ssl.google.com/android/repository/android_m2repository_r40.zip" },
+					{ "ToFile", "cardview.v7.aar" },
+					{ "RangeStart", "196438127" },
+					{ "RangeEnd", "196460160" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "androidsupport-25.0.1", "cardview.v7", "cardview.v7.aar")));
+		}
+
+
+		[Fact]
+		public void TestAndroidSupportMultiplePartialZipDownload ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/cardview.v7", new Dictionary<string, string> {
+					{ "Url", "https://dl-ssl.google.com/android/repository/android_m2repository_r40.zip" },
+					{ "ToFile", "cardview.v7.aar" },
+					{ "RangeStart", "196438127" },
+					{ "RangeEnd", "196460160" },
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/recyclerview.v7", new Dictionary<string, string> {
+					{ "Url", "https://dl-ssl.google.com/android/repository/android_m2repository_r40.zip" },
+					{ "ToFile", "recyclerview.v7.aar" },
+					{ "RangeStart", "199278205" },
+					{ "RangeEnd", "199589731" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "androidsupport-25.0.1", "cardview.v7", "cardview.v7.aar")));
+			Assert.True (File.Exists (Path.Combine (unpackDir, "androidsupport-25.0.1", "recyclerview.v7", "recyclerview.v7.aar")));
+		}
+
+
+
+		[Fact]
+		public void TestGetPartialZipItemsToDownload ()
+		{
+			var itemUrl = "https://dl-ssl.google.com/android/repository/android_m2repository_r40.zip";
+
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/cardview.v7", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "ToFile", "cardview.v7.aar" },
+					{ "RangeStart", "196438127" },
+					{ "RangeEnd", "196460160" },
+				});
+
+			prel.AddItem (
+				"XamarinBuildDownloadPartialZip", "androidsupport-25.0.1/recyclerview.v7", new Dictionary<string, string> {
+					{ "Url", itemUrl },
+					{ "ToFile", "recyclerview.v7.aar" },
+					{ "RangeStart", "199278205" },
+					{ "RangeEnd", "199589731" },
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "XamarinBuildDownloadGetItemsToDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			var itemToDownload = project.GetItems ("XamarinBuildDownloadItemToDownload");
+
+			Assert.Equal (2, itemToDownload.Count);
+			Assert.True (itemToDownload.First ().GetMetadata ("Url").EvaluatedValue == itemUrl);
+		}
+
+		[Fact]
+		public void TestPathGreaterThan260Chars ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+
+			for (var i = 1; unpackDir.Length < 260; i++)
+				unpackDir = Path.Combine (unpackDir, $"segment{i}");
+
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "GAppM-8.8.0", new Dictionary<string, string> {
+					{ "Url", "https://dl.google.com/firebase/ios/analytics/86849febfdc4ff13/GoogleAppMeasurement-8.8.0.tar.gz" },
+					{ "Kind", "Tgz" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "GAppM-8.8.0", "GoogleAppMeasurement-8.8.0", "dummy.txt")));
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <Target Name="Pack"></Target>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" PrivateAssets="none" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="16.0.461" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.Build.Download\Xamarin.Build.Download.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.sln
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.sln
@@ -1,0 +1,47 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Build.Download", "Xamarin.Build.Download\Xamarin.Build.Download.csproj", "{7B9B1EC0-3657-4DE2-ADB4-1050BA872BA5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Build.Download.Tests", "Xamarin.Build.Download.Tests\Xamarin.Build.Download.Tests.csproj", "{A079F986-AF03-4D97-BF99-73C9FCD48EF8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{BA132B78-A5D6-4463-83D9-F26719B46362}"
+	ProjectSection(SolutionItems) = preProject
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7B9B1EC0-3657-4DE2-ADB4-1050BA872BA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B9B1EC0-3657-4DE2-ADB4-1050BA872BA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B9B1EC0-3657-4DE2-ADB4-1050BA872BA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B9B1EC0-3657-4DE2-ADB4-1050BA872BA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A079F986-AF03-4D97-BF99-73C9FCD48EF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A079F986-AF03-4D97-BF99-73C9FCD48EF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A079F986-AF03-4D97-BF99-73C9FCD48EF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A079F986-AF03-4D97-BF99-73C9FCD48EF8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.inheritsSet = VisualStudio
+		$1.scope = text/plain
+		$1.FileWidth = 120
+		$1.TabsToSpaces = False
+		$1.inheritsScope = text/plain
+		$0.CSharpFormattingPolicy = $2
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
+		$0.TextStylePolicy = $3
+		$3.FileWidth = 120
+		$3.TabsToSpaces = False
+		$3.inheritsSet = VisualStudio
+		$3.inheritsScope = text/plain
+		$3.scope = text/plain
+	EndGlobalSection
+EndGlobal

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/AsyncTask.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/AsyncTask.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.Threading;
+using System.Collections;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Xamarin.Build.Download
+{
+	//from Xamarin.Android MSBuild targets
+	public abstract class AsyncTask : Task, ICancelableTask
+	{
+		CancellationTokenSource tcs = new CancellationTokenSource ();
+		Queue logMessageQueue = new Queue ();
+		Queue warningMessageQueue = new Queue ();
+		Queue errorMessageQueue = new Queue ();
+		readonly ManualResetEvent logDataAvailable = new ManualResetEvent (false);
+		readonly ManualResetEvent errorDataAvailable = new ManualResetEvent (false);
+		readonly ManualResetEvent warningDataAvailable = new ManualResetEvent (false);
+		readonly ManualResetEvent taskCancelled = new ManualResetEvent (false);
+		readonly ManualResetEvent completed = new ManualResetEvent (false);
+		bool isRunning = true;
+		object _eventlock = new object ();
+		int UIThreadId = 0;
+
+		private enum WaitHandleIndex
+		{
+			LogDataAvailable,
+			ErrorDataAvailable,
+			WarningDataAvailable,
+			TaskCancelled,
+			Completed,
+		}
+
+		public CancellationToken Token { get { return tcs.Token; } }
+
+		public bool YieldDuringExecution { get; set; }
+
+		[Obsolete ("Do not use the Log.LogXXXX from within your Async task as it will Lock the Visual Studio UI. Use the this.LogXXXX methods instead.")]
+		private new TaskLoggingHelper Log {
+			get { return base.Log; }
+		}
+
+		public AsyncTask ()
+		{
+			YieldDuringExecution = false;
+			UIThreadId = Thread.CurrentThread.ManagedThreadId;
+		}
+
+		public void Cancel ()
+		{
+			taskCancelled.Set ();
+		}
+
+		public void Complete ()
+		{
+			completed.Set ();
+		}
+
+		public void LogDebugTaskItems (string message, params string [] items)
+		{
+			LogDebugMessage (message);
+
+			if (items == null)
+				return;
+
+			foreach (var item in items)
+				LogDebugMessage ("    {0}", item);
+		}
+
+		public void LogDebugTaskItems (string message, ITaskItem [] items)
+		{
+			LogDebugMessage (message);
+
+			if (items == null)
+				return;
+
+			foreach (var item in items)
+				LogDebugMessage ("    {0}", item.ItemSpec);
+		}
+
+		protected void LogMessage (string message, params object [] messageArgs)
+		{
+			LogMessage (string.Format (message, messageArgs));
+		}
+
+		protected void LogDebugMessage (string message, params object [] messageArgs)
+		{
+			LogMessage (string.Format (message, messageArgs), importance: MessageImportance.Low);
+		}
+
+		protected void LogMessage (string message, MessageImportance importance = MessageImportance.Normal)
+		{
+			if (UIThreadId == Thread.CurrentThread.ManagedThreadId)
+				#pragma warning disable 618
+				Log.LogMessage (importance, message);
+				#pragma warning restore 618
+
+			lock (logMessageQueue.SyncRoot) {
+				logMessageQueue.Enqueue (new BuildMessageEventArgs (
+					message: message,
+					helpKeyword: null,
+					senderName: null,
+					importance: importance
+				));
+				lock (_eventlock) {
+					if (isRunning)
+						logDataAvailable.Set ();
+				}
+			}
+		}
+
+		public void LogCodedError (string code, string message, params object [] messageArgs)
+		{
+			LogError (code, string.Format (message, messageArgs));
+		}
+
+		protected void LogError (string code, string message)
+		{
+			if (UIThreadId == Thread.CurrentThread.ManagedThreadId)
+				#pragma warning disable 618
+				Log.LogError (
+					subcategory: null,
+					errorCode: code,
+					helpKeyword: null,
+					file: null,
+					lineNumber: 0,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: message
+				);
+				#pragma warning restore 618
+
+			lock (errorMessageQueue.SyncRoot) {
+				errorMessageQueue.Enqueue (new BuildErrorEventArgs (
+					subcategory: null,
+					code: code,
+					file: null,
+					lineNumber: 0,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: message,
+					helpKeyword: null,
+					senderName: null
+				));
+				lock (_eventlock) {
+					if (isRunning)
+						errorDataAvailable.Set ();
+				}
+			}
+		}
+
+		public void LogErrorFromException (Exception exception)
+		{
+			if (UIThreadId == Thread.CurrentThread.ManagedThreadId)
+				#pragma warning disable 618
+				Log.LogErrorFromException (exception);
+				#pragma warning restore 618
+
+			StackFrame exceptionFrame = null;
+			try {
+				exceptionFrame = new StackTrace (exception, true)?.GetFrames ()?.FirstOrDefault ();
+			} catch { }
+
+			lock (errorMessageQueue.SyncRoot) {
+				errorMessageQueue.Enqueue (new BuildErrorEventArgs (
+					subcategory: null,
+					code: null,
+					file: exceptionFrame?.GetFileName (),
+					lineNumber: exceptionFrame?.GetFileLineNumber () ?? 0,
+					columnNumber: exceptionFrame?.GetFileColumnNumber () ?? 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: exception.Message,
+					helpKeyword: null,
+					senderName: null
+				));
+				lock (_eventlock) {
+					if (isRunning)
+						errorDataAvailable.Set ();
+				}
+			}
+		}
+
+		protected void LogWarning (string message, params object [] messageArgs)
+		{
+			LogWarning (string.Format (message, messageArgs));
+		}
+
+		protected void LogWarning (string message)
+		{
+			if (UIThreadId == Thread.CurrentThread.ManagedThreadId)
+				#pragma warning disable 618
+				Log.LogWarning (message);
+				#pragma warning restore 618
+
+			lock (warningMessageQueue.SyncRoot) {
+				warningMessageQueue.Enqueue (new BuildWarningEventArgs (
+					subcategory: null,
+					code: null,
+					file: null,
+					lineNumber: 0,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: message,
+					helpKeyword: null,
+					senderName: null
+				));
+				lock (_eventlock) {
+					if (isRunning)
+						warningDataAvailable.Set ();
+				}
+			}
+		}
+
+		public override bool Execute ()
+		{
+			WaitForCompletion ();
+			#pragma warning disable 618
+			return !Log.HasLoggedErrors;
+			#pragma warning restore 618
+		}
+
+		private void LogMessages ()
+		{
+			lock (logMessageQueue.SyncRoot) {
+				while (logMessageQueue.Count > 0) {
+					var args = (BuildMessageEventArgs)logMessageQueue.Dequeue ();
+					#pragma warning disable 618
+					Log.LogMessage (args.Importance, args.Message);
+					#pragma warning restore 618
+				}
+				logDataAvailable.Reset ();
+			}
+		}
+
+		private void LogErrors ()
+		{
+			lock (errorMessageQueue.SyncRoot) {
+				while (errorMessageQueue.Count > 0) {
+					var args = (BuildErrorEventArgs)errorMessageQueue.Dequeue ();
+					#pragma warning disable 618
+					Log.LogCodedError (args.Code, args.Message);
+					#pragma warning restore 618
+				}
+				errorDataAvailable.Reset ();
+			}
+		}
+
+		private void LogWarnings ()
+		{
+			lock (warningMessageQueue.SyncRoot) {
+				while (warningMessageQueue.Count > 0) {
+					var args = (BuildWarningEventArgs)warningMessageQueue.Dequeue ();
+					#pragma warning disable 618
+					Log.LogWarning (args.Message);
+					#pragma warning restore 618
+				}
+				warningDataAvailable.Reset ();
+			}
+		}
+
+		protected void WaitForCompletion ()
+		{
+			WaitHandle [] handles = {
+				logDataAvailable,
+				errorDataAvailable,
+				warningDataAvailable,
+				taskCancelled,
+				completed,
+			};
+			if (YieldDuringExecution && BuildEngine is IBuildEngine3)
+				(BuildEngine as IBuildEngine3).Yield ();
+			try {
+				while (isRunning) {
+					var index = (WaitHandleIndex)WaitHandle.WaitAny (handles, TimeSpan.FromMilliseconds (10));
+					switch (index) {
+					case WaitHandleIndex.LogDataAvailable:
+						LogMessages ();
+						break;
+					case WaitHandleIndex.ErrorDataAvailable:
+						LogErrors ();
+						break;
+					case WaitHandleIndex.WarningDataAvailable:
+						LogWarnings ();
+						break;
+					case WaitHandleIndex.TaskCancelled:
+						tcs.Cancel ();
+						isRunning = false;
+						break;
+					case WaitHandleIndex.Completed:
+						isRunning = false;
+						break;
+					}
+				}
+
+			} finally {
+				if (YieldDuringExecution && BuildEngine is IBuildEngine3)
+					(BuildEngine as IBuildEngine3).Reacquire ();
+			}
+		}
+	}
+
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Crc64.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Crc64.cs
@@ -1,0 +1,192 @@
+﻿/*
+ * Originally ported from: https://github.com/gityf/crc/blob/8045f50ba6e4193d4ee5d2539025fef26e613c9f/crc/crc64.c
+ *
+ * Copyright (c) 2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE. */
+
+using System;
+using System.Security.Cryptography;
+
+namespace Xamarin.Build.Download
+{
+	/// <summary>
+	///  CRC64 variant: crc-64-jones 64-bit
+	///  * Poly: 0xad93d23594c935a9
+	///  Changes beyond initial implementation:
+	///  * Starting Value: ulong.MaxValue
+	///  * XOR length in HashFinal()
+	/// </summary>
+	public class Crc64 : HashAlgorithm
+	{
+		static readonly ulong[] Table = {
+			0x0000000000000000, 0x7ad870c830358979,
+			0xf5b0e190606b12f2, 0x8f689158505e9b8b,
+			0xc038e5739841b68f, 0xbae095bba8743ff6,
+			0x358804e3f82aa47d, 0x4f50742bc81f2d04,
+			0xab28ecb46814fe75, 0xd1f09c7c5821770c,
+			0x5e980d24087fec87, 0x24407dec384a65fe,
+			0x6b1009c7f05548fa, 0x11c8790fc060c183,
+			0x9ea0e857903e5a08, 0xe478989fa00bd371,
+			0x7d08ff3b88be6f81, 0x07d08ff3b88be6f8,
+			0x88b81eabe8d57d73, 0xf2606e63d8e0f40a,
+			0xbd301a4810ffd90e, 0xc7e86a8020ca5077,
+			0x4880fbd87094cbfc, 0x32588b1040a14285,
+			0xd620138fe0aa91f4, 0xacf86347d09f188d,
+			0x2390f21f80c18306, 0x594882d7b0f40a7f,
+			0x1618f6fc78eb277b, 0x6cc0863448deae02,
+			0xe3a8176c18803589, 0x997067a428b5bcf0,
+			0xfa11fe77117cdf02, 0x80c98ebf2149567b,
+			0x0fa11fe77117cdf0, 0x75796f2f41224489,
+			0x3a291b04893d698d, 0x40f16bccb908e0f4,
+			0xcf99fa94e9567b7f, 0xb5418a5cd963f206,
+			0x513912c379682177, 0x2be1620b495da80e,
+			0xa489f35319033385, 0xde51839b2936bafc,
+			0x9101f7b0e12997f8, 0xebd98778d11c1e81,
+			0x64b116208142850a, 0x1e6966e8b1770c73,
+			0x8719014c99c2b083, 0xfdc17184a9f739fa,
+			0x72a9e0dcf9a9a271, 0x08719014c99c2b08,
+			0x4721e43f0183060c, 0x3df994f731b68f75,
+			0xb29105af61e814fe, 0xc849756751dd9d87,
+			0x2c31edf8f1d64ef6, 0x56e99d30c1e3c78f,
+			0xd9810c6891bd5c04, 0xa3597ca0a188d57d,
+			0xec09088b6997f879, 0x96d1784359a27100,
+			0x19b9e91b09fcea8b, 0x636199d339c963f2,
+			0xdf7adabd7a6e2d6f, 0xa5a2aa754a5ba416,
+			0x2aca3b2d1a053f9d, 0x50124be52a30b6e4,
+			0x1f423fcee22f9be0, 0x659a4f06d21a1299,
+			0xeaf2de5e82448912, 0x902aae96b271006b,
+			0x74523609127ad31a, 0x0e8a46c1224f5a63,
+			0x81e2d7997211c1e8, 0xfb3aa75142244891,
+			0xb46ad37a8a3b6595, 0xceb2a3b2ba0eecec,
+			0x41da32eaea507767, 0x3b024222da65fe1e,
+			0xa2722586f2d042ee, 0xd8aa554ec2e5cb97,
+			0x57c2c41692bb501c, 0x2d1ab4dea28ed965,
+			0x624ac0f56a91f461, 0x1892b03d5aa47d18,
+			0x97fa21650afae693, 0xed2251ad3acf6fea,
+			0x095ac9329ac4bc9b, 0x7382b9faaaf135e2,
+			0xfcea28a2faafae69, 0x8632586aca9a2710,
+			0xc9622c4102850a14, 0xb3ba5c8932b0836d,
+			0x3cd2cdd162ee18e6, 0x460abd1952db919f,
+			0x256b24ca6b12f26d, 0x5fb354025b277b14,
+			0xd0dbc55a0b79e09f, 0xaa03b5923b4c69e6,
+			0xe553c1b9f35344e2, 0x9f8bb171c366cd9b,
+			0x10e3202993385610, 0x6a3b50e1a30ddf69,
+			0x8e43c87e03060c18, 0xf49bb8b633338561,
+			0x7bf329ee636d1eea, 0x012b592653589793,
+			0x4e7b2d0d9b47ba97, 0x34a35dc5ab7233ee,
+			0xbbcbcc9dfb2ca865, 0xc113bc55cb19211c,
+			0x5863dbf1e3ac9dec, 0x22bbab39d3991495,
+			0xadd33a6183c78f1e, 0xd70b4aa9b3f20667,
+			0x985b3e827bed2b63, 0xe2834e4a4bd8a21a,
+			0x6debdf121b863991, 0x1733afda2bb3b0e8,
+			0xf34b37458bb86399, 0x8993478dbb8deae0,
+			0x06fbd6d5ebd3716b, 0x7c23a61ddbe6f812,
+			0x3373d23613f9d516, 0x49aba2fe23cc5c6f,
+			0xc6c333a67392c7e4, 0xbc1b436e43a74e9d,
+			0x95ac9329ac4bc9b5, 0xef74e3e19c7e40cc,
+			0x601c72b9cc20db47, 0x1ac40271fc15523e,
+			0x5594765a340a7f3a, 0x2f4c0692043ff643,
+			0xa02497ca54616dc8, 0xdafce7026454e4b1,
+			0x3e847f9dc45f37c0, 0x445c0f55f46abeb9,
+			0xcb349e0da4342532, 0xb1eceec59401ac4b,
+			0xfebc9aee5c1e814f, 0x8464ea266c2b0836,
+			0x0b0c7b7e3c7593bd, 0x71d40bb60c401ac4,
+			0xe8a46c1224f5a634, 0x927c1cda14c02f4d,
+			0x1d148d82449eb4c6, 0x67ccfd4a74ab3dbf,
+			0x289c8961bcb410bb, 0x5244f9a98c8199c2,
+			0xdd2c68f1dcdf0249, 0xa7f41839ecea8b30,
+			0x438c80a64ce15841, 0x3954f06e7cd4d138,
+			0xb63c61362c8a4ab3, 0xcce411fe1cbfc3ca,
+			0x83b465d5d4a0eece, 0xf96c151de49567b7,
+			0x76048445b4cbfc3c, 0x0cdcf48d84fe7545,
+			0x6fbd6d5ebd3716b7, 0x15651d968d029fce,
+			0x9a0d8ccedd5c0445, 0xe0d5fc06ed698d3c,
+			0xaf85882d2576a038, 0xd55df8e515432941,
+			0x5a3569bd451db2ca, 0x20ed197575283bb3,
+			0xc49581ead523e8c2, 0xbe4df122e51661bb,
+			0x3125607ab548fa30, 0x4bfd10b2857d7349,
+			0x04ad64994d625e4d, 0x7e7514517d57d734,
+			0xf11d85092d094cbf, 0x8bc5f5c11d3cc5c6,
+			0x12b5926535897936, 0x686de2ad05bcf04f,
+			0xe70573f555e26bc4, 0x9ddd033d65d7e2bd,
+			0xd28d7716adc8cfb9, 0xa85507de9dfd46c0,
+			0x273d9686cda3dd4b, 0x5de5e64efd965432,
+			0xb99d7ed15d9d8743, 0xc3450e196da80e3a,
+			0x4c2d9f413df695b1, 0x36f5ef890dc31cc8,
+			0x79a59ba2c5dc31cc, 0x037deb6af5e9b8b5,
+			0x8c157a32a5b7233e, 0xf6cd0afa9582aa47,
+			0x4ad64994d625e4da, 0x300e395ce6106da3,
+			0xbf66a804b64ef628, 0xc5bed8cc867b7f51,
+			0x8aeeace74e645255, 0xf036dc2f7e51db2c,
+			0x7f5e4d772e0f40a7, 0x05863dbf1e3ac9de,
+			0xe1fea520be311aaf, 0x9b26d5e88e0493d6,
+			0x144e44b0de5a085d, 0x6e963478ee6f8124,
+			0x21c640532670ac20, 0x5b1e309b16452559,
+			0xd476a1c3461bbed2, 0xaeaed10b762e37ab,
+			0x37deb6af5e9b8b5b, 0x4d06c6676eae0222,
+			0xc26e573f3ef099a9, 0xb8b627f70ec510d0,
+			0xf7e653dcc6da3dd4, 0x8d3e2314f6efb4ad,
+			0x0256b24ca6b12f26, 0x788ec2849684a65f,
+			0x9cf65a1b368f752e, 0xe62e2ad306bafc57,
+			0x6946bb8b56e467dc, 0x139ecb4366d1eea5,
+			0x5ccebf68aecec3a1, 0x2616cfa09efb4ad8,
+			0xa97e5ef8cea5d153, 0xd3a62e30fe90582a,
+			0xb0c7b7e3c7593bd8, 0xca1fc72bf76cb2a1,
+			0x45775673a732292a, 0x3faf26bb9707a053,
+			0x70ff52905f188d57, 0x0a2722586f2d042e,
+			0x854fb3003f739fa5, 0xff97c3c80f4616dc,
+			0x1bef5b57af4dc5ad, 0x61372b9f9f784cd4,
+			0xee5fbac7cf26d75f, 0x9487ca0fff135e26,
+			0xdbd7be24370c7322, 0xa10fceec0739fa5b,
+			0x2e675fb4576761d0, 0x54bf2f7c6752e8a9,
+			0xcdcf48d84fe75459, 0xb71738107fd2dd20,
+			0x387fa9482f8c46ab, 0x42a7d9801fb9cfd2,
+			0x0df7adabd7a6e2d6, 0x772fdd63e7936baf,
+			0xf8474c3bb7cdf024, 0x829f3cf387f8795d,
+			0x66e7a46c27f3aa2c, 0x1c3fd4a417c62355,
+			0x935745fc4798b8de, 0xe98f353477ad31a7,
+			0xa6df411fbfb21ca3, 0xdc0731d78f8795da,
+			0x536fa08fdfd90e51, 0x29b7d047efec8728,
+		};
+
+		ulong crc = ulong.MaxValue;
+		ulong length = 0;
+
+		public override void Initialize() { }
+
+		protected override void HashCore(byte[] array, int ibStart, int cbSize)
+		{
+			for (int i = ibStart; i < cbSize; i++)
+			{
+				crc = Table[(byte)(crc ^ array[i])] ^ (crc >> 8);
+			}
+			length += (ulong)cbSize;
+		}
+
+		protected override byte[] HashFinal() => BitConverter.GetBytes(crc ^ length);
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Build.Download
+{
+	public class DownloadUtils
+	{
+		public DownloadUtils (ILogger logger, string cacheDir)
+		{
+			Log = logger;
+			CacheDir = GetCacheDir (cacheDir);
+		}
+
+		public ILogger Log { get; private set; }
+		public string CacheDir { get; private set; }
+
+		public IEnumerable<XamarinBuildDownload> ParseDownloadItems (ITaskItem[] items, bool allowUnsecureUrls)
+		{
+			if (items == null || items.Length <= 0)
+				return new List<XamarinBuildDownload> ();
+			
+			var results = new List<XamarinBuildDownload> ();
+
+			foreach (var item in items) {
+				var xbd = new XamarinBuildDownload ();
+
+				xbd.Id = item.ItemSpec;
+				if (!ValidateId (xbd.Id)) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidItemId, "Invalid item ID {0}", xbd.Id);
+					continue;
+				}
+				xbd.Url = item.GetMetadata ("Url");
+				if (string.IsNullOrEmpty (xbd.Url)) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidUrl, "Missing required Url metadata on item {0}", item.ItemSpec);
+					continue;
+				}
+				xbd.Sha256 = item.GetMetadata ("Sha256");
+				xbd.Kind = GetKind (xbd.Url, item.GetMetadata ("Kind"));
+				if (xbd.Kind == ArchiveKind.Unknown) {
+					//TODO we may be able to determine the kind from the server response
+					continue;
+				}
+				if (!EnsureSecureUrl (item, xbd.Url, allowUnsecureUrls)) {
+					continue;
+				}
+
+				xbd.CustomErrorCode = item.GetMetadata ("CustomErrorCode");
+				xbd.CustomErrorMessage = item.GetMetadata ("CustomErrorMessage");
+
+				// By default, use the kind (tgz or zip) as the file extension for the cache file
+				var cacheFileExt = xbd.Kind.ToString ().ToLower ();
+
+				// If we have an uncompressed file specified (move file instead of decompressing it)
+				if (xbd.Kind == ArchiveKind.Uncompressed) {
+					// Get the filename
+					xbd.ToFile = item.GetMetadata ("ToFile");
+					// If we have a tofile set, try and grab its extension
+					if (!string.IsNullOrEmpty (xbd.ToFile))
+						cacheFileExt = Path.GetExtension (xbd.ToFile)?.ToLower () ?? string.Empty;
+				}
+
+				xbd.CacheFile = Path.Combine (CacheDir, item.ItemSpec.TrimEnd('.') + "." + cacheFileExt.TrimStart('.'));
+				xbd.DestinationDir = Path.GetFullPath (Path.Combine (CacheDir, item.ItemSpec));
+
+				int lockTimeout = 60;
+				if (int.TryParse (item.GetMetadata ("ExclusiveLockTimeout"), out lockTimeout))
+					xbd.ExclusiveLockTimeout = lockTimeout;
+
+				results.Add (xbd);
+			}
+
+			// Deduplicate possible results by their Id which should be unique always for the given archive
+			return results.GroupBy (item => item.Id).Select ((kvp) => kvp.FirstOrDefault ()).ToArray ();
+		}
+
+		public List<PartialZipDownload> ParsePartialZipDownloadItems (ITaskItem [] items, bool allowUnsecureUrls)
+		{
+			if (items == null || items.Length <= 0)
+				return new List<PartialZipDownload> ();
+			
+			var result = new List<PartialZipDownload> ();
+
+			foreach (var part in items) {
+
+				var id = part.ItemSpec;
+				if (!DownloadUtils.ValidateId (id)) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidItemId, "Invalid item ID {0}", id);
+					continue;
+				}
+
+				var toFile = part.GetMetadata ("ToFile");
+				if (string.IsNullOrEmpty (toFile)) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidToFile, "Invalid or missing required ToFile metadata on item {0}", id);
+					continue;
+				}
+				var url = part.GetMetadata ("Url");
+				if (string.IsNullOrEmpty (url)) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidUrl, "Missing required Url metadata on item {0}", id);
+					continue;
+				}
+				if (!EnsureSecureUrl (part, url, allowUnsecureUrls)) {
+					continue;
+				}
+
+				var sha256 = part.GetMetadata ("Sha256");
+
+				long rangeStart = -1L;
+				long.TryParse (part.GetMetadata ("RangeStart"), out rangeStart);
+				if (rangeStart < 0) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidRangeStart, "Invalid or Missing required RangeStart metadata on item {0}", id);
+					continue;
+				}
+
+				long rangeEnd = -1L;
+				long.TryParse (part.GetMetadata ("RangeEnd"), out rangeEnd);
+				if (rangeEnd < 0) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidRangeEnd, "Invalid or Missing required RangeEnd metadata on item {0}", id);
+					continue;
+				}
+
+				if (rangeEnd <= rangeStart) {
+					Log.LogCodedError (ErrorCodes.XbdInvalidRange, "Invalid RangeStart and RangeEnd values, RangeEnd cannot be less than or equal to RangeStart, on item {0}", id);
+					continue;
+				}
+
+				var customErrorMsg = part.GetMetadata ("CustomErrorMessage");
+				var customErrorCode = part.GetMetadata ("CustomErrorCode");
+
+				result.Add (new PartialZipDownload {
+					Id = id,
+					ToFile = toFile,
+					Url = url,
+					Sha256 = sha256,
+					RangeStart = rangeStart,
+					RangeEnd = rangeEnd,
+					CustomErrorMessage = customErrorMsg,
+					CustomErrorCode = customErrorCode,
+				});
+			}
+
+			// Deduplicate multiple id's of the same value
+			var uniqueParts = result.GroupBy (p => p.Id).Select (kvp => kvp.FirstOrDefault ());
+
+			return uniqueParts.ToList ();
+		}
+
+		public bool EnsureSecureUrl (ITaskItem item, string url, bool allowUnsecureUrls)
+		{
+			if (!allowUnsecureUrls) {
+				if (url.StartsWith ("http:", StringComparison.OrdinalIgnoreCase)) {
+					Log.LogCodedError (ErrorCodes.XbdUnsecureUrl, "Unsecure download url '{0}' not allowed, unless 'XamarinBuildDownloadAllowUnsecure' is set to 'true' for the project, for {1}", url, item.ItemSpec);
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		public static string GetCacheDir (string overrideCacheDir = null)
+		{
+			string cacheDir = overrideCacheDir;
+
+			if (string.IsNullOrEmpty (cacheDir)) {
+				if (Platform.IsMac) {
+					cacheDir = Path.Combine (
+						Environment.GetFolderPath (Environment.SpecialFolder.Personal),
+						"Library", "Caches", "XamarinBuildDownload"
+					);
+				} else {
+					cacheDir = Path.Combine (
+						Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData),
+						"XamarinBuildDownloadCache"
+					);
+				}
+			}
+
+			cacheDir = Path.GetFullPath (cacheDir);
+
+			Directory.CreateDirectory (cacheDir);
+
+			return cacheDir;
+		}
+
+		//Format is ID-VERSION
+		//ID:
+		// * must start with a letter
+		// * may contain letters, periods, spaces and underscores
+		// * must end with a letter or number
+		//VERSION:
+		// * components separated by periods
+		// * each component must consist of letters and numbers
+		// * optional hyphen and pre-release id (eg: '-beta01')
+		static readonly Regex idRegex = new Regex (
+			@"[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+-[A-Za-z\d]+(\.[A-Za-z\d]+)*(/[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+)?(-\w*)?"
+			,
+			RegexOptions.Compiled
+		);
+
+		public bool IsAlreadyDownloaded (XamarinBuildDownload xbd)
+		{
+			// Skip extraction if the file is already in place
+			var flagFile = xbd.DestinationDir + ".unpacked";
+			return File.Exists (flagFile) || File.Exists (xbd.CacheFile);
+		}
+
+		public bool IsAlreadyDownloaded (string cacheDirectory, PartialZipDownload partialZipDownload)
+		{
+			return File.Exists (Path.Combine (cacheDirectory, partialZipDownload.Id, partialZipDownload.ToFile));
+		}
+
+		public static bool ValidateId (string id)
+		{
+			try {
+				var match = idRegex.Match (id);
+				return match.Length == id.Length;
+			} catch {
+				return false;
+			}
+		}
+
+		public ArchiveKind GetKind (string urlMetadata, string kindMetadata)
+		{
+
+			if (kindMetadata != null) {
+				ArchiveKind parsed;
+				if (Enum.TryParse (kindMetadata, out parsed) && parsed != ArchiveKind.Unknown) {
+					return parsed;
+				}
+				Log.LogCodedError (ErrorCodes.UnknownArchiveType, "Unknown archive kind '{0}' for '{1}'", kindMetadata, urlMetadata);
+				return ArchiveKind.Unknown;
+			}
+
+			if (urlMetadata.EndsWith (".zip", StringComparison.OrdinalIgnoreCase)
+				|| urlMetadata.EndsWith (".nupkg", StringComparison.OrdinalIgnoreCase)) {
+				return ArchiveKind.Zip;
+			}
+
+			if (urlMetadata.EndsWith (".tgz", StringComparison.OrdinalIgnoreCase)
+				|| urlMetadata.EndsWith (".tar.gz", StringComparison.OrdinalIgnoreCase)) {
+				return ArchiveKind.Tgz;
+			}
+
+			Log.LogCodedError (ErrorCodes.UnknownArchiveType, "Unable to determine kind of archive '{0}'", urlMetadata);
+			return ArchiveKind.Unknown;
+		}
+
+		public static Stream ObtainExclusiveFileLock (string file, CancellationToken cancelToken, TimeSpan timeout, ILogger log = null)
+		{
+			var linkedCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource (
+				cancelToken,
+				new CancellationTokenSource (timeout).Token);
+			
+			while (!linkedCancelTokenSource.IsCancellationRequested) {
+				try {
+					var lockStream = File.Open (file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+					return lockStream;
+				} catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException) {
+					Thread.Sleep (100);
+				} catch (Exception ex) {
+					log?.LogErrorFromException (ex);
+				}
+			}
+
+			return null;
+		}
+
+		public static string Crc64(string s)
+		{
+			var bytes = Encoding.UTF8.GetBytes(s);
+			return HashBytes(bytes);
+		}
+
+		public static string HashBytes(byte[] bytes)
+		{
+			using (var hashAlg = new Crc64())
+			{
+				byte[] hash = hashAlg.ComputeHash(bytes);
+				return ToHexString(hash);
+			}
+		}
+
+		public static string ToHexString(byte[] hash)
+		{
+			char[] array = new char[hash.Length * 2];
+			for (int i = 0, j = 0; i < hash.Length; i += 1, j += 2)
+			{
+				byte b = hash[i];
+				array[j] = GetHexValue(b / 16);
+				array[j + 1] = GetHexValue(b % 16);
+			}
+			return new string(array);
+		}
+
+		static char GetHexValue(int i) => (char)(i < 10 ? i + 48 : i - 10 + 65);
+
+		public static string HashSha256 (string value)
+		{
+			return HashSha256 (Encoding.UTF8.GetBytes (value));
+		}
+
+		public static string HashSha256 (byte[] value)
+		{
+			using (var sha256 = new SHA256Managed())
+			{
+				var hash = new StringBuilder();
+				var hashData = sha256.ComputeHash(value);
+				foreach (var b in hashData)
+					hash.Append(b.ToString("x2"));
+
+				return hash.ToString();
+			}
+		}
+
+		public static string HashSha256 (Stream value)
+		{
+			using (var sha256 = new SHA256Managed())
+			{
+				var hash = new StringBuilder();
+				var hashData = sha256.ComputeHash(value);
+				foreach (var b in hashData)
+					hash.Append(b.ToString("x2"));
+
+				return hash.ToString();
+			}
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ErrorCodes.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ErrorCodes.cs
@@ -1,0 +1,28 @@
+﻿using System;
+namespace Xamarin.Build.Download
+{
+	public static class ErrorCodes
+	{
+		public const string DownloadFailed = "XBD001";
+		public const string ExtractionFailed = "XBD002";
+		public const string DownloadedFileMissing = "XBD003";
+		public const string DirectoryCreateFailed = "XBD005";
+		public const string DirectoryDeleteFailed = "XBD006";
+		public const string ExclusiveLockTimeout = "XBD008";
+		public const string PartialDownloadFailed = "XBD009";
+
+		public const string UnknownArchiveType = "XBD010";
+
+		public const string XbdInvalidItemId = "XBD020";
+		public const string XbdInvalidUrl = "XBD021";
+		public const string XbdInvalidToFile = "XBD022";
+
+		public const string XbdInvalidRange = "XBD030";
+		public const string XbdInvalidRangeStart = "XBD031";
+		public const string XbdInvalidRangeEnd = "XBD032";
+
+		public const string XbdUnsecureUrl = "XBD040";
+
+		public const string XbdUnsupportedItemGroup = "XBD100";
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/HttpMultipartContentParser.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/HttpMultipartContentParser.cs
@@ -1,0 +1,245 @@
+﻿//using System;
+//using System.Threading.Tasks;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Net.Http;
+//using System.IO;
+//using System.Text;
+//using System.Net.Http.Headers;
+
+//namespace Xamarin.Build.Download
+//{
+//	static class HttpMultipartContentParser
+//	{
+//		public static async Task<List<Part>> ReadAsMultiPartContentAsync (this HttpContent content, int bufferSize = 2048)
+//		{
+//			var encoding = Encoding.UTF8;
+//			var parsedParts = new List<Part> ();
+
+//			// Find the boundary
+//			var boundary = content?.Headers?.ContentType?.Parameters.FirstOrDefault (
+//							   p => p.Name.Equals ("boundary", StringComparison.OrdinalIgnoreCase))?.Value ?? string.Empty;
+
+//			var boundaryBytes = encoding.GetBytes ("--" + boundary + "\r\n");
+//			var lastBoundaryBytes = encoding.GetBytes ("--" + boundary + "--\r\n");
+//			//var newlineBytes = encoding.GetBytes ("\r\n");
+//			var doubleNewlineBytes = encoding.GetBytes ("\r\n\r\n");
+
+//			var contentData = new List<byte> ();
+//			var part = new Part ();
+//			var buffer = new byte [bufferSize];
+//			var inputStream = await content.ReadAsStreamAsync ();
+//			var data = new List<byte> ();
+
+//			var parseState = ParseState.Initiating;
+
+//			while (true) {
+//				var read = await inputStream.ReadAsync (buffer, 0, buffer.Length);
+
+//				// Exit loop once done reading stream
+//				if (read <= 0)
+//					break;
+
+//				// Add the data read into our overall buffer
+//				data.AddRange (buffer.Take (read));
+
+//				while (true) {
+//					if (parseState == ParseState.Initiating) {
+
+//						var boundaryIndex = data.IndexOfPattern (boundaryBytes);
+
+//						// Not enough data in the buffer, keep reading and try again
+//						if (boundaryIndex < 0)
+//							break;
+
+//						// Remove everything up to and including the first boundary
+//						data.RemoveRange (0, boundaryIndex + boundaryBytes.Length);
+
+//						parseState = ParseState.ReadingHeaders;
+//						continue; // Check state again
+
+//					} else if (parseState == ParseState.ReadingHeaders) {
+
+//						var dblNlIndex = data.IndexOfPattern (doubleNewlineBytes);
+
+//						// Still receiving headers, keep reading
+//						if (dblNlIndex < 0)
+//							break;
+
+//						var hdata = data.Take (dblNlIndex + 1).ToArray ();
+//						var headersData = encoding.GetString (hdata, 0, hdata.Length);
+
+//						// Parse out the headers
+//						var headers = headersData.Split (new string [] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+//						foreach (var header in headers) {
+//							var headerParts = header.Split (new [] { ':' }, 2);
+//							if (headerParts != null && headerParts.Length == 2)
+//								part.Headers.Add (headerParts [0].Trim (), headerParts [1].Trim ());
+//						}
+
+//						//isAudioPart = part.ContentType.Equals("audio/mpeg", StringComparison.OrdinalIgnoreCase);
+
+//						// Remove everything up to the end of the headers (including the newlines)
+//						data.RemoveRange (0, dblNlIndex + doubleNewlineBytes.Length);
+
+//						parseState = ParseState.ReadingStream;
+//						continue;
+
+//					} else if (parseState == ParseState.ReadingStream) {
+
+//						var wasLastBoundary = false;
+//						var boundaryIndex = data.IndexOfPattern (boundaryBytes);
+//						if (boundaryIndex < 0) {
+//							boundaryIndex = data.IndexOfPattern (lastBoundaryBytes);
+//							wasLastBoundary = true;
+//						}
+
+//						byte [] d;
+
+//						// still receiving stream data, keep going
+//						if (boundaryIndex < 0) {
+//							// Grab all available data
+//							d = data.ToArray ();
+//							data.Clear ();
+//						} else {
+//							// Grab only the data up until the boundary we found
+//							d = data.Take (boundaryIndex).ToArray ();
+//							data.RemoveRange (0, boundaryIndex);
+//						}
+
+//						contentData.AddRange (d); // Add the data to another buffer
+
+//						if (boundaryIndex < 0) {
+//							// Still no boundary found, keep reading
+//							break;
+//						} else {
+//							// Found our boundary, continue on checking the buffer
+//							// TODO: wrap up the part
+//							part.Data = contentData.ToArray ();
+
+//							// Fire the event
+//							parsedParts.Add (part);
+
+//							// Reset
+//							parseState = ParseState.Initiating;
+//							part = new Part ();
+//							contentData.Clear ();
+
+//							if (wasLastBoundary) {
+//								parseState = ParseState.Closed;
+//								break;
+//							} else
+//								continue;
+//						}
+
+//					}
+
+//				}
+
+//				if (parseState == ParseState.Closed)
+//					break;
+//			}
+
+//			return parsedParts;
+//		}
+//	}
+
+//	enum ParseState
+//	{
+//		Initiating,
+//		ReadingHeaders,
+//		ReadingStream,
+//		Closed
+//	}
+
+//	public class Part
+//	{
+//		public Part ()
+//		{
+//			Headers = new Dictionary<string, string> ();
+//		}
+
+//		public byte [] Data { get; set; }
+
+//		public Dictionary<string, string> Headers { get; set; }
+
+//		public string ContentType {
+//			get { return GetHeaderValue ("Content-Type"); }
+//		}
+
+//		public string ContentDisposition {
+//			get { return GetHeaderValue ("Content-Disposition"); }
+//		}
+
+//		public string ContentID {
+//			get { return GetHeaderValue ("Content-ID"); }
+//		}
+
+//		public System.Net.Http.Headers.ContentRangeHeaderValue ContentRange {
+//			get {
+//				var result = new ContentRangeHeaderValue (0L);
+//				var cr = GetHeaderValue ("Content-Range");
+//				if (!string.IsNullOrEmpty (cr))
+//					ContentRangeHeaderValue.TryParse (cr, out result);
+//				return result;
+//			}
+//		}
+
+//		string GetHeaderValue (string name)
+//		{
+//			if (Headers == null || !Headers.ContainsKey (name))
+//				return string.Empty;
+
+//			return Headers [name].Trim ();
+//		}
+//	}
+
+//	public static class ByteExtensionMethods
+//	{
+//		public static int IndexOfPattern (this List<byte> source, byte [] searchPattern)
+//		{
+//			var indices = IndexesOfPattern (source, searchPattern);
+
+//			return indices.Count <= 0 ? -1 : indices [0];
+//		}
+
+//		public static List<int> IndexesOfPattern (this List<byte> source, byte [] searchPattern)
+//		{
+//			var list = new List<int> ();
+
+//			if (IsEmptyLocate (source, searchPattern))
+//				return list;
+
+//			for (int i = 0; i < source.Count; i++) {
+//				if (!IsMatch (source, i, searchPattern))
+//					continue;
+
+//				list.Add (i);
+//			}
+
+//			return list;
+//		}
+
+//		static bool IsMatch (List<byte> source, int position, byte [] candidate)
+//		{
+//			if (candidate.Length > (source.Count - position))
+//				return false;
+
+//			for (int i = 0; i < candidate.Length; i++)
+//				if (source [position + i] != candidate [i])
+//					return false;
+
+//			return true;
+//		}
+
+//		static bool IsEmptyLocate (List<byte> array, byte [] candidate)
+//		{
+//			return array == null
+//				|| candidate == null
+//				|| array.Count <= 0
+//				|| candidate.Length == 0
+//				|| candidate.Length > array.Count;
+//		}
+
+//	}
+//}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/MSBuildExtensions.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/MSBuildExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Build.Download
+{
+	//from Xamarin.Android MSBuild targets
+	static class MSBuildExtensions
+	{
+		public static void LogDebugMessage (this TaskLoggingHelper log, string message, params object [] messageArgs)
+		{
+			log.LogMessage (MessageImportance.Low, message, messageArgs);
+		}
+
+		public static void LogCodedError (this TaskLoggingHelper log, string code, string message, params object [] messageArgs)
+		{
+			log.LogError (string.Empty, code, string.Empty, string.Empty, 0, 0, 0, 0, message, messageArgs);
+		}
+	}
+
+	public interface ILogger
+	{
+		void LogCodedError (string code, string message, params object [] messageArgs);
+		void LogErrorFromException (System.Exception exception);
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/PListObject.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/PListObject.cs
@@ -1,0 +1,2266 @@
+﻿// 
+// PObject.cs
+//  
+// Author:
+//       Mike Krüger <mkrueger@xamarin.com>
+//       Alex Corrado <corrado@xamarin.com>
+// 
+// Copyright (c) 2011 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Now a purely managed implementation for plist reading & writing.
+// Define POBJECT_MONOMAC to enable the conversions to/from NSObject and friends.
+
+// Binary format reference: http://opensource.apple.com/source/CF/CF-635.21/CFBinaryPList.c
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security;
+using System.Threading.Tasks;
+
+#if POBJECT_MONOMAC
+using MonoMac.Foundation;
+using MonoMac.ObjCRuntime;
+#endif
+
+namespace Xamarin.MacDev
+{
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	abstract class PObject
+	{
+		public static PObject Create (PObjectType type)
+		{
+			switch (type) {
+				case PObjectType.Dictionary:
+				return new PDictionary ();
+				case PObjectType.Array:
+				return new PArray ();
+				case PObjectType.Number:
+				return new PNumber (0);
+				case PObjectType.Real:
+				return new PReal (0);
+				case PObjectType.Boolean:
+				return new PBoolean (true);
+				case PObjectType.Data:
+				return new PData (new byte[0]);
+				case PObjectType.String:
+				return new PString ("");
+				case PObjectType.Date:
+				return new PDate (DateTime.Now);
+				default:
+				throw new ArgumentOutOfRangeException ();
+			}
+		}
+
+		public static IEnumerable<KeyValuePair<string, PObject>> ToEnumerable (PObject obj)
+		{
+			if (obj is PDictionary)
+				return (PDictionary) obj;
+
+			if (obj is PArray)
+				return ((PArray) obj).Select (k => new KeyValuePair<string, PObject> (k is IPValueObject ? ((IPValueObject) k).Value.ToString () : null, k));
+
+			return Enumerable.Empty <KeyValuePair<string, PObject>> ();
+		}
+
+		PObjectContainer parent;
+		public PObjectContainer Parent {
+			get { return parent; }
+			set {
+				if (parent != null && value != null)
+					throw new NotSupportedException ("Already parented.");
+
+				parent = value;
+			}
+		}
+
+		public abstract PObject Clone ();
+
+		public void Replace (PObject newObject)
+		{
+			var p = Parent;
+			if (p is PDictionary) {
+				var dict = (PDictionary)p;
+				var key = dict.GetKey (this);
+				if (key == null)
+					return;
+				Remove ();
+				dict[key] = newObject;
+			} else if (p is PArray) {
+				var arr = (PArray)p;
+				arr.Replace (this, newObject);
+			}
+		}
+
+		public string Key {
+			get {
+				if (Parent is PDictionary) {
+					var dict = (PDictionary)Parent;
+					return dict.GetKey (this);
+				}
+				return null;
+			}
+		}
+
+		public void Remove ()
+		{
+			if (Parent is PDictionary) {
+				var dict = (PDictionary)Parent;
+				dict.Remove (Key);
+			} else if (Parent is PArray) {
+				var arr = (PArray)Parent;
+				arr.Remove (this);
+			} else {
+				if (Parent == null)
+					throw new InvalidOperationException ("Can't remove from null parent");
+				throw new InvalidOperationException ("Can't remove from parent " + Parent);
+			}
+		}
+
+		#if POBJECT_MONOMAC
+				public abstract NSObject Convert ();
+		#endif
+
+		public abstract PObjectType Type { get; }
+
+		public static implicit operator PObject (string value)
+		{
+			return new PString (value);
+		}
+
+		public static implicit operator PObject (int value)
+		{
+			return new PNumber (value);
+		}
+
+		public static implicit operator PObject (double value)
+		{
+			return new PReal (value);
+		}
+
+		public static implicit operator PObject (bool value)
+		{
+			return new PBoolean (value);
+		}
+
+		public static implicit operator PObject (DateTime value)
+		{
+			return new PDate (value);
+		}
+
+		public static implicit operator PObject (byte[] value)
+		{
+			return new PData (value);
+		}
+
+		protected virtual void OnChanged (EventArgs e)
+		{
+			if (SuppressChangeEvents)
+				return;
+
+			var handler = Changed;
+			if (handler != null)
+				handler (this, e);
+
+			if (Parent != null)
+				Parent.OnCollectionChanged (Key, this);
+		}
+
+		protected bool SuppressChangeEvents {
+			get; set;
+		}
+
+		public event EventHandler Changed;
+
+		public byte[] ToByteArray (bool binary)
+		{
+			var format = binary? PropertyListFormat.Binary : PropertyListFormat.Xml;
+
+			using (var stream = new MemoryStream ()) {
+				using (var context = format.StartWriting (stream))
+					context.WriteObject (this);
+				return stream.ToArray ();
+			}
+		}
+
+		public string ToXml ()
+		{
+			return Encoding.UTF8.GetString (ToByteArray (false));
+		}
+
+		#if POBJECT_MONOMAC
+				static readonly IntPtr selObjCType = Selector.GetHandle ("objCType");
+
+		public static PObject FromNSObject (NSObject val)
+		{
+			if (val == null)
+				return null;
+			
+			var dict = val as NSDictionary;
+			if (dict != null) {
+				var result = new PDictionary ();
+				foreach (var pair in dict) {
+					string k = pair.Key.ToString ();
+					result[k] = FromNSObject (pair.Value);
+				}
+				return result;
+			}
+			
+			var arr = val as NSArray;
+			if (arr != null) {
+				var result = new PArray ();
+				uint count = arr.Count;
+				for (uint i = 0; i < count; i++) {
+					var obj = Runtime.GetNSObject (arr.ValueAt (i));
+					if (obj != null)
+						result.Add (FromNSObject (obj));
+				}
+				return result;
+			}
+			
+			var str = val as NSString;
+			if (str != null)
+				return str.ToString ();
+			
+			var nr = val as NSNumber;
+			if (nr != null) {
+				char t;
+				unsafe {
+					t = (char) *((byte*) MonoMac.ObjCRuntime.Messaging.IntPtr_objc_msgSend (val.Handle, selObjCType));
+				}
+				if (t == 'c' || t == 'C' || t == 'B')
+					return nr.BoolValue;
+				return nr.Int32Value;
+			}
+			
+			var date = val as NSDate;
+			if (date != null)
+				return (DateTime) date;
+			
+			var data = val as NSData;
+			if (data != null) {
+				var bytes = new byte[data.Length];
+				System.Runtime.InteropServices.Marshal.Copy (data.Bytes, bytes, 0, (int)data.Length);
+				return bytes;
+			}
+			
+			throw new NotSupportedException (val.ToString ());
+		}
+		#endif
+
+		public static PObject FromByteArray (byte[] array, int startIndex, int length, out bool isBinary)
+		{
+			var ctx = PropertyListFormat.Binary.StartReading (array, startIndex, length);
+
+			isBinary = true;
+
+			try {
+				if (ctx == null) {
+					isBinary = false;
+					ctx = PropertyListFormat.CreateReadContext (array, startIndex, length);
+					if (ctx == null)
+						return null;
+				}
+
+				return ctx.ReadObject ();
+			} finally {
+				if (ctx != null)
+					ctx.Dispose ();
+			}
+		}
+
+		public static PObject FromByteArray (byte[] array, out bool isBinary)
+		{
+			return FromByteArray (array, 0, array.Length, out isBinary);
+		}
+
+		public static PObject FromString (string str)
+		{
+			var ctx = PropertyListFormat.CreateReadContext (Encoding.UTF8.GetBytes (str));
+			if (ctx == null)
+				return null;
+			return ctx.ReadObject ();
+		}
+
+		public static PObject FromStream (Stream stream)
+		{
+			var ctx = PropertyListFormat.CreateReadContext (stream);
+			if (ctx == null)
+				return null;
+			return ctx.ReadObject ();
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	abstract class PObjectContainer : PObject
+	{
+		public abstract int Count { get; }
+
+		public bool Reload (string fileName)
+		{
+			using (var stream = new FileStream (fileName, FileMode.Open, FileAccess.Read)) {
+				using (var ctx = PropertyListFormat.CreateReadContext (stream)) {
+					if (ctx == null)
+						return false;
+
+					return Reload (ctx);
+				}
+			}
+		}
+
+		protected abstract bool Reload (PropertyListFormat.ReadWriteContext ctx);
+
+		public Task SaveAsync (string filename, bool atomic = false, bool binary = false)
+		{
+			return Task.Factory.StartNew (() => Save (filename, atomic, binary));
+		}
+
+		public void Save (string filename, bool atomic = false, bool binary = false)
+		{
+			var tempFile = atomic? GetTempFileName (filename) : filename;
+			try {
+				if (!Directory.Exists (Path.GetDirectoryName (tempFile)))
+					Directory.CreateDirectory (Path.GetDirectoryName (tempFile));
+
+				using (var stream = new FileStream (tempFile, FileMode.Create, FileAccess.Write)) {
+					using (var ctx = binary? PropertyListFormat.Binary.StartWriting (stream) : PropertyListFormat.Xml.StartWriting (stream))
+						ctx.WriteObject (this);
+				}
+				if (atomic) {
+					if (File.Exists (filename))
+						File.Replace (tempFile, filename, null, true);
+					else
+						File.Move (tempFile, filename);
+				}
+			} finally {
+				if (atomic)
+					File.Delete (tempFile); // just in case- no exception is raised if file is not found
+			}
+		}
+
+		static string GetTempFileName (string filename)
+		{
+			var i = 1;
+			var tempfile = filename + ".tmp";
+			while (File.Exists (tempfile))
+				tempfile = filename + ".tmp." + (i++).ToString ();
+			return tempfile;
+		}
+
+		protected void OnChildAdded (string key, PObject child)
+		{
+			child.Parent = this;
+
+			OnCollectionChanged (PObjectContainerAction.Added, key, null, child);
+		}
+
+		internal void OnCollectionChanged (string key, PObject child)
+		{
+			OnCollectionChanged (PObjectContainerAction.Changed, key, null, child);
+		}
+
+		protected void OnChildRemoved (string key, PObject child)
+		{
+			child.Parent = null;
+
+			OnCollectionChanged (PObjectContainerAction.Removed, key, child, null);
+		}
+
+		protected void OnChildReplaced (string key, PObject oldChild, PObject newChild)
+		{
+			oldChild.Parent = null;
+			newChild.Parent = this;
+
+			OnCollectionChanged (PObjectContainerAction.Replaced, key, oldChild, newChild);
+		}
+
+		protected void OnCleared ()
+		{
+			OnCollectionChanged (PObjectContainerAction.Cleared, null, null, null);
+		}
+
+		protected void OnCollectionChanged (PObjectContainerAction action, string key, PObject oldChild, PObject newChild)
+		{
+			if (SuppressChangeEvents)
+				return;
+
+			var handler = CollectionChanged;
+			if (handler != null)
+				handler (this, new PObjectContainerEventArgs (action, key, oldChild, newChild));
+
+			OnChanged (EventArgs.Empty);
+
+			if (Parent != null)
+				Parent.OnCollectionChanged (Key, this);
+		}
+
+		public event EventHandler<PObjectContainerEventArgs> CollectionChanged;
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	interface IPValueObject
+	{
+		object Value { get; set; }
+		bool TrySetValueFromString (string text, IFormatProvider formatProvider);
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	abstract class PValueObject<T> : PObject, IPValueObject
+	{
+		T val;
+		public T Value {
+			get {
+				return val;
+			}
+			set {
+				val = value;
+				OnChanged (EventArgs.Empty);
+			}
+		}
+
+		object IPValueObject.Value {
+			get { return Value; }
+			set { Value = (T) value; }
+		}
+
+		protected PValueObject (T value)
+		{
+			Value = value;
+		}
+
+		protected PValueObject ()
+		{
+		}
+
+		public static implicit operator T (PValueObject<T> pObj)
+		{
+			return pObj != null ? pObj.Value : default(T);
+		}
+
+		public abstract bool TrySetValueFromString (string text, IFormatProvider formatProvider);
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PDictionary : PObjectContainer, IEnumerable<KeyValuePair<string, PObject>>
+	{
+		static readonly byte[] BeginMarkerBytes = Encoding.ASCII.GetBytes ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		static readonly byte[] EndMarkerBytes = Encoding.ASCII.GetBytes ("</plist>");
+
+		readonly Dictionary<string, PObject> dict;
+		readonly List<string> order;
+
+		public PObject this[string key] {
+			get {
+				PObject value;
+				if (dict.TryGetValue (key, out value))
+					return value;
+				return null;
+			}
+			set {
+				PObject existing;
+				bool exists = dict.TryGetValue (key, out existing);
+				if (!exists)
+					order.Add (key);
+
+				dict[key] = value;
+
+				if (exists)
+					OnChildReplaced (key, existing, value);
+				else
+					OnChildAdded (key, value);
+			}
+		}
+
+		public void Add (string key, PObject value)
+		{
+			dict.Add (key, value);
+			order.Add (key);
+
+			OnChildAdded (key, value);
+		}
+
+		public void InsertAfter (string keyBefore, string key, PObject value)
+		{
+			dict.Add (key, value);
+			order.Insert (order.IndexOf (keyBefore) + 1, key);
+
+			OnChildAdded (key, value);
+		}
+
+		public override int Count {
+			get { return dict.Count; }
+		}
+
+		#region IEnumerable[KeyValuePair[System.String,PObject]] implementation
+		public IEnumerator<KeyValuePair<string, PObject>> GetEnumerator ()
+		{
+			foreach (var key in order)
+				yield return new KeyValuePair<string, PObject> (key, dict[key]);
+		}
+		#endregion
+
+		#region IEnumerable implementation
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return GetEnumerator ();
+		}
+		#endregion
+
+		public PDictionary ()
+		{
+			dict = new Dictionary<string, PObject> ();
+			order = new List<string> ();
+		}
+
+		public override PObject Clone ()
+		{
+			var dict = new PDictionary ();
+			foreach (var kv in this)
+				dict.Add (kv.Key, kv.Value.Clone ());
+			return dict;
+		}
+
+		public bool ContainsKey (string name)
+		{
+			return dict.ContainsKey (name);
+		}
+
+		public bool Remove (string key)
+		{
+			PObject obj;
+			if (dict.TryGetValue (key, out obj)) {
+				dict.Remove (key);
+				order.Remove (key);
+				OnChildRemoved (key, obj);
+				return true;
+			}
+			return false;
+		}
+
+		public void Clear ()
+		{
+			dict.Clear ();
+			order.Clear ();
+			OnCleared ();
+		}
+
+		public bool ChangeKey (PObject obj, string newKey)
+		{
+			return ChangeKey (obj, newKey, null);
+		}
+
+		public bool ChangeKey (PObject obj, string newKey, PObject newValue)
+		{
+			var oldkey = GetKey (obj);
+			if (oldkey == null || dict.ContainsKey (newKey))
+				return false;
+
+			dict.Remove (oldkey);
+			dict.Add (newKey, newValue ?? obj);
+			order[order.IndexOf (oldkey)] = newKey;
+			if (newValue != null) {
+				OnChildRemoved (oldkey, obj);
+				OnChildAdded (newKey, newValue);
+			} else {
+				OnChildRemoved (oldkey, obj);
+				OnChildAdded (newKey, obj);
+			}
+			return true;
+		}
+
+		public string GetKey (PObject obj)
+		{
+			foreach (var pair in dict) {
+				if (pair.Value == obj)
+					return pair.Key;
+			}
+			return null;
+		}
+
+		public T Get<T> (string key) where T : PObject
+		{
+			PObject obj;
+
+			if (!dict.TryGetValue (key, out obj))
+				return null;
+
+			return obj as T;
+		}
+
+		public bool TryGetValue<T> (string key, out T value) where T : PObject
+		{
+			PObject obj;
+
+			if (!dict.TryGetValue (key, out obj)) {
+				value = default (T);
+				return false;
+			}
+
+			value = obj as T;
+
+			return value != null;
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			List<NSObject> objs = new List<NSObject> ();
+			List<NSObject> keys = new List<NSObject> ();
+			
+			foreach (var key in order) {
+				var val = dict[key].Convert ();
+				objs.Add (val);
+				keys.Add (new NSString (key));
+			}
+			return NSDictionary.FromObjectsAndKeys (objs.ToArray (), keys.ToArray ());
+		}
+		#endif
+
+		static int IndexOf (byte[] haystack, int startIndex, byte[] needle)
+		{
+			int maxLength = haystack.Length - needle.Length;
+			int n;
+
+			for (int i = startIndex; i < maxLength; i++) {
+				for (n = 0; n < needle.Length; n++) {
+					if (haystack[i+n] != needle[n])
+						break;
+				}
+
+				if (n == needle.Length)
+					return i;
+			}
+
+			return -1;
+		}
+
+		public static new PDictionary FromByteArray (byte[] array, int startIndex, int length, out bool isBinary)
+		{
+			return (PDictionary) PObject.FromByteArray (array, startIndex, length, out isBinary);
+		}
+
+		public static new PDictionary FromByteArray (byte[] array, out bool isBinary)
+		{
+			return (PDictionary) PObject.FromByteArray (array, out isBinary);
+		}
+
+		public static PDictionary FromBinaryXml (byte[] array)
+		{
+			//find the raw plist within the .mobileprovision file
+			int start = IndexOf (array, 0, BeginMarkerBytes);
+			bool binary;
+			int length;
+
+			if (start < 0 || (length = (IndexOf (array, start, EndMarkerBytes) - start)) < 1)
+				throw new Exception ("Did not find XML plist in buffer.");
+
+			length += EndMarkerBytes.Length;
+
+			return PDictionary.FromByteArray (array, start, length, out binary);
+		}
+
+		[Obsolete ("Use FromFile")]
+		public static PDictionary Load (string fileName)
+		{
+			bool isBinary;
+			return FromFile (fileName, out isBinary);
+		}
+
+		public static PDictionary FromFile (string fileName)
+		{
+			bool isBinary;
+			return FromFile (fileName, out isBinary);
+		}
+
+		public static Task<PDictionary> FromFileAsync (string fileName)
+		{
+			return Task<PDictionary>.Factory.StartNew (() => {
+				bool isBinary;
+				return FromFile (fileName, out isBinary);
+			});
+		}
+
+		public static PDictionary FromFile (string fileName, out bool isBinary)
+		{
+			using (var stream = new FileStream (fileName, FileMode.Open, FileAccess.Read)) {
+				isBinary = true;
+				var ctx = PropertyListFormat.Binary.StartReading (stream);
+				try {
+					if (ctx == null) {
+						isBinary = false;
+						ctx = PropertyListFormat.CreateReadContext (stream);
+						if (ctx == null)
+							throw new FormatException ("Unrecognized property list format.");
+					}
+					return (PDictionary)ctx.ReadObject ();
+				} finally {
+					if (ctx != null)
+						ctx.Dispose ();
+				}
+			}
+		}
+
+		public static PDictionary FromBinaryXml (string fileName)
+		{
+			return FromBinaryXml (File.ReadAllBytes (fileName));
+		}
+
+		protected override bool Reload (PropertyListFormat.ReadWriteContext ctx)
+		{
+			SuppressChangeEvents = true;
+			var result = ctx.ReadDict (this);
+			SuppressChangeEvents = false;
+			if (result)
+				OnChanged (EventArgs.Empty);
+			return result;
+		}
+
+		public override string ToString ()
+		{
+			return string.Format ("[PDictionary: Items={0}]", dict.Count);
+		}
+
+		public void SetString (string key, string value)
+		{
+			var result = Get<PString> (key);
+
+			if (result == null)
+				this[key] = new PString (value);
+			else
+				result.Value = value;
+		}
+
+		public PString GetString (string key)
+		{
+			var result = Get<PString> (key);
+
+			if (result == null)
+				this[key] = result = new PString ("");
+
+			return result;
+		}
+
+		public PArray GetArray (string key)
+		{
+			var result = Get<PArray> (key);
+
+			if (result == null)
+				this[key] = result = new PArray ();
+
+			return result;
+		}
+
+		public override PObjectType Type {
+			get { return PObjectType.Dictionary; }
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PArray : PObjectContainer, IEnumerable<PObject>
+	{
+		List<PObject> list;
+
+		public override int Count {
+			get { return list.Count; }
+		}
+
+		public PObject this[int i] {
+			get {
+				return list[i];
+			}
+			set {
+				if (i < 0 || i >= Count)
+					throw new ArgumentOutOfRangeException ();
+				var existing = list[i];
+				list[i] = value;
+
+				OnChildReplaced (null, existing, value);
+			}
+		}
+
+		public PArray ()
+		{
+			list = new List<PObject> ();
+		}
+
+		public override PObject Clone ()
+		{
+			var array = new PArray ();
+			foreach (var item in this)
+				array.Add (item.Clone ());
+			return array;
+		}
+
+		protected override bool Reload (PropertyListFormat.ReadWriteContext ctx)
+		{
+			SuppressChangeEvents = true;
+			var result = ctx.ReadArray (this);
+			SuppressChangeEvents = false;
+			if (result)
+				OnChanged (EventArgs.Empty);
+			return result;
+		}
+
+		public void Add (PObject obj)
+		{
+			list.Add (obj);
+			OnChildAdded (null, obj);
+		}
+
+		public void Insert (int index, PObject obj)
+		{
+			list.Insert (index, obj);
+			OnChildAdded (null, obj);
+		}
+
+		public void Replace (PObject oldObj, PObject newObject)
+		{
+			for (int i = 0; i < Count; i++) {
+				if (list[i] == oldObj) {
+					list[i] = newObject;
+					OnChildReplaced (null, oldObj, newObject);
+					break;
+				}
+			}
+		}
+
+		public void Remove (PObject obj)
+		{
+			if (list.Remove (obj))
+				OnChildRemoved (null, obj);
+		}
+
+		public void Clear ()
+		{
+			list.Clear ();
+			OnCleared ();
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return NSArray.FromNSObjects (list.Select (x => x.Convert ()).ToArray ());
+		}
+		#endif
+
+		public override string ToString ()
+		{
+			return string.Format ("[PArray: Items={0}]", Count);
+		}
+
+		public void AssignStringList (string strList)
+		{
+			SuppressChangeEvents = true;
+			try {
+				Clear ();
+				foreach (var item in strList.Split (',', ' ')) {
+					if (string.IsNullOrEmpty (item))
+						continue;
+					Add (new PString (item));
+				}
+			} finally {
+				SuppressChangeEvents = false;
+				OnChanged (EventArgs.Empty);
+			}
+		}
+
+		public string[] ToStringArray ()
+		{
+			var strlist = new List<string> ();
+
+			foreach (PString str in list.OfType<PString> ())
+				strlist.Add (str.Value);
+
+			return strlist.ToArray ();
+		}
+
+		public string ToStringList ()
+		{
+			var sb = new StringBuilder ();
+			foreach (PString str in list.OfType<PString> ()) {
+				if (sb.Length > 0)
+					sb.Append (", ");
+				sb.Append (str);
+			}
+			return sb.ToString ();
+		}
+
+		public IEnumerator<PObject> GetEnumerator ()
+		{
+			return list.GetEnumerator ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			return list.GetEnumerator ();
+		}
+
+		public override PObjectType Type {
+			get { return PObjectType.Array; }
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PBoolean : PValueObject<bool>
+	{
+		public PBoolean (bool value) : base(value)
+		{
+		}
+
+		public override PObject Clone ()
+		{
+			return new PBoolean (Value);
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return NSNumber.FromBoolean (Value);
+		}
+		#endif
+
+		public override PObjectType Type {
+			get { return PObjectType.Boolean; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			const StringComparison ic = StringComparison.OrdinalIgnoreCase;
+
+			if ("true".Equals (text, ic) || "yes".Equals (text, ic)) {
+				Value = true;
+				return true;
+			}
+
+			if ("false".Equals (text, ic) || "no".Equals (text, ic)) {
+				Value = false;
+				return true;
+			}
+
+			return false;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PData : PValueObject<byte[]>
+	{
+		static readonly byte[] Empty = new byte [0];
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			// Work around a bug in NSData.FromArray as it cannot (currently) handle
+			// zero length arrays
+			if (Value.Length == 0)
+				return new NSData ();
+			else
+				return NSData.FromArray (Value);
+		}
+		#endif
+
+		public PData (byte[] value) : base(value ?? Empty)
+		{
+		}
+
+		public override PObject Clone ()
+		{
+			return new PData (Value);
+		}
+
+		public override PObjectType Type {
+			get { return PObjectType.Data; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			return false;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PDate : PValueObject<DateTime>
+	{
+		public PDate (DateTime value) : base(value)
+		{
+		}
+
+		public override PObject Clone ()
+		{
+			return new PDate (Value);
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return (NSDate) Value;
+		}
+		#endif
+
+		public override PObjectType Type {
+			get { return PObjectType.Date; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			DateTime result;
+			if (DateTime.TryParse (text, formatProvider, DateTimeStyles.None, out result)) {
+				Value = result;
+				return true;
+			}
+			return false;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PNumber : PValueObject<int>
+	{
+		public PNumber (int value) : base(value)
+		{
+		}
+
+		public override PObject Clone ()
+		{
+			return new PNumber (Value);
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return NSNumber.FromInt32 (Value);
+		}
+		#endif
+
+		public override PObjectType Type {
+			get { return PObjectType.Number; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			int result;
+			if (int.TryParse (text, NumberStyles.Integer, formatProvider, out result)) {
+				Value = result;
+				return true;
+			}
+			return false;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PReal : PValueObject<double>
+	{
+		public PReal (double value) : base(value)
+		{
+		}
+
+		public override PObject Clone ()
+		{
+			return new PReal (Value);
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return NSNumber.FromDouble (Value);
+		}
+#endif
+
+		public override PObjectType Type {
+			get { return PObjectType.Real; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			double result;
+			if (double.TryParse (text, NumberStyles.AllowDecimalPoint, formatProvider, out result)) {
+				Value = result;
+				return true;
+			}
+			return false;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	class PString : PValueObject<string>
+	{
+		public PString (string value) : base(value)
+		{
+			if (value == null)
+				throw new ArgumentNullException ("value");
+		}
+
+		public override PObject Clone ()
+		{
+			return new PString (Value);
+		}
+
+		#if POBJECT_MONOMAC
+				public override NSObject Convert ()
+		{
+			return new NSString (Value);
+		}
+		#endif
+
+		public override PObjectType Type {
+			get { return PObjectType.String; }
+		}
+
+		public override bool TrySetValueFromString (string text, IFormatProvider formatProvider)
+		{
+			Value = text;
+			return true;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	abstract class PropertyListFormat
+	{
+		public static readonly PropertyListFormat Xml = new XmlFormat ();
+		public static readonly PropertyListFormat Binary = new BinaryFormat ();
+
+		// Stream must be seekable
+		public static ReadWriteContext CreateReadContext (Stream input)
+		{
+			return Binary.StartReading (input) ?? Xml.StartReading (input);
+		}
+
+		public static ReadWriteContext CreateReadContext (byte[] array, int startIndex, int length)
+		{
+			return CreateReadContext (new MemoryStream (array, startIndex, length));
+		}
+
+		public static ReadWriteContext CreateReadContext (byte[] array)
+		{
+			return CreateReadContext (new MemoryStream (array, 0, array.Length));
+		}
+
+		// returns null if the input is not of the correct format. Stream must be seekable
+		public abstract ReadWriteContext StartReading (Stream input);
+		public abstract ReadWriteContext StartWriting (Stream output);
+
+		public ReadWriteContext StartReading (byte[] array, int startIndex, int length)
+		{
+			return StartReading (new MemoryStream (array, startIndex, length));
+		}
+
+		public ReadWriteContext StartReading (byte[] array)
+		{
+			return StartReading (new MemoryStream (array, 0, array.Length));
+		}
+
+		class BinaryFormat : PropertyListFormat
+		{
+			// magic is bplist + 2 byte version id
+			static readonly byte[] BPLIST_MAGIC   = { 0x62, 0x70, 0x6C, 0x69, 0x73, 0x74 };  // "bplist"
+			static readonly byte[] BPLIST_VERSION = { 0x30, 0x30 }; // "00"
+
+			public override ReadWriteContext StartReading (Stream input)
+			{
+				if (input.Length < BPLIST_MAGIC.Length + 2)
+					return null;
+
+				input.Seek (0, SeekOrigin.Begin);
+				for (var i = 0; i < BPLIST_MAGIC.Length; i++) {
+					if ((byte)input.ReadByte () != BPLIST_MAGIC [i])
+						return null;
+				}
+
+				// skip past the 2 byte version id for now
+				//  we currently don't bother checking it because it seems different versions of OSX might write different values here?
+				input.Seek (2, SeekOrigin.Current);
+				return new Context (input, true);
+			}
+
+			public override ReadWriteContext StartWriting (Stream output)
+			{
+				output.Write (BPLIST_MAGIC, 0, BPLIST_MAGIC.Length);
+				output.Write (BPLIST_VERSION, 0, BPLIST_VERSION.Length);
+
+				return new Context (output, false);
+			}
+
+			class Context : ReadWriteContext {
+
+				static readonly DateTime AppleEpoch = new DateTime (2001, 1, 1, 0, 0, 0, DateTimeKind.Utc); //see CFDateGetAbsoluteTime
+
+				//https://github.com/mono/referencesource/blob/mono/mscorlib/system/datetime.cs
+				const long TicksPerMillisecond = 10000;
+				const long TicksPerSecond = TicksPerMillisecond * 1000;
+
+				Stream stream;
+				int currentLength;
+
+				CFBinaryPlistTrailer trailer;
+
+				//for writing
+				List<object> objectRefs;
+				int currentRef;
+				long[] offsets;
+
+				public Context (Stream stream, bool reading)
+				{
+					this.stream = stream;
+					if (reading) {
+						trailer = CFBinaryPlistTrailer.Read (this);
+						ReadObjectHead ();
+					}
+				}
+
+				#region Binary reading members
+				protected override bool ReadBool ()
+				{
+					return CurrentType == PlistType.@true;
+				}
+
+				protected override void ReadObjectHead ()
+				{
+					var b = stream.ReadByte ();
+					var len = 0L;
+					var type = (PlistType)(b & 0xF0);
+					if (type == PlistType.@null) {
+						type = (PlistType)b;
+					} else {
+						len = b & 0x0F;
+						if (len == 0xF) {
+							ReadObjectHead ();
+							len = ReadInteger ();
+						}
+					}
+					CurrentType = type;
+					currentLength = (int)len;
+				}
+
+				protected override long ReadInteger ()
+				{
+					switch (CurrentType) {
+						case PlistType.integer:
+						return ReadBigEndianInteger ((int)Math.Pow (2, currentLength));
+					}
+
+					throw new NotSupportedException ("Integer of type: " + CurrentType);
+				}
+
+				protected override double ReadReal ()
+				{
+					var bytes = ReadBigEndianBytes ((int)Math.Pow (2, currentLength));
+					switch (CurrentType) {
+						case PlistType.real:
+						switch (bytes.Length) {
+							case 4:
+							return (double)BitConverter.ToSingle (bytes, 0);
+							case 8:
+							return BitConverter.ToDouble (bytes, 0);
+						}
+						throw new NotSupportedException (bytes.Length + "-byte real");
+					}
+
+					throw new NotSupportedException ("Real of type: " + CurrentType);
+				}
+
+				protected override DateTime ReadDate ()
+				{
+					var bytes = ReadBigEndianBytes (8);
+					var seconds = BitConverter.ToDouble (bytes, 0);
+					// We need to manually convert the seconds to ticks because
+					//  .NET DateTime/TimeSpan methods dealing with (milli)seconds
+					//  round to the nearest millisecond (bxc #29079)
+					return AppleEpoch.AddTicks ((long)(seconds * TicksPerSecond));
+				}
+
+				protected override byte[] ReadData ()
+				{
+					var bytes = new byte [currentLength];
+					stream.Read (bytes, 0, currentLength);
+					return bytes;
+				}
+
+				protected override string ReadString ()
+				{
+					byte[] bytes;
+					switch (CurrentType) {
+						case PlistType.@string: // ASCII
+						bytes = new byte [currentLength];
+						stream.Read (bytes, 0, bytes.Length);
+						return Encoding.ASCII.GetString (bytes);
+						case PlistType.wideString: //CFBinaryPList.c: Unicode string...big-endian 2-byte uint16_t
+						bytes = new byte [currentLength * 2];
+						stream.Read (bytes, 0, bytes.Length);
+						return Encoding.BigEndianUnicode.GetString (bytes);
+					}
+
+					throw new NotSupportedException ("String of type: " + CurrentType);
+				}
+
+				public override bool ReadArray (PArray array)
+				{
+					if (CurrentType != PlistType.array)
+						return false;
+
+					array.Clear ();
+
+					// save currentLength as it will be overwritten by next ReadObjectHead call
+					var len = currentLength;
+					for (var i = 0; i < len; i++) {
+						var obj = ReadObjectByRef ();
+						if (obj != null)
+							array.Add (obj);
+					}
+
+					return true;
+				}
+
+				public override bool ReadDict (PDictionary dict)
+				{
+					if (CurrentType != PlistType.dict)
+						return false;
+
+					dict.Clear ();
+
+					// save currentLength as it will be overwritten by next ReadObjectHead call
+					var len = currentLength;
+					var keys = new string [len];
+					for (var i = 0; i < len; i++)
+						keys [i] = ((PString)ReadObjectByRef ()).Value;
+					for (var i = 0; i < len; i++)
+						dict.Add (keys [i], ReadObjectByRef ());
+
+					return true;
+				}
+
+				PObject ReadObjectByRef ()
+				{
+					// read index into offset table
+					var objRef = (long)ReadBigEndianUInteger (trailer.ObjectRefSize);
+
+					// read offset in file from table
+					var lastPos = stream.Position;
+					stream.Seek (trailer.OffsetTableOffset + objRef * trailer.OffsetEntrySize, SeekOrigin.Begin);
+					stream.Seek ((long)ReadBigEndianUInteger (trailer.OffsetEntrySize), SeekOrigin.Begin);
+
+					ReadObjectHead ();
+					var obj = ReadObject ();
+
+					// restore original position
+					stream.Seek (lastPos, SeekOrigin.Begin);
+					return obj;
+				}
+
+				byte[] ReadBigEndianBytes (int count)
+				{
+					var bytes = new byte [count];
+					stream.Read (bytes, 0, count);
+					if (BitConverter.IsLittleEndian)
+						Array.Reverse (bytes);
+					return bytes;
+				}
+
+				long ReadBigEndianInteger (int numBytes)
+				{
+					var bytes = ReadBigEndianBytes (numBytes);
+					switch (numBytes) {
+						case 1:
+						return (long)bytes [0];
+						case 2:
+						return (long)BitConverter.ToInt16 (bytes, 0);
+						case 4:
+						return (long)BitConverter.ToInt32 (bytes, 0);
+						case 8:
+						return BitConverter.ToInt64 (bytes, 0);
+					}
+					throw new NotSupportedException (bytes.Length + "-byte integer");
+				}
+
+				ulong ReadBigEndianUInteger (int numBytes)
+				{
+					var bytes = ReadBigEndianBytes (numBytes);
+					switch (numBytes) {
+						case 1:
+						return (ulong)bytes [0];
+						case 2:
+						return (ulong)BitConverter.ToUInt16 (bytes, 0);
+						case 4:
+						return (ulong)BitConverter.ToUInt32 (bytes, 0);
+						case 8:
+						return BitConverter.ToUInt64 (bytes, 0);
+					}
+					throw new NotSupportedException (bytes.Length + "-byte integer");
+				}
+
+				ulong ReadBigEndianUInt64 ()
+				{
+					var bytes = ReadBigEndianBytes (8);
+					return BitConverter.ToUInt64 (bytes, 0);
+				}
+				#endregion
+
+				#region Binary writing members
+				public override void WriteObject (PObject value)
+				{
+					if (offsets == null)
+						InitOffsetTable (value);
+					base.WriteObject (value);
+				}
+
+				protected override void Write (PBoolean boolean)
+				{
+					WriteObjectHead (boolean, boolean? PlistType.@true : PlistType.@false);
+				}
+
+				protected override void Write (PNumber number)
+				{
+					if (WriteObjectHead (number, PlistType.integer))
+						Write (number.Value);
+				}
+
+				protected override void Write (PReal real)
+				{
+					if (WriteObjectHead (real, PlistType.real))
+						Write (real.Value);
+				}
+
+				protected override void Write (PDate date)
+				{
+					if (WriteObjectHead (date, PlistType.date)) {
+						var bytes = MakeBigEndian (BitConverter.GetBytes (date.Value.Subtract (AppleEpoch).TotalSeconds));
+						stream.Write (bytes, 0, bytes.Length);
+					}
+				}
+
+				protected override void Write (PData data)
+				{
+					var bytes = data.Value;
+					if (WriteObjectHead (data, PlistType.data, bytes.Length))
+						stream.Write (bytes, 0, bytes.Length);
+				}
+
+				protected override void Write (PString str)
+				{
+					var type = PlistType.@string;
+					byte[] bytes;
+
+					if (str.Value.Any (c => c > 127)) {
+						type  = PlistType.wideString;
+						bytes = Encoding.BigEndianUnicode.GetBytes (str.Value);
+					} else {
+						bytes = Encoding.ASCII.GetBytes (str.Value);
+					}
+
+					if (WriteObjectHead (str, type, str.Value.Length))
+						stream.Write (bytes, 0, bytes.Length);
+				}
+
+				protected override void Write (PArray array)
+				{
+					if (!WriteObjectHead (array, PlistType.array, array.Count))
+						return;
+
+					var curRef = currentRef;
+
+					foreach (var item in array)
+						Write (GetObjRef (item), trailer.ObjectRefSize);
+
+					currentRef = curRef;
+
+					foreach (var item in array)
+						WriteObject (item);
+				}
+
+				protected override void Write (PDictionary dict)
+				{
+					if (!WriteObjectHead (dict, PlistType.dict, dict.Count))
+						return;
+
+					// it's unfortunate we have to loop so many times, but we gotta do it
+					//  if we want to lay things out the same way apple does
+
+					var curRef = currentRef;
+
+					//write key refs
+					foreach (var item in dict)
+						Write (GetObjRef (item.Key), trailer.ObjectRefSize);
+
+					//write value refs
+					foreach (var item in dict)
+						Write (GetObjRef (item.Value), trailer.ObjectRefSize);
+
+					currentRef = curRef;
+
+					//write keys and values
+					foreach (var item in dict)
+						WriteObject (item.Key);
+					foreach (var item in dict)
+						WriteObject (item.Value);
+				}
+
+				bool WriteObjectHead (PObject obj, PlistType type, int size = 0)
+				{
+					var id = GetObjRef (obj);
+					if (offsets [id] != 0) // if we've already been written, don't write us again
+						return false;
+					offsets [id] = stream.Position;
+					switch (type) {
+						case PlistType.@null:
+						case PlistType.@false:
+						case PlistType.@true:
+						case PlistType.fill:
+						stream.WriteByte ((byte)type);
+						break;
+						case PlistType.date:
+						stream.WriteByte (0x33);
+						break;
+						case PlistType.integer:
+						case PlistType.real:
+						break;
+						default:
+						if (size < 15) {
+							stream.WriteByte ((byte)((byte)type | size));
+						} else {
+							stream.WriteByte ((byte)((byte)type | 0xF));
+							Write (size);
+						}
+						break;
+					}
+					return true;
+				}
+
+				void Write (double value)
+				{
+					if (value >= float.MinValue && value <= float.MaxValue) {
+						stream.WriteByte ((byte)PlistType.real | 0x2);
+						var bytes = MakeBigEndian (BitConverter.GetBytes ((float) value));
+						stream.Write (bytes, 0, bytes.Length);
+					} else {
+						stream.WriteByte ((byte)PlistType.real | 0x3);
+						var bytes = MakeBigEndian (BitConverter.GetBytes (value));
+						stream.Write (bytes, 0, bytes.Length);
+					}
+				}
+
+				void Write (int value)
+				{
+					if (value < 0) { //they always write negative numbers with 8 bytes
+						stream.WriteByte ((byte)PlistType.integer | 0x3);
+						var bytes = MakeBigEndian (BitConverter.GetBytes ((long)value));
+						stream.Write (bytes, 0, bytes.Length);
+					} else if (value >= 0 && value < byte.MaxValue) {
+						stream.WriteByte ((byte)PlistType.integer);
+						stream.WriteByte ((byte)value);
+					} else if (value >= short.MinValue && value < short.MaxValue) {
+						stream.WriteByte ((byte)PlistType.integer | 0x1);
+						var bytes = MakeBigEndian (BitConverter.GetBytes ((short)value));
+						stream.Write (bytes, 0, bytes.Length);
+					} else {
+						stream.WriteByte ((byte)PlistType.integer | 0x2);
+						var bytes = MakeBigEndian (BitConverter.GetBytes (value));
+						stream.Write (bytes, 0, bytes.Length);
+					}
+				}
+
+				void Write (long value, int byteCount)
+				{
+					byte[] bytes;
+					switch (byteCount) {
+						case 1:
+						stream.WriteByte ((byte)value);
+						break;
+						case 2:
+						bytes = MakeBigEndian (BitConverter.GetBytes ((short)value));
+						stream.Write (bytes, 0, bytes.Length);
+						break;
+						case 4:
+						bytes = MakeBigEndian (BitConverter.GetBytes ((int)value));
+						stream.Write (bytes, 0, bytes.Length);
+						break;
+						case 8:
+						bytes = MakeBigEndian (BitConverter.GetBytes (value));
+						stream.Write (bytes, 0, bytes.Length);
+						break;
+						default:
+						throw new NotSupportedException (byteCount.ToString () + "-byte integer");
+					}
+				}
+
+				void InitOffsetTable (PObject topLevel)
+				{
+					objectRefs = new List<object> ();
+
+					var count = 0;
+					MakeObjectRefs (topLevel, ref count);
+					trailer.ObjectRefSize = GetMinByteLength (count);
+					offsets = new long [count];
+				}
+
+				void MakeObjectRefs (object obj, ref int count)
+				{
+					if (obj == null)
+						return;
+
+					if (ShouldDuplicate (obj) || !objectRefs.Any (val => PObjectEqualityComparer.Instance.Equals (val, obj))) {
+						objectRefs.Add (obj);
+						count++;
+					}
+
+					// for containers, also count their contents
+					var pobj = obj as PObject;
+					if (pobj != null) {
+						switch (pobj.Type) {
+
+							case PObjectType.Array:
+							foreach (var child in (PArray)obj)
+								MakeObjectRefs (child, ref count);
+							break;
+							case PObjectType.Dictionary:
+							foreach (var child in (PDictionary)obj)
+								MakeObjectRefs (child.Key, ref count);
+							foreach (var child in (PDictionary)obj)
+								MakeObjectRefs (child.Value, ref count);
+							break;
+						}
+					}
+				}
+
+				static bool ShouldDuplicate (object obj)
+				{
+					var pobj = obj as PObject;
+					if (pobj == null)
+						return false;
+
+					return pobj.Type == PObjectType.Boolean || pobj.Type == PObjectType.Array || pobj.Type == PObjectType.Dictionary ||
+						       (pobj.Type == PObjectType.String && ((PString)pobj).Value.Any (c => c > 255)); // this is weird. Some things are duplicated
+				}
+
+				int GetObjRef (object obj)
+				{
+					if (currentRef < objectRefs.Count && PObjectEqualityComparer.Instance.Equals (objectRefs [currentRef], obj))
+						return currentRef++;
+
+					return objectRefs.FindIndex (val => PObjectEqualityComparer.Instance.Equals (val, obj));
+				}
+
+				static int GetMinByteLength (long value)
+				{
+					if (value >= 0 && value < byte.MaxValue)
+						return 1;
+					if (value >= short.MinValue && value < short.MaxValue)
+						return 2;
+					if (value >= int.MinValue && value < int.MaxValue)
+						return 4;
+					return 8;
+				}
+
+				static byte[] MakeBigEndian (byte[] bytes)
+				{
+					if (BitConverter.IsLittleEndian)
+						Array.Reverse (bytes);
+					return bytes;
+				}
+				#endregion
+
+				public override void Dispose ()
+				{
+					if (offsets != null) {
+						trailer.OffsetTableOffset = stream.Position;
+						trailer.OffsetEntrySize = GetMinByteLength (trailer.OffsetTableOffset);
+						foreach (var offset in offsets)
+							Write (offset, trailer.OffsetEntrySize);
+
+						// seems like they always add 6 extra bytes here. not sure why
+						for (var i = 0; i < 6; i++)
+							stream.WriteByte ((byte)0);
+
+						trailer.Write (this);
+					}
+				}
+
+				class PObjectEqualityComparer : IEqualityComparer<object>
+				{
+					public static readonly PObjectEqualityComparer Instance = new PObjectEqualityComparer ();
+
+					PObjectEqualityComparer ()
+					{
+					}
+
+					public new bool Equals (object x, object y)
+					{
+						var vx = x as IPValueObject;
+						var vy = y as IPValueObject;
+
+						if (vx == null && vy == null)
+							return EqualityComparer<object>.Default.Equals (x, y);
+
+						if (vx == null && x != null && vy.Value != null)
+							return vy.Value.Equals (x);
+
+						if (vy == null && y != null && vx.Value != null)
+							return vx.Value.Equals (y);
+
+						if (vx == null || vy == null)
+							return false;
+
+						return vx.Value.Equals (vy.Value);
+					}
+
+					public int GetHashCode (object obj)
+					{
+						var valueObj = obj as IPValueObject;
+						if (valueObj != null)
+							return valueObj.Value.GetHashCode ();
+						return obj.GetHashCode ();
+					}
+				}
+
+				struct CFBinaryPlistTrailer
+				{
+					const int TRAILER_SIZE = 26;
+
+					public int OffsetEntrySize;
+					public int ObjectRefSize;
+					public long ObjectCount;
+					public long TopLevelRef;
+					public long OffsetTableOffset;
+
+					public static CFBinaryPlistTrailer Read (Context ctx)
+					{
+						var pos = ctx.stream.Position;
+						ctx.stream.Seek (-TRAILER_SIZE, SeekOrigin.End);
+						var result = new CFBinaryPlistTrailer {
+							OffsetEntrySize = ctx.stream.ReadByte (),
+							ObjectRefSize = ctx.stream.ReadByte (),
+							ObjectCount = (long)ctx.ReadBigEndianUInt64 (),
+							TopLevelRef = (long)ctx.ReadBigEndianUInt64 (),
+							OffsetTableOffset = (long)ctx.ReadBigEndianUInt64 ()
+						};
+						ctx.stream.Seek (pos, SeekOrigin.Begin);
+						return result;
+					}
+
+					public void Write (Context ctx)
+					{
+						byte[] bytes;
+						ctx.stream.WriteByte ((byte)OffsetEntrySize);
+						ctx.stream.WriteByte ((byte)ObjectRefSize);
+						// apple's comments say this is the number of entries in the offset table, but this really *is* number of objects??!?!
+						bytes = MakeBigEndian (BitConverter.GetBytes ((long)ctx.objectRefs.Count));
+						ctx.stream.Write (bytes, 0, bytes.Length);
+						bytes = new byte [8]; //top level always at offset 0
+						ctx.stream.Write (bytes, 0, bytes.Length);
+						bytes = MakeBigEndian (BitConverter.GetBytes (OffsetTableOffset));
+						ctx.stream.Write (bytes, 0, bytes.Length);
+					}
+				}
+			}
+		}
+
+		// Adapted from:
+		//https://github.com/mono/monodevelop/blob/07d9e6c07e5be8fe1d8d6f4272d3969bb087a287/main/src/addins/MonoDevelop.MacDev/MonoDevelop.MacDev.Plist/PlistDocument.cs
+		class XmlFormat : PropertyListFormat
+		{
+			const string PLIST_HEADER = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+";
+			static readonly Encoding outputEncoding = new UTF8Encoding (false, false);
+
+			public override ReadWriteContext StartReading (Stream input)
+			{ 
+				//allow DTD but not try to resolve it from web
+				var settings = new XmlReaderSettings () {
+					CloseInput = true,
+					DtdProcessing = DtdProcessing.Ignore,
+					XmlResolver = null,
+				};
+
+				XmlReader reader = null;
+				input.Seek (0, SeekOrigin.Begin);
+				try {
+					reader = XmlReader.Create (input, settings);
+					reader.ReadToDescendant ("plist");
+					while (reader.Read () && reader.NodeType != XmlNodeType.Element)
+						;
+				} catch (Exception ex) {
+					Console.WriteLine ("Exception: {0}", ex);
+				}
+
+				if (reader == null || reader.EOF)
+					return null;
+
+				return new Context (reader);
+			}
+
+			public override ReadWriteContext StartWriting (Stream output)
+			{
+				var writer = new StreamWriter (output, outputEncoding);
+				writer.Write (PLIST_HEADER);
+
+				return new Context (writer);
+			}
+
+			class Context : ReadWriteContext
+			{
+				const string DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssK";
+
+				XmlReader reader;
+				TextWriter writer;
+
+				int indentLevel;
+				string indentString;
+
+				public Context (XmlReader reader)
+				{
+					this.reader = reader;
+					ReadObjectHead ();
+				}
+				public Context (TextWriter writer)
+				{
+					this.writer = writer;
+					indentString = "";
+				}
+
+				#region XML reading members
+				protected override void ReadObjectHead ()
+				{
+					try {
+						CurrentType = (PlistType) Enum.Parse (typeof (PlistType), reader.LocalName);
+					} catch (Exception ex) {
+						throw new ArgumentException (string.Format ("Failed to parse PList data type: {0}", reader.LocalName), ex);
+					}
+				}
+
+				protected override bool ReadBool ()
+				{
+					// Create the PBoolean object, then move to the xml reader to next node
+					// so we are ready to parse the next object. 'bool' types don't have
+					// content so we have to move the reader manually, unlike integers which
+					// implicitly move to the next node because we parse the content.
+					var result = CurrentType == PlistType.@true;
+					reader.Read ();
+					return result;
+				}
+
+				protected override long ReadInteger ()
+				{
+					return reader.ReadElementContentAsLong ();
+				}
+
+				protected override double ReadReal ()
+				{
+					return reader.ReadElementContentAsDouble ();
+				}
+
+				protected override DateTime ReadDate ()
+				{
+					return DateTime.ParseExact (reader.ReadElementContentAsString (), DATETIME_FORMAT, CultureInfo.InvariantCulture).ToUniversalTime ();
+				}
+
+				protected override byte[] ReadData ()
+				{
+					return Convert.FromBase64String (reader.ReadElementContentAsString ());
+				}
+
+				protected override string ReadString ()
+				{
+					return reader.ReadElementContentAsString ();
+				}
+
+				public override bool ReadArray (PArray array)
+				{
+					if (CurrentType != PlistType.array)
+						return false;
+
+					array.Clear ();
+
+					if (reader.IsEmptyElement) {
+						reader.Read ();
+						return true;
+					}
+
+					// advance to first node
+					reader.ReadStartElement ();
+					while (!reader.EOF && reader.NodeType != XmlNodeType.Element && reader.NodeType != XmlNodeType.EndElement) {
+						if (!reader.Read ())
+							break;
+					}
+
+					while (!reader.EOF && reader.NodeType != XmlNodeType.EndElement) {
+						if (reader.NodeType == XmlNodeType.Element) {
+							ReadObjectHead ();
+
+							var val = ReadObject ();
+							if (val != null)
+								array.Add (val);
+						} else if (!reader.Read ()) {
+							break;
+						}
+					}
+
+					if (!reader.EOF && reader.NodeType == XmlNodeType.EndElement && reader.Name == "array") {
+						reader.ReadEndElement ();
+						return true;
+					}
+
+					return false;
+				}
+
+				public override bool ReadDict (PDictionary dict)
+				{
+					if (CurrentType != PlistType.dict)
+						return false;
+
+					dict.Clear ();
+
+					if (reader.IsEmptyElement) {
+						reader.Read ();
+						return true;
+					}
+
+					reader.ReadToDescendant ("key");
+
+					while (!reader.EOF && reader.NodeType == XmlNodeType.Element) {
+						var key = reader.ReadElementString ();
+
+						while (!reader.EOF && reader.NodeType != XmlNodeType.Element && reader.Read ()) {
+							if (reader.NodeType == XmlNodeType.EndElement)
+								throw new FormatException (string.Format ("No value found for key {0}", key));
+						}
+
+						ReadObjectHead ();
+						var result = ReadObject ();
+						if (result != null)
+							dict.Add (key, result);
+
+						do {
+							if (reader.NodeType == XmlNodeType.Element && reader.Name == "key")
+								break;
+
+							if (reader.NodeType == XmlNodeType.EndElement)
+								break;
+						} while (reader.Read ());
+					}
+
+					if (!reader.EOF && reader.NodeType == XmlNodeType.EndElement && reader.Name == "dict") {
+						reader.ReadEndElement ();
+						return true;
+					}
+
+					return false;
+				}
+				#endregion
+
+				#region XML writing members
+				protected override void Write (PBoolean boolean)
+				{
+					WriteLine (boolean.Value? "<true/>" : "<false/>");
+				}
+
+				protected override void Write (PNumber number)
+				{
+					WriteLine ("<integer>" + SecurityElement.Escape (number.Value.ToString (CultureInfo.InvariantCulture)) + "</integer>");
+				}
+
+				protected override void Write (PReal real)
+				{
+					WriteLine ("<real>" + SecurityElement.Escape (real.Value.ToString (CultureInfo.InvariantCulture)) + "</real>");
+				}
+
+				protected override void Write (PDate date)
+				{
+					WriteLine ("<date>" + SecurityElement.Escape (date.Value.ToString (DATETIME_FORMAT, CultureInfo.InvariantCulture)) + "</date>");
+				}
+
+				protected override void Write (PData data)
+				{
+					WriteLine ("<data>" + SecurityElement.Escape (Convert.ToBase64String (data.Value)) + "</data>");
+				}
+
+				protected override void Write (PString str)
+				{
+					WriteLine ("<string>" + SecurityElement.Escape (str.Value) + "</string>");
+				}
+
+				protected override void Write (PArray array)
+				{
+					if (array.Count == 0) {
+						WriteLine ("<array/>");
+						return;
+					}
+
+					WriteLine ("<array>");
+					IncreaseIndent ();
+
+					foreach (var item in array)
+						WriteObject (item);
+
+					DecreaseIndent ();
+					WriteLine ("</array>");
+				}
+
+				protected override void Write (PDictionary dict)
+				{
+					if (dict.Count == 0) {
+						WriteLine ("<dict/>");
+						return;
+					}
+
+					WriteLine ("<dict>");
+					IncreaseIndent ();
+
+					foreach (var kv in dict) {
+						WriteLine ("<key>" + SecurityElement.Escape (kv.Key) + "</key>");
+						WriteObject (kv.Value);
+					}
+
+					DecreaseIndent ();
+					WriteLine ("</dict>");
+				}
+
+				void WriteLine (string value)
+				{
+					writer.Write (indentString);
+					writer.Write (value);
+					writer.Write ('\n');
+				}
+
+				void IncreaseIndent ()
+				{
+					indentString = new string ('\t', ++indentLevel);
+				}
+
+				void DecreaseIndent ()
+				{
+					indentString = new string ('\t', --indentLevel);
+				}
+				#endregion
+
+				public override void Dispose ()
+				{
+					if (writer != null) {
+						writer.Write ("</plist>\n");
+						writer.Flush ();
+						writer.Dispose ();
+					}
+				}
+			}
+		}
+
+		public abstract class ReadWriteContext : IDisposable
+		{
+			// Binary: The type is encoded in the 4 high bits; the low bits are data (except: null, true, false)
+			// Xml: The enum value name == element tag name (this actually reads a superset of the format, since null, fill and wideString are not plist xml elements afaik)
+			protected enum PlistType : byte
+			{
+				@null      = 0x00,
+				@false     = 0x08,
+				@true      = 0x09,
+				fill       = 0x0F,
+				integer    = 0x10,
+				real       = 0x20,
+				date       = 0x30,
+				data       = 0x40,
+				@string    = 0x50,
+				wideString = 0x60,
+				array      = 0xA0,
+				dict       = 0xD0,
+			}
+
+			#region Reading members
+			public PObject ReadObject ()
+			{
+				switch (CurrentType) {
+					case PlistType.@true:
+					case PlistType.@false:
+					return new PBoolean (ReadBool ());
+					case PlistType.fill:
+					ReadObjectHead ();
+					return ReadObject ();
+
+					case PlistType.integer:
+					return new PNumber ((int)ReadInteger ()); //FIXME: should PNumber handle 64-bit values? ReadInteger can if necessary
+					case PlistType.real:
+					return new PReal (ReadReal ());    //FIXME: we should probably make PNumber take floating point as well as ints
+
+					case PlistType.date:
+					return new PDate (ReadDate ());
+					case PlistType.data:
+					return new PData (ReadData ());
+
+					case PlistType.@string:
+					case PlistType.wideString:
+					return new PString (ReadString ());
+
+					case PlistType.array:
+					var array = new PArray ();
+					ReadArray (array);
+					return array;
+
+					case PlistType.dict:
+					var dict = new PDictionary ();
+					ReadDict (dict);
+					return dict;
+				}
+				return null;
+			}
+
+			protected abstract void ReadObjectHead ();
+			protected PlistType CurrentType { get; set; }
+
+			protected abstract bool ReadBool ();
+			protected abstract long ReadInteger ();
+			protected abstract double ReadReal ();
+			protected abstract DateTime ReadDate ();
+			protected abstract byte[] ReadData ();
+			protected abstract string ReadString ();
+
+			public abstract bool ReadArray (PArray array);
+			public abstract bool ReadDict (PDictionary dict);
+			#endregion
+
+			#region Writing members
+			public virtual void WriteObject (PObject value)
+			{
+				switch (value.Type) {
+					case PObjectType.Boolean:
+					Write ((PBoolean)value);
+					return;
+					case PObjectType.Number:
+					Write ((PNumber)value);
+					return;
+					case PObjectType.Real:
+					Write ((PReal)value);
+					return;
+					case PObjectType.Date:
+					Write ((PDate)value);
+					return;
+					case PObjectType.Data:
+					Write ((PData)value);
+					return;
+					case PObjectType.String:
+					Write ((PString)value);
+					return;
+					case PObjectType.Array:
+					Write ((PArray)value);
+					return;
+					case PObjectType.Dictionary:
+					Write ((PDictionary)value);
+					return;
+				}
+				throw new NotSupportedException (value.Type.ToString ());
+			}
+
+			protected abstract void Write (PBoolean boolean);
+			protected abstract void Write (PNumber number);
+			protected abstract void Write (PReal real);
+			protected abstract void Write (PDate date);
+			protected abstract void Write (PData data);
+			protected abstract void Write (PString str);
+			protected abstract void Write (PArray array);
+			protected abstract void Write (PDictionary dict);
+			#endregion
+
+			public abstract void Dispose ();
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	enum PObjectContainerAction {
+		Added,
+		Changed,
+		Removed,
+		Replaced,
+		Cleared
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	sealed class PObjectContainerEventArgs : EventArgs
+	{
+		internal PObjectContainerEventArgs (PObjectContainerAction action, string key, PObject oldItem, PObject newItem)
+		{
+			Action = action;
+			Key = key;
+			OldItem = oldItem;
+			NewItem = newItem;
+		}
+
+		public PObjectContainerAction Action {
+			get; private set;
+		}
+
+		public string Key {
+			get; private set;
+		}
+
+		public PObject OldItem {
+			get; private set;
+		}
+
+		public PObject NewItem {
+			get; private set;
+		}
+	}
+
+	#if !POBJECT_INTERNAL
+	public
+	#endif
+	enum PObjectType
+	{
+		Dictionary,
+		Array,
+		Real,
+		Number,
+		Boolean,
+		Data,
+		String,
+		Date
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/PartialZipDownload.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/PartialZipDownload.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace Xamarin.Build.Download
+{
+	public class PartialZipDownload
+	{
+		public string Id { get; set; }
+		public string ToFile { get; set; }
+		public string Url { get; set; }
+		public long RangeStart { get; set; }
+		public long RangeEnd { get; set; }
+		public string Sha256 { get; set; }
+
+		public string CustomErrorMessage { get; set; }
+		public string CustomErrorCode { get; set; }
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Platform.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Platform.cs
@@ -1,0 +1,69 @@
+﻿// 
+// Platform.cs
+// 
+// Copyright (c) 2009 Novell, Inc. (http://www.novell.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Xamarin.Build.Download
+{
+	static class Platform
+	{
+		static Platform ()
+		{
+			IsWindows = System.IO.Path.DirectorySeparatorChar == '\\';
+			IsMac = !IsWindows && IsRunningOnMac();
+			IsX11 = !IsMac && Environment.OSVersion.Platform == PlatformID.Unix;
+		}
+
+		public static bool IsMac { get; private set; }
+		public static bool IsX11 { get; private set; }
+		public static bool IsWindows { get; private set; }
+
+		//From Managed.Windows.Forms/XplatUI
+		static bool IsRunningOnMac ()
+		{
+			IntPtr buf = IntPtr.Zero;
+			try {
+				buf = Marshal.AllocHGlobal (8192);
+				// This is a hacktastic way of getting sysname from uname ()
+				if (uname (buf) == 0) {
+					string os = Marshal.PtrToStringAnsi (buf);
+					if (os == "Darwin")
+						return true;
+				}
+			}
+			#pragma warning disable RECS0022
+			catch
+			#pragma warning restore RECS0022
+			{
+			} finally {
+				if (buf != IntPtr.Zero)
+					Marshal.FreeHGlobal (buf);
+			}
+			return false;
+		}
+
+		[DllImport ("libc")]
+		static extern int uname (IntPtr buf);
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
@@ -1,0 +1,254 @@
+﻿//
+// ProcessArgumentBuilder.cs
+//
+// Copyright (c) 2010 Novell, Inc.
+// Copyright (c) 2011-2016 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Xamarin.MacDev
+{
+	/// <summary>
+	/// Builds a process argument string.
+	/// </summary>
+	class ProcessArgumentBuilder
+	{
+		readonly HashSet<string> hash = new HashSet<string> ();
+		readonly StringBuilder builder = new StringBuilder ();
+
+		public string ProcessPath {
+			get; private set;
+		}
+
+		public ProcessArgumentBuilder ()
+		{
+		}
+
+		public ProcessArgumentBuilder (string processPath)
+		{
+			ProcessPath = processPath;
+		}
+
+		public int Length {
+			get { return builder.Length; }
+		}
+
+		/// <summary>
+		/// Adds an argument without escaping or quoting.
+		/// </summary>
+		public void Add (string argument)
+		{
+			if (builder.Length > 0)
+				builder.Append (' ');
+
+			builder.Append (argument);
+			hash.Add (argument);
+		}
+
+		/// <summary>
+		/// Adds multiple arguments without escaping or quoting.
+		/// </summary>
+		public void Add (params string[] args)
+		{
+			foreach (var a in args)
+				Add (a);
+		}
+
+		/// <summary>
+		/// Adds a formatted argument, quoting and escaping as necessary.
+		/// </summary>
+		public void AddQuotedFormat (string argumentFormat, params object[] values)
+		{
+			AddQuoted (string.Format (argumentFormat, values));
+		}
+
+		public void AddQuotedFormat (string argumentFormat, object val0)
+		{
+			AddQuoted (string.Format (argumentFormat, val0));
+		}
+
+		static void AppendQuoted (StringBuilder quoted, string text)
+		{
+			quoted.Append ("\"");
+			quoted.Append (text);
+			quoted.Append ("\"");
+		}
+
+		/// <summary>Adds an argument, quoting and escaping as necessary.</summary>
+		/// <remarks>The .NET process class does not support escaped
+		/// arguments, only quoted arguments with escaped quotes.</remarks>
+		public void AddQuoted (string argument)
+		{
+			if (argument == null)
+				return;
+
+			if (builder.Length > 0)
+				builder.Append (' ');
+
+			AppendQuoted (builder, argument);
+			hash.Add (argument);
+		}
+
+		/// <summary>
+		/// Adds multiple arguments, quoting and escaping each as necessary.
+		/// </summary>
+		public void AddQuoted (params string[] args)
+		{
+			foreach (var a in args)
+				AddQuoted (a);
+		}
+
+		/// <summary>
+		/// Contains the specified argument.
+		/// </summary>
+		/// <param name="argument">Argument.</param>
+		public bool Contains (string argument)
+		{
+			return hash.Contains (argument);
+		}
+
+		/// <summary>Quotes a string, escaping if necessary.</summary>
+		/// <remarks>The .NET process class does not support escaped
+		/// arguments, only quoted arguments with escaped quotes.</remarks>
+		public static string Quote (string text)
+		{
+			var quoted = new StringBuilder ();
+
+			AppendQuoted (quoted, text);
+
+			return quoted.ToString ();
+		}
+
+		public override string ToString ()
+		{
+			return builder.ToString ();
+		}
+
+		static string GetArgument (StringBuilder builder, string buf, int startIndex, out int endIndex, out Exception ex)
+		{
+			bool escaped = false;
+			char qchar, c = '\0';
+			int i = startIndex;
+
+			builder.Clear ();
+			switch (buf[startIndex]) {
+				case '\'': qchar = '\''; i++; break;
+				case '"': qchar = '"'; i++; break;
+				default: qchar = '\0'; break;
+			}
+
+			while (i < buf.Length) {
+				c = buf[i];
+
+				if (c == qchar && !escaped) {
+					// unescaped qchar means we've reached the end of the argument
+					i++;
+					break;
+				}
+
+				if (c == '\\') {
+					escaped = true;
+				} else if (escaped) {
+					builder.Append (c);
+					escaped = false;
+				} else if (qchar == '\0' && (c == ' ' || c == '\t')) {
+					break;
+				} else if (qchar == '\0' && (c == '\'' || c == '"')) {
+					string sofar = builder.ToString ();
+					string embedded;
+
+					if ((embedded = GetArgument (builder, buf, i, out endIndex, out ex)) == null)
+						return null;
+
+					i = endIndex;
+					builder.Clear ();
+					builder.Append (sofar);
+					builder.Append (embedded);
+					continue;
+				} else {
+					builder.Append (c);
+				}
+
+				i++;
+			}
+
+			if (escaped || (qchar != '\0' && c != qchar)) {
+				ex = new FormatException (escaped ? "Incomplete escape sequence." : "No matching quote found.");
+				endIndex = -1;
+				return null;
+			}
+
+			endIndex = i;
+			ex = null;
+
+			return builder.ToString ();
+		}
+
+		static bool TryParse (string commandline, out string[] argv, out Exception ex)
+		{
+			var builder = new StringBuilder ();
+			var args = new List<string> ();
+			string argument;
+			int i = 0, j;
+			char c;
+
+			while (i < commandline.Length) {
+				c = commandline[i];
+				if (c != ' ' && c != '\t') {
+					if ((argument = GetArgument (builder, commandline, i, out j, out ex)) == null) {
+						argv =  null;
+						return false;
+					}
+
+					args.Add (argument);
+					i = j;
+				}
+
+				i++;
+			}
+
+			argv = args.ToArray ();
+			ex = null;
+
+			return true;
+		}
+
+		public static bool TryParse (string commandline, out string[] argv)
+		{
+			Exception ex;
+
+			return TryParse (commandline, out argv, out ex);
+		}
+
+		public static string[] Parse (string commandline)
+		{
+			string[] argv;
+			Exception ex;
+
+			if (!TryParse (commandline, out argv, out ex))
+				throw ex;
+
+			return argv;
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessUtils.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessUtils.cs
@@ -1,0 +1,85 @@
+﻿//
+// ProcessUtils.cs
+//
+// Author:
+//       Michael Hutchinson <mhutch@xamarin.com>
+//       Jérémie Laval <jeremie.laval@xamarin.com>
+//
+// Copyright (c) 2012 Xamarin, Inc.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Components.Ide.Activation
+{
+	public static class ProcessUtils
+	{
+		public static async Task<int> StartProcess (ProcessStartInfo psi, TextWriter stdout, TextWriter stderr, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested ();
+			psi.UseShellExecute = false;
+			psi.RedirectStandardOutput |= stdout != null;
+			psi.RedirectStandardError |= stderr != null;
+
+			var process = new Process {
+				StartInfo = psi,
+				EnableRaisingEvents = true,
+			};
+
+			Task output = Task.FromResult (true);
+			Task error = Task.FromResult (true);
+			Task exit = WaitForExitAsync (process);
+			using (process) {
+				process.Start ();
+
+				// If the token is cancelled while we're running, kill the process.
+				// Otherwise once we finish the Task.WhenAll we can remove this registration
+				// as there is no longer any need to Kill the process.
+				//
+				// We wrap `stdout` and `stderr` in syncronized wrappers for safety in case they
+				// end up writing to the same buffer, or they are the same object.
+				using (cancellationToken.Register (() => KillProcess (process))) {
+					if (psi.RedirectStandardOutput)
+						output = ReadStreamAsync (process.StandardOutput, TextWriter.Synchronized (stdout));
+
+					if (psi.RedirectStandardError)
+						error = ReadStreamAsync (process.StandardError, TextWriter.Synchronized (stderr));
+
+					await Task.WhenAll (new [] { output, error, exit }).ConfigureAwait (false);
+				}
+				// If we invoke 'KillProcess' our output, error and exit tasks will all complete normally.
+				// To protected against passing the user incomplete data we have to call
+				// `cancellationToken.ThrowIfCancellationRequested ()` here.
+				cancellationToken.ThrowIfCancellationRequested ();
+				return process.ExitCode;
+			}
+		}
+
+		static void KillProcess (Process p)
+		{
+			try {
+				p.Kill ();
+			} catch (InvalidOperationException) {
+				// If the process has already exited this could happen
+			}
+		}
+
+		static Task WaitForExitAsync (Process process)
+		{
+			var exitDone = new TaskCompletionSource<bool> ();
+			process.Exited += (o, e) => exitDone.TrySetResult (true);
+			return exitDone.Task;
+		}
+
+		static async Task ReadStreamAsync (StreamReader stream, TextWriter destination)
+		{
+			int read;
+			var buffer = new char [4096];
+			while ((read = await stream.ReadAsync (buffer, 0, buffer.Length).ConfigureAwait (false)) > 0)
+				destination.Write (buffer, 0, read);
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/VS7ZipLocator.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/VS7ZipLocator.cs
@@ -1,0 +1,185 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.Build.Download
+{
+	public static class VS7ZipLocator
+	{
+		const string VS_2017_RELATIVE_PATH_TO_7Z = @"Common7\IDE\Extensions\Xamarin\VisualStudio\7-Zip\7z.exe";
+		const string VS_2019_RELATIVE_PATH_TO_7Z = @"Common7\IDE\Extensions\Xamarin.VisualStudio\7-Zip\7z.exe";
+
+		public static string Locate7Zip(string vsInstallRoot)
+		{
+			var path = FindLegacy();
+
+			if (!string.IsNullOrEmpty(path))
+				return path;
+
+			return FindNew(vsInstallRoot);
+		}
+
+		static string FindNew(string vsInstallRoot)
+		{
+			string tryPath = null;
+
+			// Try for 2017 or 2019 VSInstallRoot Paths plus the known relative path
+			// Since the relative paths for 2019 are different than 2019
+			if (!string.IsNullOrEmpty(vsInstallRoot))
+			{
+				// VS 2019
+				tryPath = Path.Combine(vsInstallRoot, VS_2019_RELATIVE_PATH_TO_7Z);
+				if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+					return tryPath;
+
+				// VS 2017
+				tryPath = Path.Combine(vsInstallRoot, VS_2017_RELATIVE_PATH_TO_7Z);
+				if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+					return tryPath;
+			}
+
+			// Fall back to trying some hard coded likely paths
+			tryPath = FindInVs("2019", VS_2019_RELATIVE_PATH_TO_7Z);
+			if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+				return tryPath;
+
+			tryPath = FindInVs("2017", VS_2017_RELATIVE_PATH_TO_7Z);
+			if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+				return tryPath;
+
+			// Try for local installation of 7z
+			tryPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "7-Zip", "7z.exe");
+			if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+				return tryPath;
+
+			// Try for local installation of 7z
+			tryPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "7-Zip", "7z.exe");
+			if (!string.IsNullOrEmpty(tryPath) && File.Exists(tryPath))
+				return tryPath;
+
+			return null;
+		}
+
+		static string FindInVs(string vsYear, string relativePathTo7z)
+		{
+			foreach (var drive in DriveInfo.GetDrives())
+			{
+				var root = $@"{drive.Name}Program Files (x86)\Microsoft Visual Studio\{vsYear}";
+
+				if (Directory.Exists(root))
+				{
+					var sxsDirs = Directory.GetDirectories(root, "*", SearchOption.TopDirectoryOnly);
+
+					if (sxsDirs != null && sxsDirs.Length > 0)
+					{
+						foreach (var sxsDir in sxsDirs)
+						{
+							var path7z = Path.Combine(sxsDir, relativePathTo7z);
+							if (File.Exists(path7z))
+								return path7z;
+						}
+					}
+				}
+			}
+
+			return null;
+		}
+
+		static string FindLegacy()
+		{
+			using (var topKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Xamarin\XamarinVS"))
+			{
+				string version;
+				if (topKey != null && (version = (topKey.GetValue("InstalledVersion") as string)) != null)
+				{
+					using (var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Xamarin\VisualStudio"))
+					{
+						if (key != null)
+						{
+							foreach (var skName in key.GetSubKeyNames())
+							{
+								using (var sk = key.OpenSubKey(skName))
+								{
+									if (sk == null)
+										continue;
+									var path = sk.GetValue("Path") as string;
+									if (path == null)
+										continue;
+									path = Path.Combine(path, version, "7-Zip", "7z.exe");
+									if (File.Exists(path))
+									{
+										return path;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			using (var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio"))
+			{
+				if (key != null)
+				{
+					foreach (var skName in key.GetSubKeyNames())
+					{
+						if (skName == null || !skName.EndsWith("_Config"))
+							continue;
+
+						using (var sk = key.OpenSubKey(skName + @"\Packages\{296e6a4e-2bd5-44b7-a96d-8ee3d9cda2f6}"))
+						{
+							if (sk == null)
+								continue;
+
+							var path = sk.GetValue("CodeBase") as string;
+
+							if (path == null)
+								continue;
+
+							var sZipPath = Path.Combine(Path.GetDirectoryName(path), "7-Zip", "7z.exe");
+							if (File.Exists(sZipPath))
+							{
+								return sZipPath;
+							}
+						}
+					}
+				}
+			}
+
+			using (var topKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Xamarin\XamarinVS"))
+			{
+				string version;
+				if (topKey != null && (version = (topKey.GetValue("InstalledVersion") as string)) != null)
+				{
+					using (var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Xamarin\VisualStudio"))
+					{
+						if (key != null)
+						{
+							foreach (var skName in key.GetSubKeyNames())
+							{
+								using (var sk = key.OpenSubKey(skName))
+								{
+									if (sk == null)
+										continue;
+									var path = sk.GetValue("Path") as string;
+									if (path == null)
+										continue;
+									path = Path.Combine(path, "Xamarin", version, "7-Zip", "7z.exe");
+									if (File.Exists(path))
+									{
+										return path;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard20</TargetFramework>
+    <AssemblyName>Xamarin.Build.Download</AssemblyName>
+    <Nullable>disable</Nullable>
+    <!-- Don't include the assembly in the lib\ folder in the nupkg -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <PackageId>Xamarin.Build.Download</PackageId>
+    <Title>Xamarin Build-time Download Support</Title>
+    <PackageVersion>0.11.4</PackageVersion>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>
+    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=864965</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Description>Support for downloading and unpacking archives when building MSBuild projects</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/xamarin/XamarinComponents.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- build -->
+    <None Include="Xamarin.Build.Download.targets" Pack="True" PackagePath="build\Xamarin.Build.Download.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Xamarin.Build.Download.props" Pack="True" PackagePath="build\Xamarin.Build.Download.props" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(TargetPath)" Pack="True" PackagePath="build\Xamarin.Build.Download.dll" />
+    <None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\Newtonsoft.Json.dll" Visible="False" Pack="True" PackagePath="build\Newtonsoft.Json.dll" />
+    <None Include="$(PkgMicrosoft_Win32_Registry)\runtimes\win\lib\netstandard2.0\Microsoft.Win32.Registry.dll" Visible="False" Pack="True" PackagePath="build\Microsoft.Win32.Registry.dll" />
+
+    <!-- buildTransitive: we _could_ import targets, but this is more work for me to write -->
+    <None Include="Xamarin.Build.Download.targets" Pack="True" PackagePath="buildTransitive\Xamarin.Build.Download.targets" />
+    <None Include="Xamarin.Build.Download.props" Pack="True" PackagePath="buildTransitive\Xamarin.Build.Download.props" />
+    <None Include="$(TargetPath)" Pack="True" PackagePath="buildTransitive\Xamarin.Build.Download.dll" />
+    <None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\Newtonsoft.Json.dll" Visible="False" Pack="True" PackagePath="buildTransitive\Newtonsoft.Json.dll" />
+    <None Include="$(PkgMicrosoft_Win32_Registry)\runtimes\win\lib\netstandard2.0\Microsoft.Win32.Registry.dll" Visible="False" Pack="True" PackagePath="buildTransitive\Microsoft.Win32.Registry.dll" />
+    <!-- legal -->
+    <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICE.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0.0" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" PrivateAssets="all" GeneratePathProperty="true" />
+  </ItemGroup>
+</Project>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.props
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<!--
+		This is expected to be in packages\Xamarin.Build.Download\build, so
+		XamarinBuildDownloadDir defaults to packages\.xbcache
+		-->
+		<XamarinBuildDownloadDir Condition="'$(OS)'=='Unix' and '$(XamarinBuildDownloadDir)'==''">$(HOME)\Library\Caches\XamarinBuildDownload\</XamarinBuildDownloadDir>
+		<XamarinBuildDownloadDir Condition="'$(OS)'!='Unix' and '$(XamarinBuildDownloadDir)'==''">$(LocalAppData)\XamarinBuildDownloadCache\</XamarinBuildDownloadDir> 
+
+		<XamarinBuildResourceMergeThrowOnMissingAssembly Condition="'$(XamarinBuildResourceMergeThrowOnMissingAssembly)'==''">True</XamarinBuildResourceMergeThrowOnMissingAssembly>
+	</PropertyGroup>
+</Project>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<UsingTask TaskName="Xamarin.Build.Download.XamarinDownloadArchives" AssemblyFile="Xamarin.Build.Download.dll" />
+	<UsingTask TaskName="Xamarin.Build.Download.XamarinDownloadPartialZips" AssemblyFile="Xamarin.Build.Download.dll" />
+	<UsingTask TaskName="Xamarin.Build.Download.XamarinBuildGetArchivesToDownload" AssemblyFile="Xamarin.Build.Download.dll" />
+	<UsingTask TaskName="Xamarin.Build.Download.XamarinBuildCastAssemblyResources" AssemblyFile="Xamarin.Build.Download.dll" />
+	
+	<PropertyGroup>
+		<XamarinBuildDownloadDir Condition="'$(XamarinBuildDownloadDir)' != '' and !HasTrailingSlash('$(XamarinBuildDownloadDir)')">$(XamarinBuildDownloadDir)\</XamarinBuildDownloadDir>
+		<XamarinBuildDownloadAllowUnsecure Condition="'$(XamarinBuildDownloadAllowUnsecure)' == ''">false</XamarinBuildDownloadAllowUnsecure>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="('$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetPlatformIdentifier)'=='ios') and ('$(OutputType)' != 'Library' or '$(IsAppExtension)'=='True')">
+		<_XamarinBuildDownloadMasterBeforeTargets>GetFrameworkPaths</_XamarinBuildDownloadMasterBeforeTargets>
+		<_XamarinBuildDownloadMasterBeforeTargets Condition="$(TargetFramework.Contains('-ios'))">_BeforeCoreCompileInterfaceDefinitions</_XamarinBuildDownloadMasterBeforeTargets>
+		<_XamarinBuildDownloadMasterDependsOnTargets>_XamarinBuildDownload;_XamarinBuildCastAssemblyResources</_XamarinBuildDownloadMasterDependsOnTargets>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetPlatformIdentifier)'=='android'">
+		<_XamarinBuildDownloadIsAndroid>true</_XamarinBuildDownloadIsAndroid>
+		<_XamarinBuildDownloadMasterBeforeTargets>_ResolveLibraryProjectImports</_XamarinBuildDownloadMasterBeforeTargets>
+		<_XamarinBuildDownloadMasterDependsOnTargets>ResolveAssemblyReferences;_XamarinBuildDownload;_XamarinBuildDownloadAarRestore;_XamarinBuildDownloadAarInclude</_XamarinBuildDownloadMasterDependsOnTargets>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(_XamarinBuildDownloadIsAndroid)'==''">
+		<_XamarinBuildDownloadIsAndroid>false</_XamarinBuildDownloadIsAndroid>
+	</PropertyGroup>
+	
+	<PropertyGroup>
+		<CleanDependsOn>
+			$(CleanDependsOn);
+			_CleanXbdMerge;
+		</CleanDependsOn>
+	</PropertyGroup>
+
+
+	<!--
+	In XS, props files are not inserted in the correct place (https://bugzilla.xamarin.com/show_bug.cgi?id=19054)
+	so targets files cannot reference $(XamarinBuildDownloadDir) when registering items.
+	This is a workaround: it provides a point to register targets that can insert the items.
+	-->
+	<Target Name="_XamarinBuildAddDownloadedItems" DependsOnTargets="@(XamarinBuildRestoreResources)" />
+
+	<Target
+			Name="_XamarinBuildDownload"
+			DependsOnTargets="_XamarinBuildAddDownloadedItems;_XamarinBuildDownloadCore;_XamarinBuildDownloadPartialZipsCore"
+		/>
+
+	<Target Name="_XamarinBuildDownloadCore"
+			Condition="'@(XamarinBuildDownload)'!=''">
+
+		<XamarinDownloadArchives
+			AllowUnsecureUrls="$(XamarinBuildDownloadAllowUnsecure)"
+			Archives="@(XamarinBuildDownload)"
+			DestinationBase="$(XamarinBuildDownloadDir)"
+			CacheDirectory="$(XamarinBuildDownloadDir)"
+			User7ZipPath="$(XamarinBuildDownloadUser7ZipPath)"
+			VsInstallRoot="$(VsInstallRoot)"
+			IsAndroid="$(_XamarinBuildDownloadIsAndroid)"
+			/>
+	</Target>
+
+	<Target Name="_XamarinBuildDownloadPartialZipsCore"
+			Condition="'@(XamarinBuildDownloadPartialZip)'!=''">
+		<XamarinDownloadPartialZips
+			AllowUnsecureUrls="$(XamarinBuildDownloadAllowUnsecure)"
+			Parts="@(XamarinBuildDownloadPartialZip)"
+			CacheDirectory="$(XamarinBuildDownloadDir)"
+			IsAndroid="$(_XamarinBuildDownloadIsAndroid)"
+			/>
+	</Target>
+
+	<Target Name="_XamarinBuildCastAssemblyResources"
+			DependsOnTargets="_XamarinBuildDownload"
+			Condition="'@(RestoreAssemblyResource)'!=''"
+			>
+		<XamarinBuildCastAssemblyResources
+			RestoreAssemblyResources="@(RestoreAssemblyResource)">
+			<Output TaskParameter="BundleResources" ItemName="BundleResource" />
+		</XamarinBuildCastAssemblyResources>
+	</Target>
+
+	<Target Name="_XamarinBuildDownloadAarRestore"
+		Condition="'@(XamarinBuildDownloadRestoreAssemblyAar)'!=''"
+		DependsOnTargets="_XamarinBuildDownload">
+		<Warning
+			Code="XBD100"
+			Text="ItemGroup `XamarinBuildDownloadRestoreAssemblyAar` is no longer supported.  If your build is failing, revert to an older Xamarin.Build.Download version, or migrate your packages to use the new `XamarinBuildDownloadAndroidAarLibrary` ItemGroup.  If your build is succeeding it is safe to ignore this warning."
+			/>
+	</Target>
+	
+	<Target Name="_XamarinBuildDownloadAarInclude"
+		Condition="'@(XamarinBuildDownloadAndroidAarLibrary)'!=''"
+		DependsOnTargets="_XamarinBuildDownload">
+
+		<!-- Check if `AndroidAarLibrary` isn't supported and error if so -->
+		<Error 
+			Condition="'@(AvailableItemName->AnyHaveMetadataValue('Identity', 'AndroidAarLibrary'))'!='true' and ('$(AndroidClassParser)'=='' or '$(AndroidCodegenTarget)'=='')"
+			Text="This version of Xamarin.Build.Download requires a newer version of Xamarin.Android."
+			/>
+
+		<ItemGroup>
+			<AndroidAarLibrary Include="@(XamarinBuildDownloadAndroidAarLibrary)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_XamarinBuildDownloadMasterTarget"
+			Condition="'$(_XamarinBuildDownloadMasterDependsOnTargets)'!=''"
+			BeforeTargets="$(_XamarinBuildDownloadMasterBeforeTargets)"
+			DependsOnTargets="$(_XamarinBuildDownloadMasterDependsOnTargets)" />
+	
+	<Target Name="XamarinBuildDownloadGetItemsToDownload" Returns="@(XamarinBuildDownloadItemToDownload)">
+		<XamarinBuildGetArchivesToDownload
+			AllowUnsecureUrls="$(XamarinBuildDownloadAllowUnsecure)"
+			Archives="@(XamarinBuildDownload)"
+			PartialZipDownloads="@(XamarinBuildDownloadPartialZip)"
+			DestinationBase="$(XamarinBuildDownloadDir)"
+			CacheDirectory="$(XamarinBuildDownloadDir)">
+			<Output TaskParameter="ArchivesToDownload" ItemName="XamarinBuildDownloadItemToDownload" />
+		</XamarinBuildGetArchivesToDownload>
+	</Target>
+
+
+	<Target Name="_CleanXbdMerge">
+		<RemoveDir Directories="$(IntermediateOutputPath)XbdMerge\proguard" Condition="Exists ('$(IntermediateOutputPath)XbdMerge\proguard')" />
+		<RemoveDir Directories="$(IntermediateOutputPath)XbdMerge" Condition="Exists ('$(IntermediateOutputPath)XbdMerge')" />
+	</Target>
+</Project>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildCastAssemblyResources.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildCastAssemblyResources.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.MacDev;
+
+namespace Xamarin.Build.Download
+{
+	public class XamarinBuildCastAssemblyResources : Task
+	{
+		const string identityKey = "Identity";
+		const string logicalNameKey = "LogicalName";
+		const string optimizeKey = "Optimize";
+
+		[Required]
+		public ITaskItem [] RestoreAssemblyResources { get; set; }
+
+		[Output]
+		public ITaskItem [] BundleResources { get; set; }
+
+		public override bool Execute ()
+		{
+			var bundleResources = new List<ITaskItem> ();
+
+			foreach (var resource in RestoreAssemblyResources) {
+				var identity = resource.GetMetadata (identityKey);
+				
+				var logicalName = resource.GetMetadata (logicalNameKey);
+				logicalName = logicalName.Replace ("__monotouch_content_", "");
+				logicalName = logicalName.Replace ("_f", @"\");
+				logicalName = logicalName.Replace ("__", "_");
+
+				var bundleResource = new TaskItem (identity);
+				bundleResource.SetMetadata (logicalNameKey, logicalName);
+
+				if (identity.ToLower().EndsWith (".png"))
+					bundleResource.SetMetadata (optimizeKey, "False");
+
+				bundleResources.Add (bundleResource);
+			}
+
+			BundleResources = bundleResources.ToArray ();
+
+			return true;
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildDownload.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildDownload.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Build.Download
+{
+	public class XamarinBuildDownload
+	{
+		public string Id { get; set; }
+		public ArchiveKind Kind { get; set; }
+		public string Url { get; set; }
+		public string Sha256 { get; set; }
+
+		public string ToFile { get; set; }
+		public int ExclusiveLockTimeout { get; set; } = 60;
+
+		public string CustomErrorMessage { get; set; }
+		public string CustomErrorCode { get; set; }
+
+		public string CacheFile { get; set; }
+		public string DestinationDir { get; set; }
+	}
+
+	public enum ArchiveKind
+	{
+		Unknown = 0,
+		Zip,
+		Tgz,
+		Uncompressed,
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Build.Download
+{
+	public class XamarinBuildGetArchivesToDownload : Task, ILogger
+	{
+		public ITaskItem [] Archives { get; private set; }
+		public ITaskItem [] PartialZipDownloads { get; private set; }
+
+		[Output]
+		public ITaskItem [] ArchivesToDownload { get; private set; }
+
+		public string DestinationBase { get; set; }
+
+		public string CacheDirectory { get; set; }
+
+		public bool AllowUnsecureUrls { get; set; }
+
+		DownloadUtils downloadUtils;
+
+		public override bool Execute ()
+		{
+			var results = new List<ITaskItem> ();
+
+			downloadUtils = new DownloadUtils (this, CacheDirectory);
+
+			var items = downloadUtils.ParseDownloadItems (Archives, AllowUnsecureUrls);
+
+			if (items != null) {
+				foreach (var item in items) {
+					if (downloadUtils.IsAlreadyDownloaded (item))
+						continue;
+					var taskItem = new TaskItem (item.Id);
+					taskItem.SetMetadata ("Type", "Download");
+					taskItem.SetMetadata ("Url", item.Url);
+					taskItem.SetMetadata ("CacheFile", item.CacheFile);
+
+					if (!string.IsNullOrEmpty (item.Sha256))
+						taskItem.SetMetadata ("Sha256", item.Sha256);
+
+					results.Add (taskItem);
+				}
+			}
+
+			var partials = downloadUtils.ParsePartialZipDownloadItems (PartialZipDownloads, AllowUnsecureUrls);
+			if (partials != null) {
+				foreach (var partialZipDownload in partials) {
+					if (downloadUtils.IsAlreadyDownloaded (CacheDirectory, partialZipDownload))
+						continue;
+					var taskItem = new TaskItem (partialZipDownload.Id);
+					taskItem.SetMetadata ("Type", "PartialZipDownload");
+					taskItem.SetMetadata ("Url", partialZipDownload.Url);
+					taskItem.SetMetadata ("RangeStart", partialZipDownload.RangeStart.ToString ());
+					taskItem.SetMetadata ("RangeEnd", partialZipDownload.RangeEnd.ToString ());
+
+					if (!string.IsNullOrEmpty (partialZipDownload.Sha256))
+						taskItem.SetMetadata ("Sha256", partialZipDownload.Sha256);
+
+					results.Add (taskItem);
+				}
+			}
+
+			ArchivesToDownload = results.ToArray ();
+
+			return true;
+		}
+
+		public void LogCodedError (string code, string message, params object [] messageArgs)
+		{
+			base.Log.LogError (message, messageArgs);
+		}
+
+		public void LogErrorFromException (Exception exception)
+		{
+			base.Log.LogErrorFromException (exception);
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -1,0 +1,383 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Win32;
+using Xamarin.Components.Ide.Activation;
+using Xamarin.MacDev;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Xamarin.Build.Download
+{
+	//based on Xamarin.Android MSBuild targets
+	public class XamarinDownloadArchives : AsyncTask, ILogger
+	{
+		public ITaskItem [] Archives { get; private set; }
+
+		public string DestinationBase {get; set; }
+
+		public string CacheDirectory { get; set; }
+
+		public string User7ZipPath { get; set; }
+
+		public bool AllowUnsecureUrls { get; set; }
+
+		public string VsInstallRoot { get; set; }
+
+		public bool IsAndroid { get; set; }
+
+		DownloadUtils downloadUtils;
+
+		public override bool Execute ()
+		{
+			downloadUtils = new DownloadUtils (this, CacheDirectory);
+
+			Task.Run (async () => {
+				try {
+					var items = downloadUtils.ParseDownloadItems (Archives, AllowUnsecureUrls);
+
+					foreach (var item in items) {
+						await MakeSureLibraryIsInPlace (item, Token);
+					}
+				} catch (Exception ex) {
+					LogErrorFromException (ex);
+				} finally {
+					Complete ();
+				}
+			});
+
+			var result = base.Execute ();
+
+			return result && !Log.HasLoggedErrors;
+		}
+
+		/// <summary>
+		/// Attempt to determine the archive kind
+		/// </summary>
+		/// <returns>The archive kind, or Unknown if it could not be be determined.</returns>
+		/// <param name="urlMetadata">The 'Url' metadata.</param>
+		/// <param name="kindMetadata">The 'Kind' metadata.</param>
+
+
+		bool IsValidDownload(string cachedHashFile, string fileToHash, string expectedHash)
+		{
+			// If an expected hash wasn't provided, we skip this check and assume OK
+			if (string.IsNullOrEmpty (expectedHash))
+				return true;
+
+			var cachedHashFileExists = File.Exists (cachedHashFile);
+
+			// Use a cached hash value to compare against so we don't always recalculate the hash
+			if (cachedHashFileExists) {
+				var cachedHash = File.ReadAllText (cachedHashFile);
+
+				// See if our cached hash value matches what's expected
+				if (string.Compare (cachedHash, expectedHash, StringComparison.InvariantCultureIgnoreCase) == 0)
+					return true;
+			}
+
+			// Calculate the hash of the file
+			var hash = Sha256HashFile (fileToHash).Replace ("-", string.Empty);
+
+			LogDebugMessage ("File :{0}", fileToHash);
+			LogDebugMessage ("SHA256 : {0}", hash);
+			LogDebugMessage ("Expected SHA256 : {0}", expectedHash);
+
+			// Check to see if the new hash matches expected value
+			if (string.Compare (hash, expectedHash, StringComparison.InvariantCultureIgnoreCase) == 0) {
+
+				// Try to cache the hash file to avoid calculating it in the future
+				try {
+					File.WriteAllText (cachedHashFile, hash);
+				} catch { }
+
+				// Everything checks out
+				return true;
+			}
+
+			// If the hash didn't match, let's try to delete the cache file if it exists
+			// since we know that it's not valid anyway, no sense trying to use it again
+			if (cachedHashFileExists) {
+				try {
+					File.Delete (cachedHashFile);
+				} catch { }
+			}
+
+			LogMessage ("Hash mismatch for file: " + fileToHash, MessageImportance.High);
+			return false;
+		}
+
+		string ThisOrThat (string strOne, string strTwo)
+		{
+			if (string.IsNullOrEmpty (strOne))
+				return strTwo;
+
+			return strOne;
+		}
+
+		string ThisOrThat (string strOne, Func<string> strTwoFunc)
+		{
+			if (string.IsNullOrEmpty (strOne))
+				return strTwoFunc ();
+
+			return strOne;
+		}
+
+		async Task<bool> MakeSureLibraryIsInPlace (XamarinBuildDownload xbd, CancellationToken token)
+		{
+			// Skip extraction if the file is already in place
+			var flagFile = xbd.DestinationDir + ".unpacked";
+			if (File.Exists (flagFile))
+				return true;
+
+			try {
+				Directory.CreateDirectory (xbd.DestinationDir);
+			} catch (Exception ex) {
+				LogCodedError (ThisOrThat (xbd.CustomErrorCode, ErrorCodes.DirectoryCreateFailed), ThisOrThat (xbd.CustomErrorMessage, () => string.Format ("Failed to create directory '{0}'.", xbd.DestinationDir)));
+				LogMessage ("Directory creation failure reason: " + ex.ToString (), MessageImportance.High);
+				return false;
+			}
+
+			var lockFile = xbd.DestinationDir + ".locked";
+			using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, Token, TimeSpan.FromSeconds (xbd.ExclusiveLockTimeout), this)) {
+
+				if (lockStream == null) {
+					LogCodedError (ErrorCodes.ExclusiveLockTimeout, "Timed out waiting for exclusive file lock on: {0}", lockFile);
+					LogMessage ("Timed out waiting for an exclusive file lock on: " + lockFile, MessageImportance.High);
+					return false;
+				}
+
+				// Check flag again in case someone else downloaded this while we were waiting for the lock
+				if (File.Exists (flagFile))
+					return true;
+
+				if (!File.Exists (xbd.CacheFile) || !IsValidDownload (xbd.DestinationDir + ".sha256", xbd.CacheFile, xbd.Sha256)) {
+					try {
+						int progress = -1;
+						DownloadProgressChangedEventHandler downloadHandler = (o, e) => {
+							if (e.ProgressPercentage % 10 != 0 || progress == e.ProgressPercentage)
+								return;
+							progress = e.ProgressPercentage;
+							LogMessage (
+								"\t({0}/{1}b), total {2:F1}%", e.BytesReceived, e.TotalBytesToReceive, e.ProgressPercentage
+							);
+						};
+						using (var client = new WebClient ()) {
+							client.DownloadProgressChanged += downloadHandler;
+							client.Headers.Add ("User-Agent: Mozilla/5.0");
+							LogMessage ("  Downloading {0} to {1}", xbd.Url, xbd.CacheFile);
+							client.DownloadFileTaskAsync (xbd.Url, xbd.CacheFile).Wait (token);
+
+							LogMessage ("  Downloading Complete");
+							client.DownloadProgressChanged -= downloadHandler;
+						}
+					} catch (Exception e) {
+						LogCodedError (ThisOrThat (xbd.CustomErrorCode, ErrorCodes.DownloadFailed), ThisOrThat (xbd.CustomErrorMessage, () => string.Format ("Download failed. Please download {0} to a file called {1}.", xbd.Url, xbd.CacheFile)));
+						LogMessage ("Download failure reason: " + e.GetBaseException ().Message, MessageImportance.High);
+						File.Delete (xbd.CacheFile);
+						return false;
+					}
+				}
+
+				if (!File.Exists (xbd.CacheFile)) {
+					LogCodedError (ThisOrThat (xbd.CustomErrorCode, ErrorCodes.DownloadedFileMissing), ThisOrThat (xbd.CustomErrorMessage, () => string.Format ("Downloaded file '{0}' is missing.", xbd.CacheFile)));
+					return false;
+				}
+
+				if (xbd.Kind == ArchiveKind.Uncompressed) {
+
+					var uncompressedCacheFile = xbd.CacheFile;
+					if (!string.IsNullOrEmpty (xbd.ToFile))
+						uncompressedCacheFile = xbd.ToFile;
+
+					File.Move (xbd.CacheFile, Path.Combine (xbd.DestinationDir, Path.GetFileName (uncompressedCacheFile)));
+					File.WriteAllText (flagFile, "This marks that the extraction completed successfully");
+					return true;
+				} else {
+					if (await ExtractArchive (xbd, flagFile, token)) {
+						File.WriteAllText (flagFile, "This marks that the extraction completed successfully");
+						return true;
+					}
+				}
+			}
+
+			// We will attempt to delete the lock file when we're done
+			try {
+				if (File.Exists (lockFile))
+					File.Delete (lockFile);
+			} catch { }
+
+			return false;
+		}
+
+		async Task<bool> ExtractArchive (XamarinBuildDownload xbd, string flagFile, CancellationToken token)
+		{
+			ProcessStartInfo psi = CreateExtractionArgs (xbd.CacheFile, xbd.DestinationDir, xbd.Kind, VsInstallRoot);
+
+			try {
+				LogMessage ("Extracting {0} to {1}", xbd.CacheFile, xbd.DestinationDir);
+				var output = new StringWriter ();
+				int returnCode = await ProcessUtils.StartProcess (psi, output, output, token);
+				if (returnCode == 0) {
+					//with 7zip, tgz just gets uncompressed to a tar. now extract the tar.
+					if (xbd.Kind == ArchiveKind.Tgz && Platform.IsWindows) {
+						returnCode = await ExtractTarOnWindows (xbd, output, token);
+						if (returnCode == 0)
+							return true;
+					} else {
+						return true;
+					}
+				}
+				LogCodedError (
+					ThisOrThat (xbd.CustomErrorCode, ErrorCodes.ExtractionFailed),
+					ThisOrThat (xbd.CustomErrorMessage, () => string.Format (
+						"Unpacking failed. Please download '{0}' and extract it to the '{1}' directory " +
+						"and create an empty file called '{2}'.", xbd.Url, xbd.DestinationDir, flagFile)));
+				LogMessage ("Unpacking failure reason: " + output.ToString (), MessageImportance.High);
+			} catch (Exception ex) {
+				LogErrorFromException (ex);
+			}
+
+			//something went wrong, clean up so we try again next time
+			try {
+				Directory.Delete (xbd.DestinationDir, true);
+			} catch (Exception ex) {
+				LogCodedError (ErrorCodes.DirectoryDeleteFailed, "Failed to delete directory '{0}'.", xbd.DestinationDir);
+				LogErrorFromException (ex);
+			}
+			return false;
+		}
+
+		async Task<int> ExtractTarOnWindows (XamarinBuildDownload xbd, StringWriter output, CancellationToken token)
+		{
+			var tarFile = GetTarFileName (xbd);
+			var psi = CreateExtractionArgs (tarFile, xbd.DestinationDir, xbd.Kind, VsInstallRoot, true);
+			var returnCode = await ProcessUtils.StartProcess (psi, output, output, token);
+			if (returnCode == 7) {
+				LogMessage ("7Zip command line parse did not work.  Trying without -snl-");
+				psi = CreateExtractionArgs (tarFile, xbd.DestinationDir, xbd.Kind, VsInstallRoot, false);
+				returnCode = await ProcessUtils.StartProcess (psi, output, output, token);
+			}
+			File.Delete (tarFile);
+			return returnCode;
+		}
+
+		ProcessStartInfo CreateExtractionArgs (string file, string contentDir, ArchiveKind kind, string vsInstallRoot, bool ignoreTarSymLinks = false)
+		{
+			ProcessArgumentBuilder args = null;
+			switch (kind) {
+			case ArchiveKind.Tgz:
+				if (Platform.IsWindows)
+					args = Build7ZipExtractionArgs (file, contentDir, User7ZipPath, ignoreTarSymLinks, vsInstallRoot);
+				else
+					args = BuildTgzExtractionArgs (file, contentDir);
+				break;
+				case ArchiveKind.Zip:
+				if (Platform.IsWindows)
+					args = Build7ZipExtractionArgs (file, contentDir, User7ZipPath, false, vsInstallRoot);
+				else
+					args = BuildZipExtractionArgs (file, contentDir);
+				break;
+			default:
+				throw new ArgumentException ("kind");
+			}
+
+			ProcessStartInfo psi = null;
+			if (Platform.IsWindows)
+				psi = new ProcessStartInfo (args.ProcessPath, args.ToString ())
+				{
+					WorkingDirectory = null,
+					CreateNoWindow = true
+				};
+			else
+				psi = new ProcessStartInfo (args.ProcessPath, args.ToString ())
+				{
+					WorkingDirectory = contentDir,
+					CreateNoWindow = true
+				};
+
+			return psi;
+		}
+
+		static ProcessArgumentBuilder Build7ZipExtractionArgs (string file, string contentDir, string user7ZipPath, bool ignoreTarSymLinks, string vsInstallRoot)
+		{
+			var args = new ProcessArgumentBuilder (Get7ZipPath (user7ZipPath, vsInstallRoot));
+			//if it's a tgz, we have a two-step extraction. for the gzipped layer, extract without paths
+			if (file.EndsWith (".gz", StringComparison.OrdinalIgnoreCase) || file.EndsWith (".tgz", StringComparison.OrdinalIgnoreCase))
+				args.Add ("e");
+			else
+				args.Add ("x");
+
+			// Symbolic Links give us problems.  You need to run as admin to extract them.
+			// Adding this flag will ignore links
+			if (ignoreTarSymLinks)
+				args.Add ("-snl-");
+
+			args.AddQuoted ("-o" + contentDir);
+			args.AddQuoted (file);
+			return args;
+		}
+
+		static string Get7ZipPath (string user7ZipPath, string vsInstallRoot)
+		{
+			if (!string.IsNullOrEmpty (user7ZipPath) && File.Exists (user7ZipPath))
+				return user7ZipPath;
+
+			var path7z = VS7ZipLocator.Locate7Zip(vsInstallRoot);
+
+			if (string.IsNullOrEmpty(path7z))
+				throw new Exception ("Could not find 7zip.exe in Xamarin installation");
+
+			return path7z;
+		}
+
+		static ProcessArgumentBuilder BuildZipExtractionArgs (string file, string contentDir)
+		{
+			var args = new ProcessArgumentBuilder ("/usr/bin/unzip");
+			args.Add ("-o", "-q");
+			args.AddQuoted (file);
+			return args;
+		}
+
+		static ProcessArgumentBuilder BuildTgzExtractionArgs (string file, string contentDir)
+		{
+			var args = new ProcessArgumentBuilder ("/usr/bin/tar");
+			args.Add ("-x", "-f");
+			args.AddQuoted (file);
+			return args;
+		}
+
+		static string GetTarFileName (XamarinBuildDownload xbd)
+		{
+			var tarPath =  Path.Combine (xbd.DestinationDir, Path.ChangeExtension (Path.GetFileName (xbd.CacheFile), "tar"));
+
+			if (File.Exists (tarPath))
+				return tarPath;
+
+			var foundFile = Directory.EnumerateFiles (xbd.DestinationDir, "*.tar", SearchOption.TopDirectoryOnly).FirstOrDefault ();
+
+			return string.IsNullOrEmpty (foundFile) ? tarPath : foundFile;
+		}
+
+		public static string Sha256HashFile (string filename)
+		{
+			using (HashAlgorithm hashAlg = new SHA256Managed ()) {
+				return HashFile (filename, hashAlg);
+			}
+		}
+
+		public static string HashFile (string filename, HashAlgorithm hashAlg)
+		{
+			using (Stream file = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
+				byte[] hash = hashAlg.ComputeHash (file);
+				return BitConverter.ToString (hash);
+			}
+		}
+	}
+}

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Build.Download
+{
+	public class XamarinDownloadPartialZips : AsyncTask, ILogger
+	{
+		public ITaskItem [] Parts { get; private set; }
+
+		public string DestinationBase { get; set; }
+
+		public string CacheDirectory { get; set; }
+
+		public bool AllowUnsecureUrls { get; set; }
+
+		public bool IsAndroid { get; set; }
+
+		HttpClient http;
+
+		public override bool Execute ()
+		{
+			LogMessage ("Starting XamarinDownloadPartialZips");
+			LogMessage ("DestinationBase: {0}", DestinationBase);
+			LogMessage ("CacheDirectory: {0}", CacheDirectory);
+
+			Task.Run (async () => {
+				List<PartialZipDownload> parts = null;
+				try {
+					http = new HttpClient ();
+
+					var cacheDir = DownloadUtils.GetCacheDir (CacheDirectory);
+					var downloadUtils = new DownloadUtils (this, cacheDir);
+
+					parts = downloadUtils.ParsePartialZipDownloadItems (Parts, AllowUnsecureUrls);
+
+					await DownloadAll (cacheDir, parts).ConfigureAwait (false);
+
+				} catch (Exception ex) {
+					LogErrorFromException (ex);
+
+					// Log Custom error if one was specified in the partial download info
+					var firstPart = parts?.FirstOrDefault ();
+					if (!string.IsNullOrEmpty (firstPart?.CustomErrorCode) && !string.IsNullOrEmpty (firstPart?.CustomErrorMessage))
+						LogCodedError (firstPart.CustomErrorCode, firstPart.CustomErrorMessage);
+				} finally {
+					Complete ();
+				}
+			});
+
+			var result = base.Execute ();
+
+			return result && !Log.HasLoggedErrors;
+		}
+
+		async Task DownloadAll (string cacheDirectory, List<PartialZipDownload> parts)
+		{
+			// Get the parts all grouped by their URL so we can batch requests with multiple ranges
+			// instead of making a request to the same url for each part
+			// also only grab the parts that don't already locally exist
+			var uniqueUrls = parts
+				.Where (p => !File.Exists (Path.Combine (cacheDirectory, p.Id, p.ToFile)))
+				.GroupBy (p => p.Url);
+
+			// For each unique url...
+			foreach (var partsByUrl in uniqueUrls) {
+				var downloadUrl = partsByUrl.Key;
+
+				LogMessage ("Downloading Partial Zip parts from: " + downloadUrl);
+
+				try {
+					// Create a lock file based on the hash of the URL we are downloading from
+					// Since we could download a multipart request, we are locking on the url from any other process downloading from it
+					var lockFile = Path.Combine (cacheDirectory, DownloadUtils.Crc64 (downloadUrl) + ".locked");
+
+					using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, base.Token, TimeSpan.FromSeconds (30))) {
+
+						if (lockStream == null) {
+							LogCodedError (ErrorCodes.ExclusiveLockTimeout, "Timed out waiting for exclusive file lock on: {0}", lockFile);
+							LogMessage ("Timed out waiting for an exclusive file lock on: " + lockFile, MessageImportance.High);
+
+							// Log Custom error if one was specified in the partial download info
+							var firstPart = partsByUrl.FirstOrDefault ();
+							if (!string.IsNullOrEmpty (firstPart?.CustomErrorCode) && !string.IsNullOrEmpty (firstPart?.CustomErrorMessage))
+								LogCodedError (firstPart.CustomErrorCode, firstPart.CustomErrorMessage);
+							
+							return;
+						}
+
+						try {
+							await Download (cacheDirectory, partsByUrl.Key, partsByUrl.ToList ()).ConfigureAwait (false);
+						} catch (Exception ex) {
+							LogCodedError (ErrorCodes.PartialDownloadFailed, "Partial Download Failed for one or more parts");
+							LogErrorFromException (ex);
+
+							// Log Custom error if one was specified in the partial download info
+							var firstPart = partsByUrl.FirstOrDefault ();
+							if (!string.IsNullOrEmpty (firstPart?.CustomErrorCode) && !string.IsNullOrEmpty (firstPart?.CustomErrorMessage))
+								LogCodedError (firstPart.CustomErrorCode, firstPart.CustomErrorMessage);
+						}
+					}
+
+					try {
+						if (File.Exists (lockFile))
+							File.Delete (lockFile);
+					} catch { }
+				} catch (Exception ex) {
+
+					LogCodedError (ErrorCodes.PartialDownloadFailed, "Partial Download Failed for one or more parts");
+					LogErrorFromException (ex);
+
+					// Log Custom error if one was specified in the partial download info
+					var firstPart = partsByUrl.FirstOrDefault ();
+					if (!string.IsNullOrEmpty (firstPart?.CustomErrorCode) && !string.IsNullOrEmpty (firstPart?.CustomErrorMessage))
+						LogCodedError (firstPart.CustomErrorCode, firstPart.CustomErrorMessage);
+				}
+			}
+		}
+
+		async Task Download (string cacheDirectory, string url, List<PartialZipDownload> parts)
+		{
+			HttpResponseMessage resp;
+
+			foreach (var part in parts) {
+				var req = new HttpRequestMessage (HttpMethod.Get, url);
+
+				// This seems to fix a weird issue where killing the connection on mono on macOS
+				// causes the request to hang indefinitely
+				req.Headers.ConnectionClose = true;
+
+				req.Headers.Range = new RangeHeaderValue (part.RangeStart, part.RangeEnd);
+
+				resp = await http.SendAsync (req).ConfigureAwait (false);
+
+				using (var partStream = await resp.Content.ReadAsStreamAsync ().ConfigureAwait (false))
+					await ExtractPartAndValidate (part, partStream, cacheDirectory).ConfigureAwait (false);
+			}
+		}
+
+		string GetOutputPath (string cacheDirectory, PartialZipDownload part)
+		{
+			var outputPath = new FileInfo (Path.Combine (cacheDirectory, part.Id, part.ToFile));
+			outputPath.Directory.Create ();
+			return outputPath.FullName;
+		}
+
+		async Task<bool> ExtractPartAndValidate (PartialZipDownload part, Stream partInputStream, string cacheDirectory)
+		{
+			string fileHash = null;
+
+			var outputPath = GetOutputPath (cacheDirectory, part);
+
+			using (var iis = new System.IO.Compression.DeflateStream (partInputStream, System.IO.Compression.CompressionMode.Decompress))
+			//using (var iis = new ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream (partInputStream, new ICSharpCode.SharpZipLib.Zip.Compression.Inflater (true)))
+			using (var fs = File.Open (outputPath, FileMode.Create)) {
+				await iis.CopyToAsync (fs).ConfigureAwait (false);
+				await fs.FlushAsync ().ConfigureAwait (false);
+
+				fs.Seek (0, SeekOrigin.Begin);
+				fileHash = DownloadUtils.HashSha256 (fs);
+				LogDebugMessage ("Hash of Downloaded File: {0}", fileHash);
+
+				fs.Close ();
+			}
+
+			if (!string.IsNullOrEmpty (part.Sha256) && !part.Sha256.Equals (fileHash, StringComparison.InvariantCultureIgnoreCase)) {
+
+				// TODO: HANDLE 
+				LogMessage ("File SHA256 Hash was invalid, deleting file: {0}", part.ToFile);
+				File.Delete (outputPath);
+				return false;
+			}
+
+			return true;
+		}
+
+		string ThisOrThat (string strOne, string strTwo)
+		{
+			if (string.IsNullOrEmpty (strOne))
+				return strTwo;
+
+			return strOne;
+		}
+
+		string ThisOrThat (string strOne, Func<string> strTwoFunc)
+		{
+			if (string.IsNullOrEmpty (strOne))
+				return strTwoFunc ();
+
+			return strOne;
+		}
+	}
+}


### PR DESCRIPTION
Move `Xamarin.Build.Download` to this repository so we can better support it.

It is placed in the `util` folder which will eventually include other utility packages we produce like `binderator`.

Also adds new unit test step to CI to run `Xamarin.Build.Download.Tests`.

![image](https://user-images.githubusercontent.com/179295/200681999-0afe4b23-128c-447a-a306-e665c676b72d.png)
