### PR TITLE
[ci] Add back boots `--downgrade-first` option to ensure VSIX is installed correctly.

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -38,5 +38,5 @@ steps:
       - pwsh: dotnet tool update -g ${{ pair.key }} --version ${{ pair.value }}
         displayName: 'Install tool: ${{ pair.key }}'
         
-  - pwsh: boots $(classicInstallerUrl)
+  - pwsh: boots --url $(classicInstallerUrl) --downgrade-first
     displayName: 'Install Classic XA'


### PR DESCRIPTION
The new CI pipeline didn't include the `boots --downgrade-first` option needed to ensure the classic XA VSIX is properly installed on Windows: https://github.com/xamarin/AndroidX/pull/513.

Without this, the VSIX fails to install if there is already a newer VSIX on the build agent:

```
12/5/2022 10:06:50 PM - An extension with a matching Identifier is already installed to this product.
12/5/2022 10:06:50 PM - Microsoft.VisualStudio.ExtensionManager.AlreadyInstalledException: This extension is already installed to all applicable products.
   at VSIXInstaller.ExtensionService.GetInstallableDataImpl(IInstallableExtension extension, String extensionPackParentName, Boolean isRepairSupported, IStateData stateData, IEnumerable`1& skuData)
   at VSIXInstaller.ExtensionService.GetInstallableData(String vsixPath, String extensionPackParentName, Boolean isRepairSupported, IStateData stateData, IEnumerable`1& skuData)
   at VSIXInstaller.ExtensionPackService.IsExtensionPack(IStateData stateData, Boolean isRepairSupported)
   at VSIXInstaller.ExtensionPackService.ExpandExtensionPackToInstall(IStateData stateData, Boolean isRepairSupported)
   at VSIXInstaller.App.Initialize(Boolean isRepairSupported)
   at VSIXInstaller.App.OnStartup(StartupEventArgs e)
```