### PR TITLE
Weekly stable updates 20231124

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3552,9 +3552,9 @@
         "maven": {
           "artifactId": "kotlin-reflect",
           "groupId": "org.jetbrains.kotlin",
-          "version": "1.9.20",
+          "version": "1.9.21",
           "nuGetId": "Xamarin.Kotlin.Reflect",
-          "nuGetVersion": "1.9.20"
+          "nuGetVersion": "1.9.21"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -3565,9 +3565,9 @@
         "maven": {
           "artifactId": "kotlin-stdlib",
           "groupId": "org.jetbrains.kotlin",
-          "version": "1.9.20",
+          "version": "1.9.21",
           "nuGetId": "Xamarin.Kotlin.StdLib",
-          "nuGetVersion": "1.9.20"
+          "nuGetVersion": "1.9.21"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -3578,9 +3578,9 @@
         "maven": {
           "artifactId": "kotlin-stdlib-common",
           "groupId": "org.jetbrains.kotlin",
-          "version": "1.9.20",
+          "version": "1.9.21",
           "nuGetId": "Xamarin.Kotlin.StdLib.Common",
-          "nuGetVersion": "1.9.20"
+          "nuGetVersion": "1.9.21"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -3591,9 +3591,9 @@
         "maven": {
           "artifactId": "kotlin-stdlib-jdk7",
           "groupId": "org.jetbrains.kotlin",
-          "version": "1.9.20",
+          "version": "1.9.21",
           "nuGetId": "Xamarin.Kotlin.StdLib.Jdk7",
-          "nuGetVersion": "1.9.20"
+          "nuGetVersion": "1.9.21"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -3604,9 +3604,9 @@
         "maven": {
           "artifactId": "kotlin-stdlib-jdk8",
           "groupId": "org.jetbrains.kotlin",
-          "version": "1.9.20",
+          "version": "1.9.21",
           "nuGetId": "Xamarin.Kotlin.StdLib.Jdk8",
-          "nuGetVersion": "1.9.20"
+          "nuGetVersion": "1.9.21"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -2259,8 +2259,8 @@
       {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
-        "version": "1.9.20",
-        "nugetVersion": "1.9.20",
+        "version": "1.9.21",
+        "nugetVersion": "1.9.21",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2271,8 +2271,8 @@
       {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
-        "version": "1.9.20",
-        "nugetVersion": "1.9.20",
+        "version": "1.9.21",
+        "nugetVersion": "1.9.21",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "dependencyOnly": false,
         "templateSet": "kotlin"
@@ -2280,8 +2280,8 @@
       {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
-        "version": "1.9.20",
-        "nugetVersion": "1.9.20",
+        "version": "1.9.21",
+        "nugetVersion": "1.9.21",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2292,8 +2292,8 @@
       {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
-        "version": "1.9.20",
-        "nugetVersion": "1.9.20",
+        "version": "1.9.21",
+        "nugetVersion": "1.9.21",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2304,8 +2304,8 @@
       {
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
-        "version": "1.9.20",
-        "nugetVersion": "1.9.20",
+        "version": "1.9.21",
+        "nugetVersion": "1.9.21",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2462,8 +2462,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.21.1",
-        "nugetVersion": "2.21.1.1",
+        "version": "2.23.0",
+        "nugetVersion": "2.23.0",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": true
       },

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -278,11 +278,11 @@
 | 271|org.checkerframework:checker-compat-qual                              |2.5.6               |Xamarin.CheckerFramework.CheckerCompatQual                            |2.5.6               |
 | 272|org.checkerframework:checker-qual                                     |3.40.0              |Xamarin.CheckerFramework.CheckerQual                                  |3.40.0              |
 | 273|org.jetbrains:annotations                                             |24.1.0              |Xamarin.Jetbrains.Annotations                                         |24.1.0              |
-| 274|org.jetbrains.kotlin:kotlin-reflect                                   |1.9.20              |Xamarin.Kotlin.Reflect                                                |1.9.20              |
-| 275|org.jetbrains.kotlin:kotlin-stdlib                                    |1.9.20              |Xamarin.Kotlin.StdLib                                                 |1.9.20              |
-| 276|org.jetbrains.kotlin:kotlin-stdlib-common                             |1.9.20              |Xamarin.Kotlin.StdLib.Common                                          |1.9.20              |
-| 277|org.jetbrains.kotlin:kotlin-stdlib-jdk7                               |1.9.20              |Xamarin.Kotlin.StdLib.Jdk7                                            |1.9.20              |
-| 278|org.jetbrains.kotlin:kotlin-stdlib-jdk8                               |1.9.20              |Xamarin.Kotlin.StdLib.Jdk8                                            |1.9.20              |
+| 274|org.jetbrains.kotlin:kotlin-reflect                                   |1.9.21              |Xamarin.Kotlin.Reflect                                                |1.9.21              |
+| 275|org.jetbrains.kotlin:kotlin-stdlib                                    |1.9.21              |Xamarin.Kotlin.StdLib                                                 |1.9.21              |
+| 276|org.jetbrains.kotlin:kotlin-stdlib-common                             |1.9.21              |Xamarin.Kotlin.StdLib.Common                                          |1.9.21              |
+| 277|org.jetbrains.kotlin:kotlin-stdlib-jdk7                               |1.9.21              |Xamarin.Kotlin.StdLib.Jdk7                                            |1.9.21              |
+| 278|org.jetbrains.kotlin:kotlin-stdlib-jdk8                               |1.9.21              |Xamarin.Kotlin.StdLib.Jdk8                                            |1.9.21              |
 | 279|org.jetbrains.kotlinx:kotlinx-coroutines-android                      |1.7.3               |Xamarin.KotlinX.Coroutines.Android                                    |1.7.3.2             |
 | 280|org.jetbrains.kotlinx:kotlinx-coroutines-core                         |1.7.3               |Xamarin.KotlinX.Coroutines.Core                                       |1.7.3.2             |
 | 281|org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm                     |1.7.3               |Xamarin.KotlinX.Coroutines.Core.Jvm                                   |1.7.3.2             |


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Updates.

- `org.jetbrains.kotlin:kotlin-reflect` - 1.9.20 -> 1.9.21
- `org.jetbrains.kotlin:kotlin-stdlib` - 1.9.20 -> 1.9.21
- `org.jetbrains.kotlin:kotlin-stdlib-common` - 1.9.20 -> 1.9.21
- `org.jetbrains.kotlin:kotlin-stdlib-jdk7` - 1.9.20 -> 1.9.21
- `org.jetbrains.kotlin:kotlin-stdlib-jdk8` - 1.9.20 -> 1.9.21
- `com.google.errorprone:error_prone_annotations` - 2.21.1 -> 2.23.0
