### PR TITLE
buildtoolsinventory updates

### DIFF
--- a/docs/buildtoolsinventory.csv
+++ b/docs/buildtoolsinventory.csv
@@ -1,5 +1,5 @@
 BuildToolName,BuildToolVersion
-dotnet sdk, 7.0.306
+dotnet sdk, 7.0.403
 dotnet sdk, patch
 msbuild-sdks MSBuild.Sdk.Extras, 3.0.44
 msbuild-sdks Microsoft.Build.Traversal, 3.2.0
@@ -9,12 +9,11 @@ Mono JIT compiler, 6.12.0.188 (2020-02/ca8abcb6bc4 Thu Oct 13 14:26:22 EDT 2022)
 nuget, 6.3.1.1
 api-tools,1.3.5
 boots,1.1.0.712-preview2
-xamarin.androidbinderator.tool,0.5.6
-xamarin.androidx.migration.tool,1.0.10
-Gradle, 8.2
-Kotlin, 1.8.20
+xamarin.androidbinderator.tool,0.5.7
+Gradle, 8.4
+Kotlin, 1.9.10
 Groovy, 3.0.17
 Ant, Apache Ant(TM) version 1.10.13 compiled on January 4 2023
-JVM, 11.0.16.1 (Microsoft 11.0.16.1+1-LTS)
-openjdk, 11.0.16.1 2022-08-12 LTS
-javac, 11.0.16.1
+JVM, 11.0.21 (Eclipse Adoptium 11.0.21+9)
+openjdk, 11.0.21 2023-10-17
+javac, 11.0.21

--- a/docs/buildtoolsinventory.md
+++ b/docs/buildtoolsinventory.md
@@ -6,7 +6,7 @@
 {
     "sdk": 
     {
-        "version": "7.0.306",
+        "version": "7.0.403",
         "rollForward": "patch"
     },
     "msbuild-sdks": 
@@ -19,5 +19,5 @@
 }
 
 ```
-version7.0.306
+version7.0.403
 rollForwardpatch


### PR DESCRIPTION
### Does this change any of the generated binding API's?

CI build info (`buildtoolsinventory.*`)

