### PR TITLE
Manual updates 20221211 xbd dependencies

### DIFF
--- a/config.json
+++ b/config.json
@@ -1630,7 +1630,7 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "widgets",
         "version": "0.0.1",
-        "nugetVersion": "0.0.1.1",
+        "nugetVersion": "0.0.1.2",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
         "dependencyOnly": false
       },
@@ -1965,7 +1965,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-basement",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0",
+        "nugetVersion": "118.1.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Basement",
         "dependencyOnly": true
       },


### PR DESCRIPTION
Context:

AndroidX packages depends more and more on GPS-FB, so some older packages depend on `Xamarin.Build.Download` version `0.11.3` which causes errors like:

```
2022-12-09T09:18:27.5022560Z C:\Users\cloudtest\.nuget\packages\xamarin.build.download\0.11.3\buildTransitive\Xamarin.Build.Download.targets(52,3):
error : Cannot create a file when that file already exists. [C:\a\_work\1\s\generated\com.google.assistant.appactions.widgets\com.google.assistant.appactions.widgets.csproj]
```
`Xamarin.Google.Assistant.AppActions.Widgets`

https://www.nuget.org/packages/Xamarin.Google.Assistant.AppActions.Widgets/0.0.1.1#dependencies-body-tab

depends on `Xamarin.GooglePlayServices.Basement`

https://www.nuget.org/packages/Xamarin.GooglePlayServices.Basement/#dependencies-body-tab

which depends on XBS 0.11.3 and causes download issues.


### Does this change any of the generated binding API's?

No.

### Describe your contribution

version bumps.

Related:

https://github.com/xamarin/GooglePlayServicesComponents/pull/726