### PR TITLE
[Binderator] Add support for `extraDependencies`.

### DIFF
--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -3,17 +3,18 @@
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <ToolCommandName>xamarin-android-binderator</ToolCommandName>
     <AssemblyName>Xamarin.AndroidBinderator.Tool</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Nullable>disable</Nullable>
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.5.4</PackageVersion>
+    <PackageVersion>0.5.5</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -50,6 +50,9 @@ namespace AndroidBinderator
 		[JsonProperty("excludedRuntimeDependencies")]
 		public string ExcludedRuntimeDependencies { get; set; }
 
+		[JsonProperty("extraDependencies")]
+		public string ExtraDependencies { get; set; }
+
 		[JsonProperty("templateSet")]
 		public string TemplateSet { get; set; }
 

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.3.4</PackageVersion>
+        <PackageVersion>2.3.5</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>


### PR DESCRIPTION
There are instances where we want to add a dependency to a package that is not specified in a library's POM file.

For example:
- https://github.com/xamarin/AndroidX/issues/727#issuecomment-1539066555
- https://github.com/xamarin/AndroidX/blob/main/source/AndroidXProject.cshtml#L179-L208

Because we do not currently have support for this, we have to hardcode `@if { }` blocks to the `.csproj` template each time we want to do this.

Instead, this commit adds support for `extraDependencies` in the `config.json`, for example:

```json
{
  "groupId": "androidx.annotation",
  "artifactId": "annotation",
  "version": "1.6.0",
  "nugetVersion": "1.6.0.1",
  "nugetId": "Xamarin.AndroidX.Annotation",
  "dependencyOnly": false,
  "extraDependencies": "com.google.errorprone.error_prone_annotations"
}
```

Which produces this in the `androidx.annotation.annotation.csproj`:
```xml
<ItemGroup>
  <ProjectReference Include="..\..\generated\com.google.errorprone.error_prone_annotations\com.google.errorprone.error_prone_annotations.csproj" PrivateAssets="none" />
</ItemGroup>
```

or

```xml
<ItemGroup>
  <PackageReference Include="Xamarin.Google.ErrorProne.Annotations" Version="2.16.0.1" PrivateAssets="none" />
</ItemGroup>
```

The dependency must exist in the `config.json` so that all the normal dependency graph logic works.  Multiple dependencies can be specified separated by commas.

A minimum dependency version can also be specified:
```
"extraDependencies": "com.google.errorprone.error_prone_annotations,com.google.android.gms.play-services-appindex:16.1.0"
```

The format is:
```
{group_id}.{artifact_id}:{version}
```