### PR TITLE
[msbuild] only include `@(ProguardConfiguration)` in apps

### DIFF
--- a/source/AndroidXTargets.cshtml
+++ b/source/AndroidXTargets.cshtml
@@ -21,7 +21,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt">
+    <ProguardConfiguration Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </ProguardConfiguration>
       }


### PR DESCRIPTION
A customer reported a build error such as:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.46\targets\Microsoft.Android.Sdk.AndroidLibraries.targets(77,5):
    error XACAAR7014: System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
    at System.Text.StringBuilder.ToString()
    at Xamarin.Android.Tasks.CreateAar.RunTask()
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute()

Somewhere here:

https://github.com/xamarin/xamarin-android/blob/c31f3eda63a16e412a39fa61eb0f885be3c5f543/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs#L108-L114

The problem appears to be triggered by:

    ProguardConfigurationFiles=
    ~\.nuget\packages\xamarin.androidx.versionedparcelable\1.1.1.15\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.lifecycle.runtime\2.5.1.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.core\1.9.0.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.savedstate\1.2.0.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.recyclerview\1.2.1.7\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.lifecycle.viewmodel\2.5.1.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.lifecycle.viewmodelsavedstate\2.5.1.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.fragment\1.5.3.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.vectordrawable.animated\1.1.0.14\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.transition\1.4.1.8\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.startup.startupruntime\1.1.1.2\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.lifecycle.process\2.5.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.coordinatorlayout\1.2.0.3\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.appcompat\1.5.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.google.android.material\1.7.0\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.window\1.0.0.10\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.navigation.common\2.5.2.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.navigation.ui\2.5.2.1\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ~\.nuget\packages\xamarin.androidx.media\1.6.0.2\buildTransitive\net6.0-android31.0\..\..\proguard\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\160\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\155\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\161\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\162\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\156\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\157\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\163\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\164\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\165\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\166\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\167\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\170\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\168\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\169\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\171\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\172\jl\proguard.txt
    ..\path\to\projectreference\obj\Debug\lp\173\jl\proguard.txt

We have a compounding issue:

* AndroidX NuGets add `proguard.txt` files to class libraries

* These make it to `YourClassLibrary.aar`

* You might have class libraries that reference other class libraries

* You end up with N^2 `proguard.txt` files and hit OOM.

Step 1 to fix this is to simply not add `@(ProguardConfiguration)` from the AndroidX NuGets for class libraries.

I will investigate how we solve the `obj\Debug\lp\173\jl\proguard.txt` entries in xamarin-android.
