### PR TITLE
Bump all packages to add `net7.0-android`.

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1",
+        "nugetVersion": "1.8.1.1",
         "nugetId": "Xamarin.AndroidX.Activity",
         "dependencyOnly": false
       },
@@ -44,7 +44,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity-compose",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1",
+        "nugetVersion": "1.8.1.1",
         "nugetId": "Xamarin.AndroidX.Activity.Compose",
         "dependencyOnly": false
       },
@@ -52,7 +52,7 @@
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1",
+        "nugetVersion": "1.8.1.1",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx",
         "dependencyOnly": false
       },
@@ -60,7 +60,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.20-alpha05",
+        "nugetVersion": "1.0.0.21-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier",
         "dependencyOnly": false
       },
@@ -68,7 +68,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.20-alpha05",
+        "nugetVersion": "1.0.0.21-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon",
         "dependencyOnly": false
       },
@@ -76,7 +76,7 @@
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.20-alpha05",
+        "nugetVersion": "1.0.0.21-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider",
         "dependencyOnly": false
       },
@@ -84,7 +84,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.2",
+        "nugetVersion": "1.7.0.3",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "dependencyOnly": false,
         "extraDependencies": "androidx.annotation.annotation-jvm"
@@ -93,7 +93,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.3",
+        "nugetVersion": "1.3.1.4",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental",
         "dependencyOnly": false
       },
@@ -101,7 +101,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-jvm",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.2",
+        "nugetVersion": "1.7.0.3",
         "nugetId": "Xamarin.AndroidX.Annotation.Jvm",
         "dependencyOnly": false
       },
@@ -109,7 +109,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.5",
+        "nugetVersion": "1.6.1.6",
         "nugetId": "Xamarin.AndroidX.AppCompat",
         "dependencyOnly": false
       },
@@ -117,7 +117,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.6",
+        "nugetVersion": "1.6.1.7",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources",
         "dependencyOnly": false
       },
@@ -125,7 +125,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.5",
+        "nugetVersion": "2.2.0.6",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common",
         "dependencyOnly": false
       },
@@ -133,7 +133,7 @@
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.5",
+        "nugetVersion": "2.2.0.6",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime",
         "dependencyOnly": false
       },
@@ -141,7 +141,7 @@
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater",
         "dependencyOnly": false
       },
@@ -149,7 +149,7 @@
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.20",
+        "nugetVersion": "1.1.0.21",
         "nugetId": "Xamarin.AndroidX.AutoFill",
         "dependencyOnly": false
       },
@@ -157,7 +157,7 @@
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.17",
+        "nugetVersion": "1.1.0.18",
         "nugetId": "Xamarin.AndroidX.Biometric",
         "dependencyOnly": false
       },
@@ -165,7 +165,7 @@
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0",
+        "nugetVersion": "1.7.0.1",
         "nugetId": "Xamarin.AndroidX.Browser",
         "dependencyOnly": false
       },
@@ -173,7 +173,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2",
         "dependencyOnly": false
       },
@@ -181,7 +181,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.Core",
         "dependencyOnly": false
       },
@@ -189,7 +189,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-extensions",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.Extensions",
         "dependencyOnly": false
       },
@@ -197,7 +197,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle",
         "dependencyOnly": false
       },
@@ -205,7 +205,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-video",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.Video",
         "dependencyOnly": false
       },
@@ -213,7 +213,7 @@
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Camera.View",
         "dependencyOnly": false
       },
@@ -221,7 +221,7 @@
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.19-alpha7",
+        "nugetVersion": "1.0.0.20-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car",
         "dependencyOnly": false
       },
@@ -229,7 +229,7 @@
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.19-alpha5",
+        "nugetVersion": "1.0.0.20-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster",
         "dependencyOnly": false
       },
@@ -237,7 +237,7 @@
         "groupId": "androidx.car.app",
         "artifactId": "app",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.6",
+        "nugetVersion": "1.2.0.7",
         "nugetId": "Xamarin.AndroidX.Car.App.App",
         "dependencyOnly": false
       },
@@ -245,7 +245,7 @@
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.AndroidX.CardView",
         "dependencyOnly": false
       },
@@ -253,7 +253,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Collection",
         "dependencyOnly": false
       },
@@ -261,7 +261,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection-jvm",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Collection.Jvm",
         "dependencyOnly": false
       },
@@ -269,7 +269,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection-ktx",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx",
         "dependencyOnly": false
       },
@@ -277,7 +277,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation",
         "dependencyOnly": false
       },
@@ -285,7 +285,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Android",
         "dependencyOnly": false
       },
@@ -293,7 +293,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core",
         "dependencyOnly": false
       },
@@ -301,7 +301,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core.Android",
         "dependencyOnly": false
       },
@@ -309,7 +309,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics",
         "dependencyOnly": false
       },
@@ -317,7 +317,7 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics.Android",
         "dependencyOnly": false
       },
