### PR TITLE
Manual updates 20231215 - CI timeouts 300 minutes

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -1,7 +1,7 @@
 parameters:
   # Environment Parameters
   name: 'build'                                             # the name of the build job for dependency purposes
-  timeoutInMinutes: 150                                     # the timeout in minutes
+  timeoutInMinutes: 300                                     # the timeout in minutes
   mainBranchName: 'main'                                    # the "main" branch that should be used - can be something other than "main"
   macosAgentPoolName: 'Azure Pipelines'                     # the name of the macOS VM pool
   macosImage: internal-macos12                              # macOS VM image name, must be "internal" locked down image


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

Increased default timeouts for CI builds to fix builds failing due to timeout