### PR TITLE
Add support for exact version NuGet dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+  <!-- Enables "ExactVersion" attribute on "ProjectReference" to allow an exact NuGet reference version to be used.
+       https://github.com/NuGet/Home/issues/5556#issuecomment-1179526189  -->
+  <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_ProjectReferenceWithExplicitPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.PackageVersion)' != ''" />
+      <_ProjectReferenceWithExactPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.ExactVersion)' == 'true'" />
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExplicitPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>@(_ProjectReferenceWithExplicitPackageVersion->'%(PackageVersion)')</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExactPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>[@(_ProjectReferencesWithVersions->'%(ProjectVersion)')]</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferencesWithVersions Remove="@(_ProjectReferenceWithReassignedVersion)" />
+      <_ProjectReferencesWithVersions Include="@(_ProjectReferenceWithReassignedVersion)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -172,7 +172,8 @@
     <!-- ProjectReference -->
     @foreach (var dep in @Model.NuGetDependencies) {
       if (dep.IsProjectReference) {
-        <ProjectReference Include="..\..\generated\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId)\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId).csproj" PrivateAssets="none" />
+        var exact_version = dep.MavenArtifact.MavenArtifactVersion.StartsWith('[').ToString();
+        <ProjectReference Include="..\..\generated\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId)\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId).csproj" PrivateAssets="none" ExactVersion="@(exact_version)" />
 
       }
     }


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/764

Today, `binderator` enforces "exact dependencies" specified in POM files.  If you do not fulfill them you get this error:

```
System.Exception: 
No matching artifact config found for: 
    androidx.preference.preference:[1.2.0]
to satisfy dependency of: 
    androidx.preference.preference-ktx:1.2.0
```

However, when we create NuGets we ignore this requirement and instead allow a "greater than or equal to" dependency.  When types move from one package to another and the package versions are not kept locked, it can result in errors like `Type androidx.lifecycle.DispatchQueue is defined multiple times`. (https://github.com/xamarin/AndroidX/issues/764)

A wrinkle is that we use `<ProjectReference>` to create our dependency tree and it does not currently support specifying an "exact" version dependency.  https://github.com/NuGet/Home/issues/5556

A workaround is to use a custom target in `Directory.Build.targets` that allows a `ExactVersion="true"` attribute to be added to a `<ProjectReference>`.  This attribute is then taken into account when NuGet `pack` is run.

This should help mitigate future errors caused by types moving between Java packages that should always have synced versions.