@@ -325,7 +325,7 @@
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation",
         "dependencyOnly": false
       },
@@ -333,7 +333,7 @@
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Android",
         "dependencyOnly": false
       },
@@ -341,7 +341,7 @@
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout",
         "dependencyOnly": false
       },
@@ -349,7 +349,7 @@
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout.Android",
         "dependencyOnly": false
       },
@@ -357,7 +357,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material",
         "dependencyOnly": false
       },
@@ -365,7 +365,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Android",
         "dependencyOnly": false
       },
@@ -373,7 +373,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core",
         "dependencyOnly": false
       },
@@ -381,7 +381,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core.Android",
         "dependencyOnly": false
       },
@@ -389,7 +389,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended",
         "dependencyOnly": false
       },
@@ -397,7 +397,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended.Android",
         "dependencyOnly": false
       },
@@ -405,7 +405,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple",
         "dependencyOnly": false
       },
@@ -413,7 +413,7 @@
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple.Android",
         "dependencyOnly": false
       },
@@ -421,7 +421,7 @@
         "groupId": "androidx.compose.material3",
         "artifactId": "material3",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2.1",
+        "nugetVersion": "1.1.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3",
         "dependencyOnly": false
       },
@@ -429,7 +429,7 @@
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2.1",
+        "nugetVersion": "1.1.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClass",
         "dependencyOnly": false
       },
@@ -437,7 +437,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime",
         "dependencyOnly": false
       },
@@ -445,7 +445,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Android",
         "dependencyOnly": false
       },
@@ -453,7 +453,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-livedata",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.LiveData",
         "dependencyOnly": false
       },
@@ -461,7 +461,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2",
         "dependencyOnly": false
       },
@@ -469,7 +469,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3",
         "dependencyOnly": false
       },
@@ -477,7 +477,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable",
         "dependencyOnly": false
       },
@@ -485,7 +485,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable.Android",
         "dependencyOnly": false
       },
@@ -493,7 +493,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI",
         "dependencyOnly": false
       },
@@ -501,7 +501,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Android",
         "dependencyOnly": false
       },
@@ -509,7 +509,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry",
         "dependencyOnly": false
       },
@@ -517,7 +517,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry.Android",
         "dependencyOnly": false
       },
@@ -525,7 +525,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics",
         "dependencyOnly": false
       },
@@ -533,7 +533,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics.Android",
         "dependencyOnly": false
       },
@@ -541,7 +541,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text",
         "dependencyOnly": false
       },
@@ -549,7 +549,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text.Android",
         "dependencyOnly": false
       },
@@ -557,7 +557,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling",
         "dependencyOnly": false
       },
@@ -565,7 +565,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Android",
         "dependencyOnly": false
       },
@@ -573,7 +573,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data",
         "dependencyOnly": false
       },
@@ -581,7 +581,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data.Android",
         "dependencyOnly": false
       },
@@ -589,7 +589,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview",
         "dependencyOnly": false
       },
@@ -597,7 +597,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview.Android",
         "dependencyOnly": false
       },
@@ -605,7 +605,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit",
         "dependencyOnly": false
       },
@@ -613,7 +613,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit.Android",
         "dependencyOnly": false
       },
@@ -621,7 +621,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util",
         "dependencyOnly": false
       },
@@ -629,7 +629,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util-android",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util.Android",
         "dependencyOnly": false
       },
@@ -637,7 +637,7 @@
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-viewbinding",
         "version": "1.5.4",
-        "nugetVersion": "1.5.4",
+        "nugetVersion": "1.5.4.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.ViewBinding",
         "dependencyOnly": false
       },
@@ -645,7 +645,7 @@
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.16",
+        "nugetVersion": "1.1.0.17",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures",
         "dependencyOnly": false
       },
@@ -653,7 +653,7 @@
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures-ktx",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures.Ktx",
         "dependencyOnly": false
       },
@@ -661,7 +661,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.1.4",
-        "nugetVersion": "2.1.4.8",
+        "nugetVersion": "2.1.4.9",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout",
         "dependencyOnly": false
       },
@@ -669,7 +669,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-core",
         "version": "1.0.4",
-        "nugetVersion": "1.0.4.8",
+        "nugetVersion": "1.0.4.9",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Core",
         "dependencyOnly": false
       },
@@ -677,7 +677,7 @@
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.16",
+        "nugetVersion": "2.0.4.17",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver",
         "dependencyOnly": false
       },
@@ -685,7 +685,7 @@
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.ContentPager",
         "dependencyOnly": false
       },
@@ -693,7 +693,7 @@
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.9",
+        "nugetVersion": "1.2.0.10",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout",
         "dependencyOnly": false
       },
@@ -701,7 +701,7 @@
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.12.0",
-        "nugetVersion": "1.12.0.2",
+        "nugetVersion": "1.12.0.3",
         "nugetId": "Xamarin.AndroidX.Core",
         "dependencyOnly": false
       },
