### PR TITLE
[ci] Add support for generating `nuget-diff.md`.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -21,7 +21,7 @@ parameters:
   - 'xamarin.androidbinderator.tool': '0.5.7'
   - 'Cake.Tool': '3.2.0'
   - 'boots': '1.1.0.712-preview2'
-  - 'api-tools': '1.3.5'
+  - 'private-api-tools': '1.0.0'
 
   # Build Parameters
   verbosity: 'normal'                                       # the build verbosity: 'minimal', 'normal', 'diagnostic'

--- a/nuget-diff.cake
+++ b/nuget-diff.cake
@@ -38,14 +38,29 @@ if (!nupkgs.Any()) {
 				.Append("--prerelease")
 				.Append("--group-ids")
 				.Append("--ignore-unchanged")
+				.Append("--compare-nuget-structure")
 				.AppendSwitchQuoted("--output", OUTPUT_DIR.FullPath)
 				.AppendSwitchQuoted("--cache", CACHE_DIR.Combine("package-cache").FullPath)
 		});
 		if (exitCode != 0)
-			throw new Exception ($"api-tools exited with error code {exitCode}.");
+			throw new Exception ($"api-tools exited with error code {exitCode} ({nupkg.FullPath}).");
 	});
 }
 
+// SECTION: Create combined nuget-diff.md
+
+var nu_diffs = GetFiles($"{OUTPUT_DIR.FullPath}/**/nuget-diff.md");
+
+if (nu_diffs.Any()) {
+  using (var output = System.IO.File.Create(System.IO.Path.Combine(OUTPUT_DIR.FullPath, "all-nuget-diffs.md"))) {
+    foreach (var file in nu_diffs) {
+      using (var input = System.IO.File.OpenRead(file.FullPath)) {
+          input.CopyTo(output);
+          Console.WriteLine();
+      }
+    }
+  }
+}
 
 // SECTION: Upload Diffs
 


### PR DESCRIPTION
Context: https://github.com/mattleibow/Mono.ApiTools.NuGetDiff/pull/17

Creates a new CI artifact: `api-diff/all-nuget-diff.md`.

This file lists all changes made to the *structure* of NuGet packages built by this repository.  This will help give us extra confidence that we are not accidentally making breaking changes like removing a needed `.targets` file.

This includes:
- Changes to _which_ files are included in the package. (Note this is only presence of files, it does not compare file contents.)
- Changes to NuGet package metadata.

For example, adding support for `net7.0-android` to the `Xamarin.AndroidX.Core` package looks like this:

```
## Xamarin.AndroidX.Core

### Added/Removed File(s)

+ lib/net7.0-android33.0/Xamarin.AndroidX.Core.pdb
+ lib/net7.0-android33.0/Xamarin.AndroidX.Core.dll
+ lib/net7.0-android33.0/Xamarin.AndroidX.Core.xml
+ build/net7.0-android33.0/Xamarin.AndroidX.Core.targets
+ buildTransitive/net7.0-android33.0/Xamarin.AndroidX.Core.targets
```

Note: we are currently waiting on a new official published package of [api-tools](https://www.nuget.org/packages/api-tools) that contains this new support.  In the meantime this uses a locally built package called `private-api-tools`.