### PR TITLE
Weekly stable updates 20231027

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3371,9 +3371,9 @@
         "maven": {
           "artifactId": "guava",
           "groupId": "com.google.guava",
-          "version": "32.1.3-android",
+          "version": "32.0.1-android",
           "nuGetId": "Xamarin.Google.Guava",
-          "nuGetVersion": "32.1.3"
+          "nuGetVersion": "32.0.1"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3371,9 +3371,9 @@
         "maven": {
           "artifactId": "guava",
           "groupId": "com.google.guava",
-          "version": "31.1-android",
+          "version": "32.1.3-android",
           "nuGetId": "Xamarin.Google.Guava",
-          "nuGetVersion": "31.1.0.10"
+          "nuGetVersion": "32.1.3"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -2132,8 +2132,8 @@
       {
         "groupId": "com.google.guava",
         "artifactId": "guava",
-        "version": "31.1-android",
-        "nugetVersion": "31.1.0.10",
+        "version": "32.0.1-android",
+        "nugetVersion": "32.0.1",
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",

--- a/config.json
+++ b/config.json
@@ -2462,8 +2462,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.20.0",
-        "nugetVersion": "2.20.0.1",
+        "version": "2.21.1",
+        "nugetVersion": "2.21.1",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": true
       },

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -264,7 +264,7 @@
 | 257|com.google.flogger:flogger                                            |0.8                 |Xamarin.Flogger                                                       |0.8.0               |
 | 258|com.google.flogger:flogger-system-backend                             |0.8                 |Xamarin.Flogger.SystemBackend                                         |0.8.0               |
 | 259|com.google.guava:failureaccess                                        |1.0.2               |Xamarin.Google.Guava.FailureAccess                                    |1.0.2               |
-| 260|com.google.guava:guava                                                |32.1.3-android      |Xamarin.Google.Guava                                                  |32.1.3              |
+| 260|com.google.guava:guava                                                |32.0.1-android      |Xamarin.Google.Guava                                                  |32.0.1              |
 | 261|com.google.guava:listenablefuture                                     |1.0                 |Xamarin.Google.Guava.ListenableFuture                                 |1.0.0.16            |
 | 262|com.google.j2objc:j2objc-annotations                                  |2.8                 |Xamarin.Google.J2Objc.Annotations                                     |2.8.0.6             |
 | 263|dev.chrisbanes.snapper:snapper                                        |0.3.0               |Xamarin.Dev.ChrisBanes.Snapper                                        |0.3.0.7             |

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -264,7 +264,7 @@
 | 257|com.google.flogger:flogger                                            |0.8                 |Xamarin.Flogger                                                       |0.8.0               |
 | 258|com.google.flogger:flogger-system-backend                             |0.8                 |Xamarin.Flogger.SystemBackend                                         |0.8.0               |
 | 259|com.google.guava:failureaccess                                        |1.0.2               |Xamarin.Google.Guava.FailureAccess                                    |1.0.2               |
-| 260|com.google.guava:guava                                                |31.1-android        |Xamarin.Google.Guava                                                  |31.1.0.10           |
+| 260|com.google.guava:guava                                                |32.1.3-android      |Xamarin.Google.Guava                                                  |32.1.3              |
 | 261|com.google.guava:listenablefuture                                     |1.0                 |Xamarin.Google.Guava.ListenableFuture                                 |1.0.0.16            |
 | 262|com.google.j2objc:j2objc-annotations                                  |2.8                 |Xamarin.Google.J2Objc.Annotations                                     |2.8.0.6             |
 | 263|dev.chrisbanes.snapper:snapper                                        |0.3.0               |Xamarin.Dev.ChrisBanes.Snapper                                        |0.3.0.7             |


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):


### Does this change any of the generated binding API's?

No.

### Describe your contribution

Updates

- `com.google.guava:guava` - 31.1-android -> 32.0.1-android
- `com.google.errorprone:error_prone_annotations` - 2.20.0 -> 2.21.1