@@ -709,7 +709,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0-alpha02",
-        "nugetVersion": "1.0.0.19-alpha02",
+        "nugetVersion": "1.0.0.20-alpha02",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
@@ -717,7 +717,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.6",
+        "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.Core.GoogleShortcuts",
         "dependencyOnly": false
       },
@@ -725,7 +725,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.12.0",
-        "nugetVersion": "1.12.0.2",
+        "nugetVersion": "1.12.0.3",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx",
         "dependencyOnly": false
       },
@@ -733,7 +733,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.19",
+        "nugetVersion": "1.0.0.20",
         "nugetId": "Xamarin.AndroidX.Core.Role",
         "dependencyOnly": false
       },
@@ -741,7 +741,7 @@
         "groupId": "androidx.core",
         "artifactId": "core-splashscreen",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.4",
+        "nugetVersion": "1.0.1.5",
         "nugetId": "Xamarin.AndroidX.Core.SplashScreen",
         "dependencyOnly": false
       },
@@ -749,7 +749,7 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.CursorAdapter",
         "dependencyOnly": false
       },
@@ -757,7 +757,7 @@
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.20",
+        "nugetVersion": "1.1.0.21",
         "nugetId": "Xamarin.AndroidX.CustomView",
         "dependencyOnly": false
       },
@@ -765,7 +765,7 @@
         "groupId": "androidx.customview",
         "artifactId": "customview-poolingcontainer",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.CustomView.PoolingContainer",
         "dependencyOnly": false
       },
@@ -773,7 +773,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-adapters",
         "version": "8.1.4",
-        "nugetVersion": "8.1.4",
+        "nugetVersion": "8.1.4.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters",
         "dependencyOnly": false
       },
@@ -781,7 +781,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-common",
         "version": "8.1.4",
-        "nugetVersion": "8.1.4",
+        "nugetVersion": "8.1.4.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon",
         "dependencyOnly": false
       },
@@ -789,7 +789,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "databinding-runtime",
         "version": "8.1.4",
-        "nugetVersion": "8.1.4",
+        "nugetVersion": "8.1.4.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime",
         "dependencyOnly": false
       },
@@ -797,7 +797,7 @@
         "groupId": "androidx.databinding",
         "artifactId": "viewbinding",
         "version": "8.1.4",
-        "nugetVersion": "8.1.4",
+        "nugetVersion": "8.1.4.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding",
         "dependencyOnly": false
       },
@@ -805,7 +805,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore",
         "dependencyOnly": false
       },
@@ -813,7 +813,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core",
         "dependencyOnly": false
       },
@@ -821,7 +821,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences",
         "dependencyOnly": false
       },
@@ -829,7 +829,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core",
         "dependencyOnly": false
       },
@@ -837,7 +837,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava2",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava2",
         "dependencyOnly": false
       },
@@ -845,7 +845,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava3",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava3",
         "dependencyOnly": false
       },
@@ -853,7 +853,7 @@
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.21",
+        "nugetVersion": "1.0.1.22",
         "nugetId": "Xamarin.AndroidX.DocumentFile",
         "dependencyOnly": false
       },
@@ -861,7 +861,7 @@
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.5",
+        "nugetVersion": "1.2.0.6",
         "nugetId": "Xamarin.AndroidX.DrawerLayout",
         "dependencyOnly": false
       },
@@ -869,7 +869,7 @@
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation",
         "dependencyOnly": false
       },
@@ -877,7 +877,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.16",
+        "nugetVersion": "1.1.0.17",
         "nugetId": "Xamarin.AndroidX.Emoji",
         "dependencyOnly": false
       },
@@ -885,7 +885,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.16",
+        "nugetVersion": "1.1.0.17",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat",
         "dependencyOnly": false
       },
@@ -893,7 +893,7 @@
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.16",
+        "nugetVersion": "1.1.0.17",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled",
         "dependencyOnly": false
       },
@@ -901,7 +901,7 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2",
         "dependencyOnly": false
       },
@@ -909,7 +909,7 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views-helper",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2.ViewsHelper",
         "dependencyOnly": false
       },
@@ -917,7 +917,7 @@
         "groupId": "androidx.enterprise",
         "artifactId": "enterprise-feedback",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.7",
+        "nugetVersion": "1.1.0.8",
         "nugetId": "Xamarin.AndroidX.Enterprise.Feedback",
         "dependencyOnly": false
       },
@@ -925,7 +925,7 @@
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.3.6",
-        "nugetVersion": "1.3.6.5",
+        "nugetVersion": "1.3.6.6",
         "nugetId": "Xamarin.AndroidX.ExifInterface",
         "dependencyOnly": false
       },
@@ -933,7 +933,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Fragment",
         "dependencyOnly": false
       },
@@ -941,7 +941,7 @@
         "groupId": "androidx.fragment",
         "artifactId": "fragment-ktx",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx",
         "dependencyOnly": false
       },
@@ -949,7 +949,7 @@
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.GridLayout",
         "dependencyOnly": false
       },
