### PR TITLE
[Directory.Build.props] Add $(_DefaultTargetFrameworks).

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,9 @@
     <RepositoryBranch>$(BUILD_SOURCEBRANCH)</RepositoryBranch>
     <RepositoryCommit>$(BUILD_SOURCEVERSION)</RepositoryCommit>
 
+    <!-- Default TFM's we build for -->
+    <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android</_DefaultTargetFrameworks>
+
     <!-- Opt out of C#8 features to maintain compatibility with legacy -->
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
     <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -2,7 +2,7 @@
 @using System.Linq
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {
     <AssemblyName>@(Model.AssemblyName)</AssemblyName>

--- a/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
+++ b/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Xamarin.AndroidX.AppCompat.Resources</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>

--- a/templates/accompanist/Project.cshtml
+++ b/templates/accompanist/Project.cshtml
@@ -7,7 +7,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>@(rootNamespace)</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>

--- a/templates/auto-value/Project.cshtml
+++ b/templates/auto-value/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>Annotations</RootNamespace>
     <AssemblyName>Xamarin.Google.AutoValue.Annotations</AssemblyName>

--- a/templates/dev-chrisbanes-snapper/Project.cshtml
+++ b/templates/dev-chrisbanes-snapper/Project.cshtml
@@ -7,7 +7,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>@(rootNamespace)</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>

--- a/templates/flogger/Project.cshtml
+++ b/templates/flogger/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/gson/Project.cshtml
+++ b/templates/gson/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>GoogleGson</RootNamespace>
     <AssemblyName>GoogleGson</AssemblyName>

--- a/templates/guava/Project.cshtml
+++ b/templates/guava/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/installreferrer/Project.cshtml
+++ b/templates/installreferrer/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>Annotations</RootNamespace>
     <AssemblyName>Xamarin.Google.Android.InstallReferrer</AssemblyName>

--- a/templates/kotlin/Project.cshtml
+++ b/templates/kotlin/Project.cshtml
@@ -7,7 +7,7 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>Xamarin.Kotlin</RootNamespace>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {

--- a/templates/kotlinx/Project.cshtml
+++ b/templates/kotlinx/Project.cshtml
@@ -7,7 +7,7 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>Xamarin.KotlinX.Coroutines.Core</RootNamespace>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {

--- a/templates/napier/Project.cshtml
+++ b/templates/napier/Project.cshtml
@@ -7,7 +7,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>@(rootNamespace)</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>

--- a/templates/no-bindings/Project.cshtml
+++ b/templates/no-bindings/Project.cshtml
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
   </PropertyGroup>
 

--- a/templates/reactive-streams/Project.cshtml
+++ b/templates/reactive-streams/Project.cshtml
@@ -7,7 +7,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>@(rootNamespace)</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>

--- a/templates/rxjava/Project.cshtml
+++ b/templates/rxjava/Project.cshtml
@@ -9,7 +9,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>ReactiveX</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>

--- a/templates/tink/Project.cshtml
+++ b/templates/tink/Project.cshtml
@@ -7,7 +7,7 @@
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <RootNamespace>@(rootNamespace)</RootNamespace>
     <AssemblyName>@(assembly_name)</AssemblyName>


### PR DESCRIPTION
Although we don't currently build and ship AndroidX for `net7.0` or `net8.0`, it is a good test exercise to run `generator` against AndroidX to ensure we aren't creating any regressions in `generator`.

To do this, we currently have to change the `TargetFrameworks` in ~16 templates.

Instead, let's put the default `TargetFrameworks` to build in `Directory.Build.props`, so it only has to be changed in one place.

Note that projects (like `Xamarin.AndroidBinderator.csproj`) can continue to explicitly specify their TF(s) if they need to.