### PR TITLE
[ci] Add ApiScan.

### DIFF
--- a/build/ci/api-scan.yml
+++ b/build/ci/api-scan.yml
@@ -1,0 +1,37 @@
+parameters:
+  apiScanDirectory: $(Agent.TempDirectory)\APIScanFiles         # The directory to copy and scan assemblies
+  mainBranchName:                                               # The "main" branch that should be used - can be something other than "main"
+
+steps:
+
+ ### Copy .dll and .pdb files for APIScan
+- task: CopyFiles@2
+  displayName: 'Collect Files for APIScan'
+  inputs:
+    Contents: |
+      generated\**\bin\Release\**\?(*.dll|*.pdb)
+      util\**\bin\Release\**\?(*.dll|*.pdb)
+    TargetFolder: ${{ parameters.apiScanDirectory }}
+    OverWrite: true
+    flattenFolders: true
+  condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+
+- task: CmdLine@2
+  displayName: 'List Files for APIScan'
+  inputs:
+    script: |
+      tree ${{ parameters.apiScanDirectory }} /f        
+  condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+        
+ ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
+- task: APIScan@2
+  displayName: Run APIScan
+  inputs:
+    softwareFolder: ${{ parameters.apiScanDirectory }}
+    softwareName: $(ApiScanName)
+    softwareVersionNum: '$(Build.BuildId)'
+    isLargeApp: true
+    toolVersion: Latest
+  condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+  env:
+    AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -1,7 +1,7 @@
 parameters:
   # Environment Parameters
   name: 'build'                                             # the name of the build job for dependency purposes
-  timeoutInMinutes: 150                                     # the timeout in minutes
+  timeoutInMinutes: 180                                     # the timeout in minutes
   mainBranchName: 'main'                                    # the "main" branch that should be used - can be something other than "main"
   macosAgentPoolName: 'Azure Pipelines'                     # the name of the macOS VM pool
   macosImage: internal-macos12                              # macOS VM image name, must be "internal" locked down image
@@ -48,6 +48,7 @@ jobs:
           imageName: ${{ parameters.windowsImage }}
           classicInstallerUrl: ${{ parameters.classicXAVsix }}
           runCodeQL: true
+          runAPIScan: true
     displayName: Build
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables:
@@ -72,6 +73,10 @@ jobs:
           verbosity: ${{ parameters.verbosity }}
           configuration: ${{ parameters.configuration }}
           skipUnitTests: ${{ parameters.skipUnitTests }}
+
+      - template: api-scan.yml
+        parameters:
+          mainBranchName: ${{ parameters.mainBranchName }}
 
       # after the build is complete
       - pwsh: |


### PR DESCRIPTION
Context: In January of 2024, the EU will begin enforcing the Digital Markets Act, which, for our purposes, means that any high-volume API calls must be documented, or we must switch to using a documented high-volume API. 

Microsoft's internal "APIScan" ensures that no undocumented APIs are called.

This scan will be run only on Windows `main` builds.  Note that APIScan is run on _binaries_, not _code_, so it must be run in the build stage rather than the compliance stage.

Successful run on a PR build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8815822&view=logs&j=2f7369d1-fb97-5262-a571-f4e9c996b7d1&t=df26002c-a356-594f-dc84-ac5f1cd7aaf1

As expected for an open source, cross-platform project, there does not appear to be any issues found that need to be mitigated.  😁 