### PR TITLE
Manual updates 20230915 fix ci cake builds - bad il format

### DIFF
--- a/.github/workflows/new-releases-check.yml
+++ b/.github/workflows/new-releases-check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.x.x
+        dotnet-version: 7.x.x
         
     - name: Install dotnet-script
       run: dotnet tool install -g dotnet-script

--- a/build.cake
+++ b/build.cake
@@ -977,7 +977,6 @@ Task ("full-run")
     .IsDependentOn ("nuget")
     .IsDependentOn ("samples")
     .IsDependentOn ("samples-dotnet")
-    .IsDependentOn ("tools-executive-order")
     ;
 
 Task ("ci")
@@ -991,7 +990,6 @@ Task ("ci-build")
     .IsDependentOn ("inject-variables")
     .IsDependentOn ("binderate")
     .IsDependentOn ("nuget")
-    .IsDependentOn ("tools-executive-order")
     ;
 
 // Runs samples without building packages

--- a/build.cake
+++ b/build.cake
@@ -1,9 +1,9 @@
 // Tools needed by cake addins
-#tool nuget:?package=Cake.CoreCLR
+#tool nuget:?package=Cake.CoreCLR               // needed for debugging
 #tool nuget:?package=vswhere&version=3.1.1
 
 // Cake Addins
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
+#addin "Cake.FileHelpers"
 #addin nuget:?package=Newtonsoft.Json&version=13.0.3
 #addin nuget:?package=Cake.MonoApiTools&version=3.0.5
 #addin nuget:?package=CsvHelper&version=30.0.1
@@ -822,25 +822,6 @@ Task("samples-only-dotnet")
         });
     }
 });
-
-Task("tools-executive-order")
-    .Does
-    (
-        () =>
-        {
-            CakeExecuteScript
-                        (
-                            "./utilities.cake",
-                            new CakeSettings
-                            { 
-                                Arguments = new Dictionary<string, string>() 
-                                { 
-                                    { "target", "tools-executive-order" } 
-                                } 
-                            }
-                        );        
-        }
-    );
 
 Task("api-diff")
     .Does

--- a/build.cake
+++ b/build.cake
@@ -4,10 +4,10 @@
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=5.0.0
-#addin nuget:?package=Newtonsoft.Json&version=13.0.2
+#addin nuget:?package=Newtonsoft.Json&version=13.0.3
 #addin nuget:?package=Cake.MonoApiTools&version=3.0.5
 #addin nuget:?package=CsvHelper&version=30.0.1
-#addin nuget:?package=SharpZipLib&version=1.4.1
+#addin nuget:?package=SharpZipLib&version=1.4.2
 
 // #addin nuget:?package=NuGet.Protocol&loaddependencies=true&version=5.6.0
 // #addin nuget:?package=NuGet.Versioning&loaddependencies=true&version=5.6.0

--- a/build/ci/build-and-test.yml
+++ b/build/ci/build-and-test.yml
@@ -41,6 +41,9 @@ steps:
   - pwsh: dotnet cake utilities.cake -t=verify-namespace-file
     displayName: Verify published namespaces
 
+  - pwsh: dotnet cake utilities.cake -t=tools-executive-order
+    displayName: Generate Executive Order Build Inventory
+
   - pwsh: |
       dotnet cake build.cake `
         --target=ci-samples `

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -19,7 +19,7 @@ parameters:
   
   tools:                                                    # a list of additional .NET global tools needed
   - 'xamarin.androidbinderator.tool': '0.5.7'
-  - 'Cake.Tool': '2.3.0'
+  - 'Cake.Tool': '2.2.0'
   - 'boots': '1.1.0.712-preview2'
   - 'api-tools': '1.3.4'
 

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -19,7 +19,7 @@ parameters:
   
   tools:                                                    # a list of additional .NET global tools needed
   - 'xamarin.androidbinderator.tool': '0.5.7'
-  - 'Cake.Tool': '3.1.0'
+  - 'Cake.Tool': '2.3.0'
   - 'boots': '1.1.0.712-preview2'
   - 'api-tools': '1.3.4'
 

--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -1,8 +1,8 @@
 #! "net6.0"
 
 #r "nuget: MavenNet, 2.2.13"
-#r "nuget: Newtonsoft.Json, 13.0.1"
-#r "nuget: NuGet.Versioning, 5.11.0"
+#r "nuget: Newtonsoft.Json, 13.0.3"
+#r "nuget: NuGet.Versioning, 6.7.0"
 
 // Usage:
 //   dotnet tool install -g dotnet-script

--- a/build/scripts/utilities.csx
+++ b/build/scripts/utilities.csx
@@ -1,6 +1,6 @@
 #! "net6.0"
 
-#r "nuget: Newtonsoft.Json, 13.0.1"
+#r "nuget: Newtonsoft.Json, 13.0.3"
 
 #r "nuget: HolisticWare.Xamarin.Tools.ComponentGovernance, 0.0.1.1"
 #r "nuget: HolisticWare.Core.Net.HTTP, 0.0.1"

--- a/utilities.cake
+++ b/utilities.cake
@@ -5,9 +5,9 @@
     dotnet cake spell-check.cake -t=spell-check
  */
 #addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
-#addin nuget:?package=Newtonsoft.Json&version=12.0.3
-#addin nuget:?package=Cake.FileHelpers&version=3.2.1
-#addin nuget:?package=Mono.Cecil&version=0.11.4
+#addin nuget:?package=Newtonsoft.Json&version=13.0.3
+#addin nuget:?package=Cake.FileHelpers&version=5.0.0
+#addin nuget:?package=Mono.Cecil&version=0.11.5
 
 #addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2
 #addin nuget:?package=HolisticWare.Core.Net.HTTP&version=0.0.1

--- a/utilities.cake
+++ b/utilities.cake
@@ -4,9 +4,9 @@
      dotnet cake spell-check.cake
     dotnet cake spell-check.cake -t=spell-check
  */
-#addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
+#addin "Cake.FileHelpers"
+#addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
 #addin nuget:?package=Newtonsoft.Json&version=13.0.3
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
 #addin nuget:?package=Mono.Cecil&version=0.11.5
 
 #addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

Context:

Cake fails on CI server[s] with error

```
Error: Bad IL format. The format of the file '/Users/runner/work/1/s/tools/Addins/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple.4.3.0/runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.Apple.dylib' is invalid.
An error occurred when executing task 'tools-executive-order'.
Error: .NET CLI: Process returned an error (exit code 1).
```

- Cake downgrade 3.1.0 -> 2.3.0
- updated other tools and nuget dependencies