### PR TITLE
Manual updates 20230826 androidx.datastore (needed for firebase-sessions)

### DIFF
--- a/config.json
+++ b/config.json
@@ -630,6 +630,54 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore-core",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore.Core",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore-preferences",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore.Preferences",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore-preferences-core",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore.Preferences.Core",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore-rxjava2",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore.RxJava2",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "androidx.datastore",
+        "artifactId": "datastore-rxjava3",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
+        "nugetId": "Xamarin.AndroidX.Datastore.RxJava3",
+        "dependencyOnly": false
+      },
+      {
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",

--- a/source/androidx.datastore/datastore-core/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore-core/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.datastore/datastore-preferences-core/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore-preferences-core/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.datastore/datastore-preferences/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore-preferences/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.datastore/datastore-rxjava2/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore-rxjava2/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.datastore/datastore-rxjava3/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore-rxjava3/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/androidx.datastore/datastore/Transforms/Metadata.xml
+++ b/source/androidx.datastore/datastore/Transforms/Metadata.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):


### Does this change any of the generated binding API's?


### Describe your contribution