@@ -957,7 +957,7 @@
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.HeifWriter",
         "dependencyOnly": false
       },
@@ -965,7 +965,7 @@
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Interpolator",
         "dependencyOnly": false
       },
@@ -973,7 +973,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.AndroidX.Leanback",
         "dependencyOnly": false
       },
@@ -981,7 +981,7 @@
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference",
         "dependencyOnly": false
       },
@@ -989,7 +989,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14",
         "dependencyOnly": false
       },
@@ -997,7 +997,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.22",
+        "nugetVersion": "1.0.0.23",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI",
         "dependencyOnly": false
       },
@@ -1005,7 +1005,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
         "dependencyOnly": false
       },
@@ -1013,7 +1013,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13",
         "dependencyOnly": false
       },
@@ -1021,7 +1021,7 @@
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
         "dependencyOnly": false
       },
@@ -1029,7 +1029,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common",
         "dependencyOnly": false
       },
@@ -1037,7 +1037,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-java8",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8",
         "dependencyOnly": false
       },
@@ -1045,7 +1045,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.21",
+        "nugetVersion": "2.2.0.22",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
         "dependencyOnly": false
       },
@@ -1053,7 +1053,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData",
         "dependencyOnly": false
       },
@@ -1061,7 +1061,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core",
         "dependencyOnly": false
       },
@@ -1069,7 +1069,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core-ktx",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx",
         "dependencyOnly": false
       },
@@ -1077,7 +1077,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx",
         "dependencyOnly": false
       },
@@ -1085,7 +1085,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process",
         "dependencyOnly": false
       },
@@ -1093,7 +1093,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams",
         "dependencyOnly": false
       },
@@ -1101,7 +1101,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams-ktx",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx",
         "dependencyOnly": false
       },
@@ -1109,7 +1109,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime",
         "dependencyOnly": false
       },
@@ -1117,7 +1117,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -1125,7 +1125,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service",
         "dependencyOnly": false
       },
@@ -1133,7 +1133,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel",
         "dependencyOnly": false
       },
@@ -1141,7 +1141,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose",
         "dependencyOnly": false
       },
@@ -1149,7 +1149,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-ktx",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx",
         "dependencyOnly": false
       },
@@ -1157,7 +1157,7 @@
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState",
         "dependencyOnly": false
       },
@@ -1165,7 +1165,7 @@
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.Loader",
         "dependencyOnly": false
       },
@@ -1173,7 +1173,7 @@
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
         "dependencyOnly": false
       },
@@ -1181,7 +1181,7 @@
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.8",
+        "nugetVersion": "1.6.0.9",
         "nugetId": "Xamarin.AndroidX.Media",
         "dependencyOnly": false
       },
@@ -1189,7 +1189,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.9",
+        "nugetVersion": "1.2.1.10",
         "nugetId": "Xamarin.AndroidX.Media2.Common",
         "dependencyOnly": false
       },
@@ -1197,7 +1197,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.9",
+        "nugetVersion": "1.2.1.10",
         "nugetId": "Xamarin.AndroidX.Media2.Session",
         "dependencyOnly": false
       },
@@ -1205,7 +1205,7 @@
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.9",
+        "nugetVersion": "1.2.1.10",
         "nugetId": "Xamarin.AndroidX.Media2.Widget",
         "dependencyOnly": false
       },
@@ -1213,7 +1213,7 @@
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.1",
+        "nugetVersion": "1.6.0.2",
         "nugetId": "Xamarin.AndroidX.MediaRouter",
         "dependencyOnly": false
       },
@@ -1221,7 +1221,7 @@
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.21",
+        "nugetVersion": "2.0.1.22",
         "nugetId": "Xamarin.AndroidX.MultiDex",
         "dependencyOnly": false
       },
@@ -1229,7 +1229,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common",
         "dependencyOnly": false
       },
@@ -1237,7 +1237,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-ktx",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx",
         "dependencyOnly": false
       },
@@ -1245,7 +1245,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose",
         "dependencyOnly": false
       },
@@ -1253,7 +1253,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment",
         "dependencyOnly": false
       },
@@ -1261,7 +1261,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment-ktx",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx",
         "dependencyOnly": false
       },
@@ -1269,7 +1269,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime",
         "dependencyOnly": false
       },
@@ -1277,7 +1277,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-ktx",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -1285,7 +1285,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI",
         "dependencyOnly": false
       },
@@ -1293,7 +1293,7 @@
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui-ktx",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5",
+        "nugetVersion": "2.7.5.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx",
         "dependencyOnly": false
       },
@@ -1301,7 +1301,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
         "dependencyOnly": false
       },
@@ -1309,7 +1309,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common-ktx",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx",
         "dependencyOnly": false
       },
@@ -1317,7 +1317,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime",
         "dependencyOnly": false
       },
@@ -1325,7 +1325,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime-ktx",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -1333,7 +1333,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2",
         "dependencyOnly": false
       },
