### PR TITLE
[ci] Separate building packages and building samples into separate steps.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -734,6 +734,9 @@ Task("samples-generate-all-targets")
 
 Task("samples")
     .IsDependentOn("nuget")
+    .IsDependentOn("samples-only");
+
+Task("samples-only")
     .IsDependentOn("samples-generate-all-targets")
     .Does(() =>
 {
@@ -778,8 +781,12 @@ Task("samples")
     return;
 });
 
+
 Task("samples-dotnet")
     .IsDependentOn("nuget")
+    .IsDependentOn("samples-only-dotnet");
+
+Task("samples-only-dotnet")
     .IsDependentOn("samples-generate-all-targets")
     .Does(() =>
 {
@@ -993,13 +1000,23 @@ Task ("full-run")
     ;
 
 Task ("ci")
+    .IsDependentOn ("ci-build")
+    .IsDependentOn ("ci-samples")
+    ;
+
+// Builds packages but does not run samples
+Task ("ci-build")
     .IsDependentOn ("check-tools")
     .IsDependentOn ("inject-variables")
     .IsDependentOn ("binderate")
     .IsDependentOn ("nuget")
-    .IsDependentOn ("samples")
-    .IsDependentOn ("samples-dotnet")
     .IsDependentOn ("tools-executive-order")
+    ;
+
+// Runs samples without building packages
+Task ("ci-samples")
+    .IsDependentOn ("samples-only")
+    .IsDependentOn ("samples-only-dotnet")
     ;
 
 // for local builds, conditionally do the first binderate

--- a/build/ci/build-and-test.yml
+++ b/build/ci/build-and-test.yml
@@ -10,10 +10,9 @@ parameters:
   - Square
 
 steps:
-  # before the build starts, make sure the tooling is as expected
   - pwsh: |
       dotnet cake build.cake `
-        --target=ci `
+        --target=ci-build `
         --configuration="${{ parameters.configuration }}" `
         --verbosity="${{ parameters.verbosity }}"
     displayName: 'Build packages'
@@ -40,6 +39,19 @@ steps:
 
   - pwsh: dotnet cake utilities.cake -t=verify-namespace-file
     displayName: Verify published namespaces
+
+  - pwsh: |
+      dotnet cake build.cake `
+        --target=ci-samples `
+        --configuration="${{ parameters.configuration }}" `
+        --verbosity="${{ parameters.verbosity }}"
+    displayName: 'Build samples'
+    env:
+      JavaSdkDirectory: $(JAVA_HOME)
+      RepositoryCommit: $(Build.SourceVersion)
+      RepositoryBranch: $(Build.SourceBranchName)
+      RepositoryUrl: $(Build.Repository.Uri)
+      RepositoryType: "git"
     
   - task: DotNetCoreCLI@2
     displayName: Run unit tests


### PR DESCRIPTION
Move building packages and building samples into separate CI steps so building packages can succeed and run other CI steps even if the samples step fails.

![image](https://user-images.githubusercontent.com/179295/207946382-471046de-0184-44e6-bc87-96a6ce40c894.png)

This is accomplished with new `ci-build` and `ci-samples` Cake targets.  All existing targets continue to function the same as they always have.