### PR TITLE
[utilities.cake] Only look for namespaces in "obj" assemblies.

### DIFF
--- a/global.json
+++ b/global.json
@@ -9,6 +9,6 @@
         "MSBuild.Sdk.Extras": "3.0.44",
         "Microsoft.Build.Traversal": "3.2.0",
         "Microsoft.Build.NoTargets": "3.7.0",
-        "Xamarin.Legacy.Sdk": "0.2.0-alpha3"
+        "Xamarin.Legacy.Sdk": "0.2.0-alpha4"
     }
 }

--- a/utilities.cake
+++ b/utilities.cake
@@ -1645,11 +1645,11 @@ static List<string> FindNamespacesInDirectory (string directory)
 {
     var list = new SortedSet<string> ();
 
-    foreach (var file in System.IO.Directory.EnumerateFiles (directory, "*.dll", SearchOption.AllDirectories))
+    foreach (var file in System.IO.Directory.EnumerateFiles (directory, "*.dll", SearchOption.AllDirectories).Where (f => f.Replace ('\\', '/').Contains ("/obj/")))
         foreach (var ns in FindNamespaces (file))
             list.Add (ns);
 
-	return list.ToList ();
+    return list.ToList ();
 }
 
 static List<string> FindNamespaces (string assembly)


### PR DESCRIPTION
For some reason, `0.2.0-alpha4` of `Xamarin.Legacy.Sdk` causes package dependencies to be placed in the `/bin` directory whereas previously they were not.  Our published namespace script looks for all `.dll`'s in the `/generated` directory, which previously did not include dependencies.  This resulted in adding namespaces that were in dependencies and not just the assemblies packaged in this repository.

To fix this, we can restrict ourselves to looking for assemblies in the `/obj` directory, which does not contain dependency assemblies.