### PR TITLE
[ApiScan] Store log files and error on issues.

### DIFF
--- a/build/ci/api-scan.yml
+++ b/build/ci/api-scan.yml
@@ -15,6 +15,15 @@ steps:
     OverWrite: true
     flattenFolders: true
   condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+ 
+- task: CmdLine@2
+  displayName: 'Remove System assemblies from APIScan'
+  inputs:
+    script: |
+      del ${{ parameters.apiScanDirectory }}\System.*
+      del ${{ parameters.apiScanDirectory }}\mscorlib.dll
+      del ${{ parameters.apiScanDirectory }}\netstandard.dll
+  condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
 
 - task: CmdLine@2
   displayName: 'List Files for APIScan'
@@ -22,7 +31,7 @@ steps:
     script: |
       tree ${{ parameters.apiScanDirectory }} /f        
   condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
-        
+       
  ### Run latest version of APIScan listed at https://www.1eswiki.com/wiki/APIScan_Build_Task
 - task: APIScan@2
   displayName: Run APIScan
@@ -35,3 +44,28 @@ steps:
   condition: and(succeeded(), eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
   env:
     AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+
+- task: SdtReport@2
+  displayName: Guardian Export - Security Report
+  inputs:
+    GdnExportAllTools: false
+    GdnExportGdnToolApiScan: true
+    GdnExportOutputSuppressionFile: source.gdnsuppress
+  condition: and(eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+
+- task: PublishSecurityAnalysisLogs@3
+  displayName: Publish Guardian Artifacts
+  inputs:
+    ArtifactName: APIScan Logs
+    ArtifactType: Container
+    AllTools: false
+    APIScan: true
+    ToolLogsNotFoundAction: Warning
+  condition: and(eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
+
+- task: PostAnalysis@2
+  displayName: Fail Build on Guardian Issues
+  inputs:
+    GdnBreakAllTools: false
+    GdnBreakGdnToolApiScan: true
+  condition: and(eq(variables['runAPIScan'], 'true'), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/829
Context: https://github.com/xamarin/xamarin-android/pull/8605

In #829, I got a little ahead of myself with my quote:

> As expected for an open source, cross-platform project, there does not appear to be any issues found that need to be mitigated.

It turns out there were some issues being marked, but the scan doesn't fail the build so they were missed.

Fix 2 things:
- Use @pjcollins's more [complete solution](https://github.com/xamarin/xamarin-android/pull/8605) to store the ApiScan logs and fail the build if any issues were found.
- Fix the following failures by removing some framework assemblies that ship with `dotnet` and we are not redistributing with our packages.

```
system.objectmodel.dll(,): Error documentationnotfound: Documentation Not Found: presentationframework!System.Windows.Input.CommandValueSerializer is either an undocumented HVP API or the documentation is not discoverable.
mscorlib.dll(,): Error documentationnotfound: Documentation Not Found: system.runtime.compilerservices.visualc!System.Runtime.CompilerServices.SuppressMergeCheckAttribute is either an undocumented HVP API or the documentation is not discoverable.
netstandard.dll(,): Error documentationnotfound: Documentation Not Found: system.componentmodel.typeconverter!System.ComponentModel.Design.DesignerOptionService.DesignerOptionConverter is either an undocumented HVP API or the documentation is not discoverable.
```

CI Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8875161