### PR TITLE
Manual updates 20231110 infrastructure - Cake.Tool released 3.2.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,13 +1,13 @@
 // Tools needed by cake addins
 #tool nuget:?package=Cake.CoreCLR
-#tool nuget:?package=vswhere&version=3.1.1
+#tool nuget:?package=vswhere&version=3.1.7
 
 // Cake Addins
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
-#addin nuget:?package=Newtonsoft.Json&version=13.0.2
+#addin nuget:?package=Cake.FileHelpers&version=6.1.3
+#addin nuget:?package=Newtonsoft.Json&version=13.0.3
 #addin nuget:?package=Cake.MonoApiTools&version=3.0.5
 #addin nuget:?package=CsvHelper&version=30.0.1
-#addin nuget:?package=SharpZipLib&version=1.4.1
+#addin nuget:?package=SharpZipLib&version=1.4.2
 
 // #addin nuget:?package=NuGet.Protocol&loaddependencies=true&version=5.6.0
 // #addin nuget:?package=NuGet.Versioning&loaddependencies=true&version=5.6.0

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -19,9 +19,9 @@ parameters:
   
   tools:                                                    # a list of additional .NET global tools needed
   - 'xamarin.androidbinderator.tool': '0.5.7'
-  - 'Cake.Tool': '3.1.0'
+  - 'Cake.Tool': '3.2.0'
   - 'boots': '1.1.0.712-preview2'
-  - 'api-tools': '1.3.4'
+  - 'api-tools': '1.3.5'
 
   # Build Parameters
   verbosity: 'normal'                                       # the build verbosity: 'minimal', 'normal', 'diagnostic'

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -40,7 +40,3 @@ steps:
         
   - pwsh: boots --url $(classicInstallerUrl) --downgrade-first
     displayName: 'Install Classic XA'
-
-  - pwsh: |
-      dotnet tool uninstall --global Cake.Tool 
-      dotnet tool install --global Cake.Tool --add-source https://pkgs.dev.azure.com/cake-build/Cake/_packaging/cake/nuget/v3/index.json --version 3.2.0-alpha0025

--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -1,8 +1,8 @@
 #! "net6.0"
 
-#r "nuget: MavenNet, 2.2.13"
-#r "nuget: Newtonsoft.Json, 13.0.1"
-#r "nuget: NuGet.Versioning, 5.11.0"
+#r "nuget: MavenNet, 2.2.14"
+#r "nuget: Newtonsoft.Json, 13.0.3"
+#r "nuget: NuGet.Versioning, 6.7.0"
 
 // Usage:
 //   dotnet tool install -g dotnet-script

--- a/build/scripts/utilities.csx
+++ b/build/scripts/utilities.csx
@@ -1,10 +1,10 @@
 #! "net6.0"
 
-#r "nuget: Newtonsoft.Json, 13.0.1"
+#r "nuget: Newtonsoft.Json, 13.0.3"
 
-#r "nuget: HolisticWare.Xamarin.Tools.ComponentGovernance, 0.0.1.1"
-#r "nuget: HolisticWare.Core.Net.HTTP, 0.0.1"
-#r "nuget: HolisticWare.Core.IO, 0.0.1"
+#r "nuget: HolisticWare.Xamarin.Tools.ComponentGovernance, 0.0.1.4"
+#r "nuget: HolisticWare.Core.Net.HTTP, 0.0.4"
+#r "nuget: HolisticWare.Core.IO, 0.0.4"
 
 // Usage:
 //   dotnet tool install -g dotnet-script

--- a/utilities.cake
+++ b/utilities.cake
@@ -1216,7 +1216,7 @@ Task("generate-markdown-publish-log")
                 Error("No log file found");
                 Error($"     save ci log to {ci_publish_log_file}");
 
-                FileWriteText
+                System.IO.File.WriteAllText
                         (
                             ci_publish_log_file,
                             $"dotnet cake utilities.cake -t=generate-markdown-publish-log"

--- a/utilities.cake
+++ b/utilities.cake
@@ -4,14 +4,14 @@
      dotnet cake spell-check.cake
     dotnet cake spell-check.cake -t=spell-check
  */
-#addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
-#addin nuget:?package=Newtonsoft.Json&version=12.0.3
-#addin nuget:?package=Cake.FileHelpers&version=3.2.1
-#addin nuget:?package=Mono.Cecil&version=0.11.4
+#addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
+#addin nuget:?package=Newtonsoft.Json&version=13.0.3
+#addin nuget:?package=Cake.FileHelpers&version=6.1.3
+#addin nuget:?package=Mono.Cecil&version=0.11.5
 
-#addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2
-#addin nuget:?package=HolisticWare.Core.Net.HTTP&version=0.0.1
-#addin nuget:?package=HolisticWare.Core.IO&version=0.0.1
+#addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.4
+#addin nuget:?package=HolisticWare.Core.Net.HTTP&version=0.0.4
+#addin nuget:?package=HolisticWare.Core.IO&version=0.0.4
 
 using System.Collections.Generic;
 using System.Collections.Concurrent;


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Infrastructure updates (nugets)

Cake 3.2.0 was released

https://www.nuget.org/packages/Cake.Tool

https://www.nuget.org/packages/Cake.Tool/3.2.0

### Describe your contribution

Bumped nugets for infrastrcuture (CI AzDevOps).