### PR TITLE
Use an updated `generator`.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,10 @@
     <!-- Default TFM's we build for -->
     <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android;net7.0-android</_DefaultTargetFrameworks>
 
+    <!-- Use an updated 'generator' -->
+    <!--<_BindingsToolsLocation>$(MSBuildThisFileDirectory)/java.interop/bin/Release-net7.0/</_BindingsToolsLocation>-->
+    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.0-rc.2.479/tools/</_BindingsToolsLocation>
+    
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     
@@ -37,8 +41,11 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://aka.ms/androidx</PackageProjectUrl>
-  </PropertyGroup>
 
+    <!-- Exclude TF-specific transform files by default -->
+    <DefaultTransformExcludes>**/*.MonoAndroid12.0.xml;**/*.net6.0-android.xml;**/*.net7.0-android.xml</DefaultTransformExcludes>
+  </PropertyGroup>
+  
   <!-- Folders that .targets files need to go into -->
   <ItemGroup>
     <AndroidXNuGetTargetFolders Include="build\monoandroid12.0" />

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 // Tools needed by cake addins
 #tool nuget:?package=Cake.CoreCLR
 #tool nuget:?package=vswhere&version=3.1.7
+#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.0-rc.2.479
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=6.1.3

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -16,6 +16,7 @@ parameters:
   classicXAPkg:  https://aka.ms/xamarin-android-commercial-d17-4-macos
   classicXAVsix: https://aka.ms/xamarin-android-commercial-d17-4-windows
   skipUnitTests: false                                      # do not run unit test step
+  JICommit: 5adb4d487279d52dc10055f31bd1da9e1efab3ef        # The commit of Java.Interop to use
   
   tools:                                                    # a list of additional .NET global tools needed
   - 'xamarin.androidbinderator.tool': '0.5.7'
@@ -33,7 +34,7 @@ parameters:
   publishOutputSuffix: ''                                   # the artifact suffix to use when publishing the output folder
   signListPath: 'SignList.xml'                              # the path to the SignList.xml to copy into the nuget artifact for signing
   artifactsPath: 'output'                                   # the path to the NuGet packages that need to be signed, verified and published
-
+  
 jobs:
   - job: ${{ parameters.name }}
     strategy:
@@ -66,6 +67,10 @@ jobs:
           dotnetTools: ${{ parameters.tools }}
           classicInstallerUrl: $(classicInstallerUrl)
 
+      #- template: update-generator.yml
+      #  parameters:
+      #    JICommit: ${{ parameters.JICommit }}
+          
       - template: build-and-test.yml
         parameters:
           artifactsPath: ${{ parameters.artifactsPath }}

--- a/build/ci/update-generator.yml
+++ b/build/ci/update-generator.yml
@@ -1,0 +1,28 @@
+parameters:
+  condition: succeeded()
+  JICommit:                              # The commit of Java.Interop to use
+      
+steps:
+- pwsh: git clone --recurse-submodules https://github.com/xamarin/java.interop.git
+    
+- pwsh: git switch androidx-generator
+  workingDirectory: java.interop
+  
+- task: DotNetCoreCLI@2
+  displayName: Prepare Solution
+  inputs:
+    projects: java.interop/Java.Interop.sln
+    arguments: '-c Release -target:Prepare'
+
+- task: DotNetCoreCLI@2
+  displayName: Shut down existing build server
+  inputs:
+    command: custom
+    custom: build-server
+    arguments: shutdown
+
+- task: DotNetCoreCLI@2
+  displayName: Build Solution
+  inputs:
+    projects: java.interop/Java.Interop.sln
+    arguments: '-c Release'

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -126,7 +126,10 @@
     <TransformFile Include="..\..\source\Metadata.common.xml" >
       <Link>Transforms/Metadata.common.xml</Link>
     </TransformFile>
-    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml">
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)">
+        <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    </TransformFile>
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.$(TargetFramework).xml">
         <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
     </TransformFile>
     <AndroidJavaSource

--- a/source/Xamarin.Kotlin.StdLib/Additions/InterfacesFixups.cs
+++ b/source/Xamarin.Kotlin.StdLib/Additions/InterfacesFixups.cs
@@ -1,4 +1,7 @@
-﻿namespace Kotlin.Collections
+using Java.Lang;
+using Java.Util;
+
+namespace Kotlin.Collections
 {
 	// TODO: Remove these fixes when this bug is fixed:
 	//       https://github.com/xamarin/java.interop/issues/470
@@ -11,3 +14,22 @@
 	{
 	}
 }
+
+#if NET7_0_OR_GREATER
+namespace Kotlin.Collections.Builders
+{
+	public partial class MapBuilder
+	{
+		int IMap.Size () => Size;
+
+		global::System.Collections.ICollection IMap.Values () => Values;
+	}
+
+	public partial class MapBuilderEntries
+	{
+		public override bool Add (Object? element) => Add ((IMapEntry) element!);
+
+		public override int GetSize () => Size;
+	}
+}
+#endif

--- a/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.xml
+++ b/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.xml
@@ -442,4 +442,5 @@
       Kotlin.Time.ITimeMark
     </attr>
 
+    <remove-node path="/api/package[@name='kotlin.collections.builders']/class[@name='AbstractMapBuilderEntrySet']/method[@name='contains' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]" />
   </metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.MonoAndroid12.0.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.MonoAndroid12.0.xml
@@ -1,0 +1,119 @@
+<metadata>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+</metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.net6.0-android.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.net6.0-android.xml
@@ -1,0 +1,119 @@
+<metadata>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+</metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.xml
@@ -569,17 +569,6 @@
         >
         Xamarin.Google.Crypto.Tink.Key
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-
     <attr
         path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='SignaturePrivateKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -592,16 +581,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.aead']/class[@name='XChaCha20Poly1305Key']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -644,15 +623,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.mac']/class[@name='HmacKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -679,34 +649,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.hybrid']/class[@name='HybridPrivateKey']/method[@name='getPublicKey' and count(parameter)=0]"
         name="managedReturn"
@@ -734,15 +676,6 @@
             synchronized="false" synthetic="false" 
             />
     </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.hybrid']/class[@name='HybridPrivateKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -761,24 +694,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.jwt']/class[@name='JwtMacKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -797,47 +712,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false"  
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false"  
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-
-
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.jwt']/class[@name='JwtSignaturePrivateKey']/method[@name='getPublicKey' and count(parameter)=0]"
         name="managedReturn"

--- a/templates/tink/Project.cshtml
+++ b/templates/tink/Project.cshtml
@@ -39,7 +39,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.$(TargetFramework).xml" Link="Transforms\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This version allows us to download and build the `Java.Interop` repository from a specified commit id.  We then use the built `generator`.

In the end we went with a pre-existing NuGet package instead (the one we ship with `net8.0-android`).  

However this code may be useful in the future for other purposes? 🤷‍♂️ 