@@ -1341,7 +1341,7 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2-ktx",
         "version": "3.2.1",
-        "nugetVersion": "3.2.1.2",
+        "nugetVersion": "3.2.1.3",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2.Ktx",
         "dependencyOnly": false
       },
@@ -1349,7 +1349,7 @@
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Palette",
         "dependencyOnly": false
       },
@@ -1357,7 +1357,7 @@
         "groupId": "androidx.palette",
         "artifactId": "palette-ktx",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.14",
+        "nugetVersion": "1.0.0.15",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx",
         "dependencyOnly": false
       },
@@ -1365,7 +1365,7 @@
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.22",
+        "nugetVersion": "1.0.0.23",
         "nugetId": "Xamarin.AndroidX.PercentLayout",
         "dependencyOnly": false
       },
@@ -1373,7 +1373,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.2",
+        "nugetVersion": "1.2.1.3",
         "nugetId": "Xamarin.AndroidX.Preference",
         "dependencyOnly": false
       },
@@ -1381,7 +1381,7 @@
         "groupId": "androidx.preference",
         "artifactId": "preference-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.2",
+        "nugetVersion": "1.2.1.3",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx",
         "dependencyOnly": false
       },
@@ -1389,7 +1389,7 @@
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Print",
         "dependencyOnly": false
       },
@@ -1397,7 +1397,7 @@
         "groupId": "androidx.profileinstaller",
         "artifactId": "profileinstaller",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1.4",
+        "nugetVersion": "1.3.1.5",
         "nugetId": "Xamarin.AndroidX.ProfileInstaller.ProfileInstaller",
         "dependencyOnly": false
       },
@@ -1405,7 +1405,7 @@
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Recommendation",
         "dependencyOnly": false
       },
@@ -1413,7 +1413,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2",
+        "nugetVersion": "1.3.2.1",
         "nugetId": "Xamarin.AndroidX.RecyclerView",
         "dependencyOnly": false
       },
@@ -1421,7 +1421,7 @@
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.15",
+        "nugetVersion": "1.1.0.16",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection",
         "dependencyOnly": false
       },
@@ -1429,7 +1429,7 @@
         "groupId": "androidx.resourceinspection",
         "artifactId": "resourceinspection-annotation",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.9",
+        "nugetVersion": "1.0.1.10",
         "nugetId": "Xamarin.AndroidX.ResourceInspection.Annotation",
         "dependencyOnly": false
       },
@@ -1437,7 +1437,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Common",
         "dependencyOnly": false
       },
@@ -1445,7 +1445,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Guava",
         "dependencyOnly": false
       },
@@ -1453,7 +1453,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-ktx",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx",
         "dependencyOnly": false
       },
@@ -1461,7 +1461,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Runtime",
         "dependencyOnly": false
       },
@@ -1469,7 +1469,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-rxjava2",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2",
         "dependencyOnly": false
       },
@@ -1477,7 +1477,7 @@
         "groupId": "androidx.room",
         "artifactId": "room-rxjava3",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0",
+        "nugetVersion": "2.6.0.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3",
         "dependencyOnly": false
       },
@@ -1485,7 +1485,7 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.5",
+        "nugetVersion": "1.2.1.6",
         "nugetId": "Xamarin.AndroidX.SavedState",
         "dependencyOnly": false
       },
@@ -1493,7 +1493,7 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.5",
+        "nugetVersion": "1.2.1.6",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx",
         "dependencyOnly": false
       },
@@ -1501,7 +1501,7 @@
         "groupId": "androidx.security",
         "artifactId": "security-crypto",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.14",
+        "nugetVersion": "1.0.0.15",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto",
         "dependencyOnly": false
       },
@@ -1509,7 +1509,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Slice.Builders",
         "dependencyOnly": false
       },
@@ -1517,7 +1517,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Slice.Core",
         "dependencyOnly": false
       },
@@ -1525,7 +1525,7 @@
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.Slice.View",
         "dependencyOnly": false
       },
@@ -1533,7 +1533,7 @@
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.9",
+        "nugetVersion": "1.2.0.10",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout",
         "dependencyOnly": false
       },
@@ -1541,7 +1541,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.AndroidX.Sqlite",
         "dependencyOnly": false
       },
@@ -1549,7 +1549,7 @@
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework",
         "dependencyOnly": false
       },
@@ -1557,7 +1557,7 @@
         "groupId": "androidx.startup",
         "artifactId": "startup-runtime",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.9",
+        "nugetVersion": "1.1.1.10",
         "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime",
         "dependencyOnly": false
       },
@@ -1565,7 +1565,7 @@
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.16",
+        "nugetVersion": "1.1.0.17",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout",
         "dependencyOnly": false
       },
@@ -1573,7 +1573,7 @@
         "groupId": "androidx.tracing",
         "artifactId": "tracing",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.8",
+        "nugetVersion": "1.1.0.9",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing",
         "dependencyOnly": false
       },
