### PR TITLE
Manual updates 20230714 ci tools updates

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -9,7 +9,7 @@ parameters:
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
 
   # Tool Parameters
-  dotnetVersion: '6.0.408'                                  # the version of .NET to use
+  dotnetVersion: '6.0.410'                                  # the version of .NET to use
   dotnetWorkloadRollbackFile: 'workloads.json'
   dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'
@@ -18,8 +18,8 @@ parameters:
   skipUnitTests: false                                      # do not run unit test step
   
   tools:                                                    # a list of additional .NET global tools needed
-  - 'xamarin.androidbinderator.tool': '0.5.5'
-  - 'Cake.Tool': '2.2.0'
+  - 'xamarin.androidbinderator.tool': '0.5.6'
+  - 'Cake.Tool': '2.3.0'
   - 'boots': '1.1.0.712-preview2'
   - 'api-tools': '1.3.4'
 

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -9,7 +9,7 @@ parameters:
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
 
   # Tool Parameters
-  dotnetVersion: '6.0.410'                                  # the version of .NET to use
+  dotnetVersion: '6.0.408'                                  # the version of .NET to use
   dotnetWorkloadRollbackFile: 'workloads.json'
   dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Tooling  updates for CI.

Context:

CI builds fail

https://github.com/xamarin/GooglePlayServicesComponents/pull/794/checks?check_run_id=15026919516

The reason is older version of `xamarin.androidbinderator.tool`

```
Starting: Install tool: xamarin.androidbinderator.tool
==============================================================================
Task         : PowerShell
Description  : Run a PowerShell script on Linux, macOS, or Windows
Version      : 2.220.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/powershell
==============================================================================
Generating script.
========================== Starting Command Output ===========================
"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'C:\a\_work\_temp\ecd9799c-8404-4430-a48e-114aba91b926.ps1'"
The requested version 0.5.5 is lower than existing version 0.5.6.
##[error]PowerShell exited with code '1'.
Finishing: Install tool: xamarin.androidbinderator.tool
```

### Describe your contribution

Updated tool versions for CI/AzDO.