### PR TITLE
Use an updated `generator` for `@RestrictTo` support.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,10 @@
     <!-- Default TFM's we build for -->
     <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android;net7.0-android</_DefaultTargetFrameworks>
 
+    <!-- Use an updated 'generator' -->
+    <!-- It's ok to use "Windows" here because we only use managed code from this package -->
+    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.43/tools/</_BindingsToolsLocation>
+    
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     
@@ -37,8 +41,11 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://aka.ms/androidx</PackageProjectUrl>
-  </PropertyGroup>
 
+    <!-- Exclude TF-specific transform files by default -->
+    <DefaultTransformExcludes>**/*.MonoAndroid*.0.xml;**/*.net*.0-android.xml</DefaultTransformExcludes>
+  </PropertyGroup>
+  
   <!-- Folders that .targets files need to go into -->
   <ItemGroup>
     <AndroidXNuGetTargetFolders Include="build\monoandroid12.0" />

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 // Tools needed by cake addins
 #tool nuget:?package=Cake.CoreCLR
 #tool nuget:?package=vswhere&version=3.1.7
+#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.43
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=6.1.3

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -126,7 +126,10 @@
     <TransformFile Include="..\..\source\Metadata.common.xml" >
       <Link>Transforms/Metadata.common.xml</Link>
     </TransformFile>
-    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml">
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)">
+        <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    </TransformFile>
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.$(TargetFramework).xml">
         <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
     </TransformFile>
     <AndroidJavaSource

--- a/source/Xamarin.Kotlin.StdLib/Additions/InterfacesFixups.cs
+++ b/source/Xamarin.Kotlin.StdLib/Additions/InterfacesFixups.cs
@@ -1,4 +1,7 @@
-﻿namespace Kotlin.Collections
+using Java.Lang;
+using Java.Util;
+
+namespace Kotlin.Collections
 {
 	// TODO: Remove these fixes when this bug is fixed:
 	//       https://github.com/xamarin/java.interop/issues/470
@@ -11,3 +14,22 @@
 	{
 	}
 }
+
+#if NET7_0_OR_GREATER
+namespace Kotlin.Collections.Builders
+{
+	public partial class MapBuilder
+	{
+		int IMap.Size () => Size;
+
+		global::System.Collections.ICollection IMap.Values () => Values;
+	}
+
+	public partial class MapBuilderEntries
+	{
+		public override bool Add (Object? element) => Add ((IMapEntry) element!);
+
+		public override int GetSize () => Size;
+	}
+}
+#endif

--- a/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.net7.0-android.xml
+++ b/source/Xamarin.Kotlin.StdLib/Transforms/Metadata.net7.0-android.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <remove-node path="/api/package[@name='kotlin.collections.builders']/class[@name='AbstractMapBuilderEntrySet']/method[@name='contains' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]" />
+</metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.MonoAndroid12.0.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.MonoAndroid12.0.xml
@@ -1,0 +1,119 @@
+<metadata>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+</metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.net6.0-android.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.net6.0-android.xml
@@ -1,0 +1,119 @@
+<metadata>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false"  
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+    <add-node
+        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
+        >
+        <method 
+            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
+            deprecated="not deprecated" final="false" bridge="false" native="false" 
+            synchronized="false" synthetic="false" 
+            />
+    </add-node>
+</metadata>

--- a/source/com.google.crypto.tink/tink-android/Transforms/Metadata.xml
+++ b/source/com.google.crypto.tink/tink-android/Transforms/Metadata.xml
@@ -569,17 +569,6 @@
         >
         Xamarin.Google.Crypto.Tink.Key
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-
     <attr
         path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='SignaturePrivateKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -592,16 +581,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='EcdsaPublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.aead']/class[@name='XChaCha20Poly1305Key']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -644,15 +623,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HkdfPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.mac']/class[@name='HmacKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -679,34 +649,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesGcmHkdfStreamingKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.streamingaead']/class[@name='AesCtrHmacStreamingKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.hybrid']/class[@name='HybridPrivateKey']/method[@name='getPublicKey' and count(parameter)=0]"
         name="managedReturn"
@@ -734,15 +676,6 @@
             synchronized="false" synthetic="false" 
             />
     </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.hybrid']/class[@name='HybridPrivateKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -761,24 +694,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='AesCmacPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.prf']/class[@name='HmacPrfKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.jwt']/class[@name='JwtMacKey']/method[@name='getParameters' and count(parameter)=0]"
         name="managedReturn"
@@ -797,47 +712,6 @@
         >
         Xamarin.Google.Crypto.Tink.Parameters
     </attr>
-
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='Ed25519PrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false"  
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPkcs1PrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false"  
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-
-
-
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPrivateKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Key" name="getPublicKey"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
-    <add-node
-        path="/api/package[@name='com.google.crypto.tink.signature']/class[@name='RsaSsaPssPublicKey']"
-        >
-        <method 
-            visibility="public" static="false" abstract="false" return="com.google.crypto.tink.Parameters" name="getParameters"
-            deprecated="not deprecated" final="false" bridge="false" native="false" 
-            synchronized="false" synthetic="false" 
-            />
-    </add-node>
     <attr
         path="/api/package[@name='com.google.crypto.tink.jwt']/class[@name='JwtSignaturePrivateKey']/method[@name='getPublicKey' and count(parameter)=0]"
         name="managedReturn"

--- a/templates/kotlin/Project.cshtml
+++ b/templates/kotlin/Project.cshtml
@@ -54,7 +54,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <TransformFile Include="..\..\source\@(Model.NuGetPackageId)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.NuGetPackageId)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.NuGetPackageId)\Transforms\*.$(TargetFramework).xml" Link="Transforms\%(Filename)%(Extension)" />
     <TransformFile Include="..\..\templates\kotlin\Metadata.shared.xml" Link="Transforms\Metadata.shared.xml" />
   </ItemGroup>
 

--- a/templates/tink/Project.cshtml
+++ b/templates/tink/Project.cshtml
@@ -39,7 +39,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)" Link="Transforms\%(Filename)%(Extension)" />
+    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.$(TargetFramework).xml" Link="Transforms\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We want to use an updated version of `generator` that has `@RestrictTo` support.  This will allow consumers to be warned if they attempt to use API that Google has marked as `internal` using a `@RestrictTo` annotation.

Begin building `net7.0-android` with an updated version of `generator`.  This is accomplished by downloading the `generator` that ships in the .NET Android 8.0 RTM NuGet package.  (`Microsoft.Android.Sdk.Windows` `34.0.43`)  Note it is okay to use the "Windows" package on all platforms because we only use managed cross-platform binaries from the package.  We then set `$(_BindingsToolsLocation)` to point to this package.

There are some transforms and additions changes that only affect this newer version of `generator`, so we also need a way to apply different transform files based on the framework that is building.  The can now be done by naming the transform files with the target framework, ex: `Metadata.MonoAndroid12.0.xml` or `Metadata.net6.0-android.xml`.

- `Xamarin.Kotlin.StdLib` needed new additions/transforms that only apply to `net7.0-android`.
- `tink-android` had transforms that _should not_ be run on `net7.0-android`, so they were moved to `MonoAndroid12.0` and `net6.0-android` specific transform files.

`api-diff` reports that the changes we are looking for are present:

    ## Xamarin.AndroidX.Activity.dll
    ### Namespace AndroidX.Activity
    #### Type Changed: AndroidX.Activity.FullyDrawnReporter

    Obsoleted methods:
    ```diff
    [Obsolete ("While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.")]
    public void FullyDrawnReported ();
    ```