@@ -1581,7 +1581,7 @@
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.14",
+        "nugetVersion": "1.4.1.15",
         "nugetId": "Xamarin.AndroidX.Transition",
         "dependencyOnly": false,
         "extraDependencies": "androidx.fragment.fragment"
@@ -1590,7 +1590,7 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.AndroidX.TvProvider",
         "dependencyOnly": false
       },
@@ -1598,7 +1598,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },
@@ -1606,7 +1606,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated",
         "dependencyOnly": false
       },
@@ -1614,7 +1614,7 @@
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.21",
+        "nugetVersion": "1.1.1.22",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable",
         "dependencyOnly": false
       },
@@ -1622,7 +1622,7 @@
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.21",
+        "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.AndroidX.ViewPager",
         "dependencyOnly": false
       },
@@ -1630,7 +1630,7 @@
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.AndroidX.ViewPager2",
         "dependencyOnly": false
       },
@@ -1638,7 +1638,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.2",
+        "nugetVersion": "1.3.0.3",
         "nugetId": "Xamarin.AndroidX.Wear",
         "dependencyOnly": false
       },
@@ -1646,7 +1646,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear-input",
         "version": "1.1.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.Wear.Input",
         "dependencyOnly": false
       },
@@ -1654,7 +1654,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear-ongoing",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.Wear.Ongoing",
         "dependencyOnly": false
       },
@@ -1662,7 +1662,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear-phone-interactions",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.9",
+        "nugetVersion": "1.0.1.10",
         "nugetId": "Xamarin.AndroidX.Wear.PhoneInteractions",
         "dependencyOnly": false
       },
@@ -1670,7 +1670,7 @@
         "groupId": "androidx.wear",
         "artifactId": "wear-remote-interactions",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AndroidX.Wear.RemoteInteractions",
         "dependencyOnly": false
       },
@@ -1678,7 +1678,7 @@
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-foundation",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Foundation",
         "dependencyOnly": false
       },
@@ -1686,7 +1686,7 @@
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material",
         "dependencyOnly": false
       },
@@ -1694,7 +1694,7 @@
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material-core",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material.Core",
         "dependencyOnly": false
       },
@@ -1702,7 +1702,7 @@
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-navigation",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Navigation",
         "dependencyOnly": false
       },
@@ -1710,7 +1710,7 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout",
         "dependencyOnly": false
       },
@@ -1718,7 +1718,7 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
@@ -1728,7 +1728,7 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression-pipeline",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression.Pipeline",
         "dependencyOnly": false
       },
@@ -1736,7 +1736,7 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-proto",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Proto",
         "dependencyOnly": false
       },
@@ -1744,7 +1744,7 @@
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles",
         "dependencyOnly": false
       },
@@ -1752,7 +1752,7 @@
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-material",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Material",
         "dependencyOnly": false
       },
@@ -1760,7 +1760,7 @@
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-proto",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Proto",
         "dependencyOnly": false
       },
@@ -1768,7 +1768,7 @@
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-renderer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.6",
+        "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Renderer",
         "dependencyOnly": false,
         "frozen": true
@@ -1777,7 +1777,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace",
         "dependencyOnly": false
       },
@@ -1785,7 +1785,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Client",
         "dependencyOnly": false
       },
@@ -1793,7 +1793,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client-guava",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.ClientGuava",
         "dependencyOnly": false
       },
@@ -1801,7 +1801,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications",
         "dependencyOnly": false
       },
@@ -1809,7 +1809,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data",
         "dependencyOnly": false
       },
@@ -1817,7 +1817,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source",
         "dependencyOnly": false
       },
@@ -1825,7 +1825,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source-ktx",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source.Ktx",
         "dependencyOnly": false
       },
@@ -1833,7 +1833,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-rendering",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Rendering",
         "dependencyOnly": false
       },
@@ -1841,7 +1841,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-data",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Data",
         "dependencyOnly": false
       },
@@ -1849,7 +1849,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-guava",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Guava",
         "dependencyOnly": false
       },
@@ -1857,7 +1857,7 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-style",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Style",
         "dependencyOnly": false
       },
@@ -1865,7 +1865,7 @@
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.8.0",
-        "nugetVersion": "1.8.0.2",
+        "nugetVersion": "1.8.0.3",
         "nugetId": "Xamarin.AndroidX.WebKit",
         "dependencyOnly": false
       },
@@ -1873,7 +1873,7 @@
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Window",
         "dependencyOnly": false
       },
@@ -1881,7 +1881,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.16-alpha01",
+        "nugetVersion": "1.0.0.17-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions",
         "dependencyOnly": false
       },
@@ -1889,7 +1889,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-java",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava",
         "dependencyOnly": false
       },
@@ -1897,7 +1897,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-rxjava2",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava2",
         "dependencyOnly": false
       },
@@ -1905,7 +1905,7 @@
         "groupId": "androidx.window",
         "artifactId": "window-rxjava3",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava3",
         "dependencyOnly": false
       },
