### PR TITLE
schedule new releases on friday instead of monday

### DIFF
--- a/.github/workflows/new-releases-check.yml
+++ b/.github/workflows/new-releases-check.yml
@@ -5,7 +5,7 @@ name: Check for new stable releases
 # Runs every Monday at 06:00 UTC
 on:
   schedule:
-    - cron: 0 6 * * 1
+    - cron: 0 6 * * 5
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Changed scheduled job to start at Friday instead of Monday.
