### PR TITLE
[ci] Bump classic XA to 17.4.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -13,8 +13,8 @@ parameters:
   dotnetWorkloadRollbackFile: 'workloads.json'
   dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'
-  classicXAPkg:  https://aka.ms/xamarin-android-commercial-d17-3-macos
-  classicXAVsix: https://aka.ms/xamarin-android-commercial-d17-3-windows
+  classicXAPkg:  https://aka.ms/xamarin-android-commercial-d17-4-macos
+  classicXAVsix: https://aka.ms/xamarin-android-commercial-d17-4-windows
 
   tools:                                                    # a list of additional .NET global tools needed
   - 'xamarin.androidbinderator.tool': '0.5.4'


### PR DESCRIPTION
The way our classic XA VSIX installer works is it cannot downgrade from a higher version.  To solve this, we always first revert the VSIX to the version that ships with the installed version of Visual Studio, and then we can install our version on top of that.

Unfortunately, when our build agent images are updated to a newer version of VS than our VSIX, we cannot install our older version.

Thus, since our agents have been updated to VS 17.4, trying to install our 17.3 XA VSIX fails and the 17.4 version remains.

Mac does not suffer from this issue, so we are currently building with different versions on Windows and Mac:
Mac - Our pinned 17.3 pkg
Windows - 17.4 VSIX that ships with Visual Studio 17.4

Update both our installers to d17.4 so that both platforms are producing the same output.