@@ -1913,7 +1913,7 @@
         "groupId": "androidx.window.extensions.core",
         "artifactId": "core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.3",
+        "nugetVersion": "1.0.0.4",
         "nugetId": "Xamarin.AndroidX.Window.Extensions.Core.Core",
         "dependencyOnly": false
       },
@@ -1921,7 +1921,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.8.1",
-        "nugetVersion": "2.8.1.5",
+        "nugetVersion": "2.8.1.6",
         "nugetId": "Xamarin.AndroidX.Work.Runtime",
         "dependencyOnly": false
       },
@@ -1929,7 +1929,7 @@
         "groupId": "androidx.work",
         "artifactId": "work-runtime-ktx",
         "version": "2.8.1",
-        "nugetVersion": "2.8.1.5",
+        "nugetVersion": "2.8.1.6",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx",
         "dependencyOnly": false
       },
@@ -1937,7 +1937,7 @@
         "groupId": "com.android.installreferrer",
         "artifactId": "installreferrer",
         "version": "1.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "dependencyOnly": false,
         "frozen": true,
@@ -1947,7 +1947,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-appcompat-theme",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.AppCompat.Theme",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -1956,7 +1956,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-drawablepainter",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.DrawablePainter",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -1965,7 +1965,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-flowlayout",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.FlowLayout",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -1974,7 +1974,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.Pager",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -1983,7 +1983,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager-indicators",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.Pager.Indicators",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -1992,7 +1992,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-permissions",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.Permissions",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -2001,7 +2001,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -2010,7 +2010,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder-material",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder.Material",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -2019,7 +2019,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-swiperefresh",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.SwipeRefresh",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -2028,7 +2028,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-systemuicontroller",
         "version": "0.32.0",
-        "nugetVersion": "0.32.0.2",
+        "nugetVersion": "0.32.0.3",
         "nugetId": "Xamarin.Google.Accompanist.SystemUIController",
         "dependencyOnly": false,
         "templateSet": "accompanist"
@@ -2037,7 +2037,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter",
         "version": "1.1.18",
-        "nugetVersion": "1.1.18.7",
+        "nugetVersion": "1.1.18.8",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter",
         "dependencyOnly": false,
         "frozen": true
@@ -2046,7 +2046,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter-3",
         "version": "1.0.18",
-        "nugetVersion": "1.0.18.6",
+        "nugetVersion": "1.0.18.7",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter3",
         "dependencyOnly": false,
         "frozen": true
@@ -2055,7 +2055,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.10.0",
-        "nugetVersion": "1.10.0.1",
+        "nugetVersion": "1.10.0.2",
         "nugetId": "Xamarin.Google.Android.Material",
         "dependencyOnly": false
       },
@@ -2063,7 +2063,7 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "suggestions",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Suggestions",
         "dependencyOnly": false
       },
@@ -2071,7 +2071,7 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "widgets",
         "version": "0.0.1",
-        "nugetVersion": "0.0.1.8",
+        "nugetVersion": "0.0.1.9",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
         "dependencyOnly": false
       },
@@ -2079,7 +2079,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value-annotations",
         "version": "1.10.4",
-        "nugetVersion": "1.10.4.1",
+        "nugetVersion": "1.10.4.2",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "dependencyOnly": false,
         "templateSet": "auto-value"
@@ -2088,7 +2088,7 @@
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.10.1",
-        "nugetVersion": "2.10.1.6",
+        "nugetVersion": "2.10.1.7",
         "nugetId": "GoogleGson",
         "dependencyOnly": false,
         "templateSet": "gson"
@@ -2097,7 +2097,7 @@
         "groupId": "com.google.crypto.tink",
         "artifactId": "tink-android",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
         "dependencyOnly": false,
         "templateSet": "tink"
@@ -2106,7 +2106,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger",
         "version": "0.8",
-        "nugetVersion": "0.8.0",
+        "nugetVersion": "0.8.0.1",
         "nugetId": "Xamarin.Flogger",
         "dependencyOnly": false,
         "templateSet": "flogger"
@@ -2115,7 +2115,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger-system-backend",
         "version": "0.8",
-        "nugetVersion": "0.8.0",
+        "nugetVersion": "0.8.0.1",
         "nugetId": "Xamarin.Flogger.SystemBackend",
         "dependencyOnly": false,
         "templateSet": "flogger"
@@ -2124,7 +2124,7 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.2",
-        "nugetVersion": "1.0.2",
+        "nugetVersion": "1.0.2.1",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "dependencyOnly": false,
         "templateSet": "guava"
@@ -2133,7 +2133,7 @@
         "groupId": "com.google.guava",
         "artifactId": "guava",
         "version": "32.0.1-android",
-        "nugetVersion": "32.0.1",
+        "nugetVersion": "32.0.1.1",
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
@@ -2143,7 +2143,7 @@
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.16",
+        "nugetVersion": "1.0.0.17",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "dependencyOnly": false,
         "templateSet": "guava"
