### PR TITLE
manual updates 20231019 - Cake.Tool 3.2.0-alpha0025 setup

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -40,3 +40,7 @@ steps:
         
   - pwsh: boots --url $(classicInstallerUrl) --downgrade-first
     displayName: 'Install Classic XA'
+
+  - pwsh: |
+      dotnet tool uninstall --global Cake.Tool 
+      dotnet tool install --global Cake.Tool --add-source https://pkgs.dev.azure.com/cake-build/Cake/_packaging/cake/nuget/v3/index.json --version 3.2.0-alpha0025


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Infrastructure.

While waiting for release of Cake 3.2.0, let's use Cake.Tool preview

https://github.com/cake-build/cake/pull/4206
https://github.com/cake-build/cake/pull/4206#issuecomment-1742215387
https://dev.azure.com/cake-build/Cake/_artifacts/feed/cake/NuGet/Cake.Tool/overview/3.2.0-alpha0025

### Describe your contribution

Changed template to install Cake.Tool preview.

Added something like this:

```
dotnet tool uninstall --global Cake.Tool
dotnet tool install --global \
    Cake.Tool \
    --add-source https://pkgs.dev.azure.com/cake-build/Cake/_packaging/cake/nuget/v3/index.json \
    -version 3.2.0-alpha0025
```