### PR TITLE
[binderator] Allow `extraDependencies` to specify an `excludedDependency`.

### DIFF
--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.5.6</PackageVersion>
+    <PackageVersion>0.5.7</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -318,14 +318,24 @@ namespace AndroidBinderator
 					MavenArtifactConfig = mavenArtifact
 				});
 
-				// Gather maven dependencies to try and map out nuget dependencies
-				foreach (var mavenDep in mavenProject.Dependencies.Concat(ParseExtraDependencies(mavenArtifact.ExtraDependencies)))
-				{
+				List<Dependency> dependencies = new List<Dependency>();
+
+				// Find all the POM specified dependencies that we need to consider
+				foreach (var mavenDep in mavenProject.Dependencies) {
 					FixDependency(config, mavenArtifact, mavenDep, mavenProject);
 
 					if (!ShouldIncludeDependency(config, mavenArtifact, mavenDep, exceptions))
 						continue;
 
+					dependencies.Add(mavenDep);
+				}
+
+				// Add any "extraDependencies"
+				dependencies.AddRange(ParseExtraDependencies(mavenArtifact.ExtraDependencies));
+
+				// Try and map out nuget dependencies
+				foreach (var mavenDep in dependencies)
+				{
 					mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
 					mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
 

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.3.6</PackageVersion>
+        <PackageVersion>2.3.7</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/773

We have an artifact that specifies a dependency that we cannot automatically figure out the version to (likely due to unsupported parent POMs).

We would like to work around this by ignoring the bad dependency with `excludedRuntimeDependencies`, and then adding it back with `extraDependencies`, which will use the dependency version specified in the config file:

```
"groupId": "androidx.wear.protolayout",
"artifactId": "protolayout-expression",
"excludedRuntimeDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
"extraDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
```

However, the way we currently process this, the dependency gets excluded because the "excludes" are processed after the "extras".

Rework the logic so we run the "excludes" first and then add in the "extras".