@@ -2152,7 +2152,7 @@
         "groupId": "com.google.j2objc",
         "artifactId": "j2objc-annotations",
         "version": "2.8",
-        "nugetVersion": "2.8.0.6",
+        "nugetVersion": "2.8.0.7",
         "nugetId": "Xamarin.Google.J2Objc.Annotations",
         "dependencyOnly": false,
         "templateSet": "no-bindings"
@@ -2161,7 +2161,7 @@
         "groupId": "dev.chrisbanes.snapper",
         "artifactId": "snapper",
         "version": "0.3.0",
-        "nugetVersion": "0.3.0.7",
+        "nugetVersion": "0.3.0.8",
         "nugetId": "Xamarin.Dev.ChrisBanes.Snapper",
         "dependencyOnly": false,
         "templateSet": "dev-chrisbanes-snapper"
@@ -2170,7 +2170,7 @@
         "groupId": "io.github.aakira",
         "artifactId": "napier",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.7",
+        "nugetVersion": "2.6.1.8",
         "nugetId": "Xamarin.AAkira.Napier",
         "dependencyOnly": false,
         "templateSet": "napier"
@@ -2179,7 +2179,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxandroid",
         "version": "2.1.1",
-        "nugetVersion": "2.1.1.7",
+        "nugetVersion": "2.1.1.8",
         "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2188,7 +2188,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxjava",
         "version": "2.2.21",
-        "nugetVersion": "2.2.21.14",
+        "nugetVersion": "2.2.21.15",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2197,7 +2197,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxkotlin",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.7",
+        "nugetVersion": "2.4.0.8",
         "nugetId": "Xamarin.Android.ReactiveX.RxKotlin",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2206,7 +2206,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxandroid",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.6",
+        "nugetVersion": "3.0.2.7",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxAndroid",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2215,7 +2215,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxjava",
         "version": "3.1.8",
-        "nugetVersion": "3.1.8.1",
+        "nugetVersion": "3.1.8.2",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2224,7 +2224,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxkotlin",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.7",
+        "nugetVersion": "3.0.1.8",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxKotlin",
         "dependencyOnly": false,
         "templateSet": "rxjava"
@@ -2233,7 +2233,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-compat-qual",
         "version": "2.5.6",
-        "nugetVersion": "2.5.6",
+        "nugetVersion": "2.5.6.1",
         "nugetId": "Xamarin.CheckerFramework.CheckerCompatQual",
         "dependencyOnly": false,
         "templateSet": "no-bindings"
@@ -2242,7 +2242,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-qual",
         "version": "3.40.0",
-        "nugetVersion": "3.40.0",
+        "nugetVersion": "3.40.0.1",
         "nugetId": "Xamarin.CheckerFramework.CheckerQual",
         "dependencyOnly": false,
         "templateSet": "no-bindings"
@@ -2251,7 +2251,7 @@
         "groupId": "org.jetbrains",
         "artifactId": "annotations",
         "version": "24.1.0",
-        "nugetVersion": "24.1.0",
+        "nugetVersion": "24.1.0.1",
         "nugetId": "Xamarin.Jetbrains.Annotations",
         "dependencyOnly": false,
         "templateSet": "kotlin"
@@ -2260,7 +2260,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
         "version": "1.9.21",
-        "nugetVersion": "1.9.21",
+        "nugetVersion": "1.9.21.1",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2272,7 +2272,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
         "version": "1.9.21",
-        "nugetVersion": "1.9.21",
+        "nugetVersion": "1.9.21.1",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "dependencyOnly": false,
         "templateSet": "kotlin"
@@ -2281,7 +2281,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
         "version": "1.9.21",
-        "nugetVersion": "1.9.21",
+        "nugetVersion": "1.9.21.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2293,7 +2293,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
         "version": "1.9.21",
-        "nugetVersion": "1.9.21",
+        "nugetVersion": "1.9.21.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2305,7 +2305,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
         "version": "1.9.21",
-        "nugetVersion": "1.9.21",
+        "nugetVersion": "1.9.21.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "dependencyOnly": false,
         "templateSet": "kotlin",
@@ -2317,7 +2317,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2326,7 +2326,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2335,7 +2335,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2344,7 +2344,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-guava",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Guava",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2353,7 +2353,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-jdk8",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2362,7 +2362,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-play-services",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Play.Services",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2371,7 +2371,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-reactive",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2380,7 +2380,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2389,7 +2389,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx3",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.2",
+        "nugetVersion": "1.7.3.3",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx3",
         "dependencyOnly": false,
         "templateSet": "kotlinx"
@@ -2398,7 +2398,7 @@
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.4",
-        "nugetVersion": "1.0.4.8",
+        "nugetVersion": "1.0.4.9",
         "nugetId": "Xamarin.Android.ReactiveStreams",
         "dependencyOnly": false,
         "templateSet": "reactive-streams"


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/809

Bump all packages so we publish new ones with the `net7.0-android` framework.