### PR TITLE
Fix for AndroidX.AppCompat AOT/Reflection/Linking errors

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -139,7 +139,7 @@
           "groupId": "androidx.appcompat",
           "version": "1.6.1",
           "nuGetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
-          "nuGetVersion": "1.6.1.3"
+          "nuGetVersion": "1.6.1.4"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -113,7 +113,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.3",
+        "nugetVersion": "1.6.1.4",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
         "dependencyOnly": false
       },

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -15,7 +15,7 @@
 |   8|androidx.annotation:annotation-experimental                           |1.3.1               |Xamarin.AndroidX.Annotation.Experimental                              |1.3.1.1             |
 |   9|androidx.annotation:annotation-jvm                                    |1.6.0               |Xamarin.AndroidX.Annotation.Jvm                                       |1.6.0.2             |
 |  10|androidx.appcompat:appcompat                                          |1.6.1               |Xamarin.AndroidX.AppCompat                                            |1.6.1.3             |
-|  11|androidx.appcompat:appcompat-resources                                |1.6.1               |Xamarin.AndroidX.AppCompat.AppCompatResources                         |1.6.1.3             |
+|  11|androidx.appcompat:appcompat-resources                                |1.6.1               |Xamarin.AndroidX.AppCompat.AppCompatResources                         |1.6.1.4             |
 |  12|androidx.arch.core:core-common                                        |2.2.0               |Xamarin.AndroidX.Arch.Core.Common                                     |2.2.0.3             |
 |  13|androidx.arch.core:core-runtime                                       |2.2.0               |Xamarin.AndroidX.Arch.Core.Runtime                                    |2.2.0.3             |
 |  14|androidx.asynclayoutinflater:asynclayoutinflater                      |1.0.0               |Xamarin.AndroidX.AsyncLayoutInflater                                  |1.0.0.19            |

--- a/source/androidx.appcompat/appcompat-resources/Additions/AndroidX.AppCompat.Graphics.Drawable.DrawableContainer.cs
+++ b/source/androidx.appcompat/appcompat-resources/Additions/AndroidX.AppCompat.Graphics.Drawable.DrawableContainer.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AndroidX.AppCompat.Graphics.Drawable
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso href="https://github.com/dotnet/maui/issues/16074" />
+    /// <seealso href="https://github.com/xamarin/Xamarin.Forms/issues/15668" />
+    /// <seealso href="https://github.com/xamarin/AndroidX/issues/690#issuecomment-1414325720" />
+    [Obsolete("This class is obsoleted in this android platform. Google replaced DrawableContainer with DrawableContainerCompat")]
+    public partial class DrawableContainer : DrawableContainerCompat
+    {
+    }
+}

--- a/source/androidx.appcompat/appcompat-resources/Additions/AndroidX.AppCompat.Graphics.Drawable.DrawableWrapper.cs
+++ b/source/androidx.appcompat/appcompat-resources/Additions/AndroidX.AppCompat.Graphics.Drawable.DrawableWrapper.cs
@@ -1,0 +1,22 @@
+using Android.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AndroidX.AppCompat.Graphics.Drawable
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso href="https://github.com/dotnet/maui/issues/16074" />
+    /// <seealso href="https://github.com/xamarin/Xamarin.Forms/issues/15668" />
+    /// <seealso href="https://github.com/xamarin/AndroidX/issues/690#issuecomment-1414325720" />
+    [Obsolete("This class is obsoleted in this android platform. Google replaced DrawableWrapper with DrawableWrapperCompat")]
+    public partial class DrawableWrapper : DrawableWrapperCompat
+    {
+        public DrawableWrapper(global::Android.Graphics.Drawables.Drawable drawable) : base(drawable)
+        {
+
+        }
+    }
+}

--- a/source/androidx.appcompat/appcompat-resources/Additions/readme.md
+++ b/source/androidx.appcompat/appcompat-resources/Additions/readme.md
@@ -1,0 +1,16 @@
+# Additions
+
+## AOT Reflection issues
+
+*   https://github.com/dotnet/maui/issues/16074
+
+    Including specific android libraries via nuget causes AOT failures on RELEASE build #16074
+
+*   https://github.com/xamarin/Xamarin.Forms/issues/15668
+
+    [Bug] Updating Xamarin.AndroidX.AppCompat to 1.6.0 causes ReflectionLoadException #15668
+
+*   https://github.com/xamarin/AndroidX/issues/690#issuecomment-1414325720
+
+    Mono.Cecil.ResolutionException: Failed to resolve AndroidX.AppCompat.Graphics.Drawable.DrawableWrapper #690
+


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Yes. Adds 2 classes that were removed by google (replaced with alternatives)

### Describe your contribution

- dummy Addtions classes added to prevent Reflection, Mono.Cecil, AOT - linking errors in general
  - `AndroidX.AppCompat.Graphics.Drawable.DrawableContainer`
  - `AndroidX.AppCompat.Graphics.Drawable.DrawableWrapper`
- classes are marked with `Obsolete` attribute

Should fix MAUI/Xamarin.Forms issues:

*   https://github.com/dotnet/maui/issues/16074

    Including specific android libraries via nuget causes AOT failures on RELEASE build #16074

*   https://github.com/xamarin/Xamarin.Forms/issues/15668

    [Bug] Updating Xamarin.AndroidX.AppCompat to 1.6.0 causes ReflectionLoadException #15668

*   https://github.com/xamarin/AndroidX/issues/690#issuecomment-1414325720

    Mono.Cecil.ResolutionException: Failed to resolve AndroidX.AppCompat.Graphics.Drawable.DrawableWrapper #690

