### PR TITLE
Manual updates 20240208 improvements - template for `Directory.Build.rsp`

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,6 +29,10 @@
       {
         "templateFile": "source/AndroidXNuGetReadMe.cshtml",
         "outputFileRule": "generated/{groupid}.{artifactid}/readme.md"
+      },
+      {
+        "templateFile": "source/AndroidXDirectoryBuildRsp.cshtml",
+        "outputFileRule": "generated/{groupid}.{artifactid}/Directory.Build.rsp"
       }
     ],
     "artifacts": [

--- a/source/AndroidXDirectoryBuildRsp.cshtml
+++ b/source/AndroidXDirectoryBuildRsp.cshtml
@@ -4,6 +4,7 @@
 @using System.Xml.Linq
 
   @{
+      string path_current_directory = System.IO.Directory.GetCurrentDirectory();
       string[] artifact_version_parts = Model.NuGetVersion
                                               .Split(new string[] { "-" }, StringSplitOptions.None);
       string artifact_version = null;
@@ -21,16 +22,25 @@
           artifact_version += "-" + artifact_version_parts[1];
       }
   }
+# Directory.Build.rsp
 
-/Restore
-/ConsoleLoggerParameters:Verbosity=Minimal;Summary;ForceNoAlign
-/MaxCPUCount
-/NodeReuse:false
+# https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference  
+# https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files
+
+# artifact=@(Model.MavenGroupId):@(Model.Name) 
+
+# artifact_versioned=@(Model.MavenGroupId)-@(Model.Name)-@(artifact_version)
+
+# nuget=@(Model.NuGetPackageId).@(Model.NuGetVersion)
+
+#-ConsoleLoggerParameters:Verbosity=Minimal;Summary
+-clp:Verbosity=Minimal;Summary
+
+#-BinaryLogger:@(Model.MavenGroupId)-@(Model.Name)-@(artifact_version).binlog
+-bl:@(path_current_directory)/output/@(Model.MavenGroupId)-@(Model.Name)-@(artifact_version).binlog
 
 
-artifact=@(Model.MavenGroupId):@(Model.Name) 
-
-artifact_versioned=@(Model.MavenGroupId):@(Model.Name):@(artifact_version)
-
-nuget=@(Model.Name).@(Model.NuGetVersion)
-
+#-FileLoggerParameters:Verbosity=Diagnostic
+#/flp:v=diag;logfile=@(path_current_directory)/output/@(Model.MavenGroupId):@(Model.Name):@(artifact_version).diag.log
+-flp1:Verbosity=Diagnostic;errorsonly;logfile=@(path_current_directory)/output/@(Model.MavenGroupId):@(Model.Name):@(artifact_version).errors.diag.log
+-flp2:Verbosity=Diagnostic;warningsonly;logfile=@(path_current_directory)/output/@(Model.MavenGroupId):@(Model.Name):@(artifact_version).warnings.diag.log

--- a/source/AndroidXDirectoryBuildRsp.cshtml
+++ b/source/AndroidXDirectoryBuildRsp.cshtml
@@ -1,0 +1,36 @@
+﻿@using System
+@using System.IO
+@using System.Linq
+@using System.Xml.Linq
+
+  @{
+      string[] artifact_version_parts = Model.NuGetVersion
+                                              .Split(new string[] { "-" }, StringSplitOptions.None);
+      string artifact_version = null;
+
+      string artifact_version_release = artifact_version_parts[0];
+      string[] artifact_version_release_parts = artifact_version_release.Split(new string[] { "." }, StringSplitOptions.None);
+      artifact_version = string.Join(".", artifact_version_release_parts, 0, 3);
+
+      if (artifact_version_parts.Length == 1)
+      {
+          // release
+      }
+      if (artifact_version_parts.Length == 2)
+      {
+          artifact_version += "-" + artifact_version_parts[1];
+      }
+  }
+
+/Restore
+/ConsoleLoggerParameters:Verbosity=Minimal;Summary;ForceNoAlign
+/MaxCPUCount
+/NodeReuse:false
+
+
+artifact=@(Model.MavenGroupId):@(Model.Name) 
+
+artifact_versioned=@(Model.MavenGroupId):@(Model.Name):@(artifact_version)
+
+nuget=@(Model.Name).@(Model.NuGetVersion)
+


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

In order to get more information and isolated information the template to generate per project (`csproj`) was added.

Template generates `Directory.Build.rsp` with

- binlogger
- fileloggers

with diagnostic output.