### PR TITLE
Manual updates 20240210 fixes for intermittent CI errors on Windows `java.lang.OutOfMemoryError`

### DIFF
--- a/samples/BuildAll/BuildAll/BuildAll.csproj
+++ b/samples/BuildAll/BuildAll/BuildAll.csproj
@@ -60,7 +60,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/BuildAll/BuildAll/BuildAll.csproj
+++ b/samples/BuildAll/BuildAll/BuildAll.csproj
@@ -60,6 +60,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/BuildAll/BuildAll/Properties/AndroidManifest.xml
+++ b/samples/BuildAll/BuildAll/Properties/AndroidManifest.xml
@@ -4,5 +4,5 @@
 		HeifWriter minSDK=28
 	-->
 	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="31" />
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:largeHeap="true"></application>
 </manifest>

--- a/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/BuildMinimalAppCompat.csproj
+++ b/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/BuildMinimalAppCompat.csproj
@@ -25,7 +25,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -43,6 +43,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -60,6 +61,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/BuildMinimalAppCompat.csproj
+++ b/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/BuildMinimalAppCompat.csproj
@@ -25,6 +25,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/Properties/AndroidManifest.xml
+++ b/samples/BuildMinimalAppCompat/BuildMinimalAppCompat/Properties/AndroidManifest.xml
@@ -4,5 +4,5 @@
 		HeifWriter minSDK=28
 	-->
 	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="29" />
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:largeHeap="true"></application>
 </manifest>

--- a/samples/BuildMinimalAppCompat/ClassLibrary/ClassLibrary.csproj
+++ b/samples/BuildMinimalAppCompat/ClassLibrary/ClassLibrary.csproj
@@ -17,6 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -34,6 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/BuildMinimalMaterial/BuildMinimalMaterial/ BuildMinimalMaterial.csproj
+++ b/samples/BuildMinimalMaterial/BuildMinimalMaterial/ BuildMinimalMaterial.csproj
@@ -25,7 +25,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -43,6 +43,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -60,6 +61,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/BuildMinimalMaterial/BuildMinimalMaterial/ BuildMinimalMaterial.csproj
+++ b/samples/BuildMinimalMaterial/BuildMinimalMaterial/ BuildMinimalMaterial.csproj
@@ -25,6 +25,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/samples/BuildMinimalMaterial/BuildMinimalMaterial/Properties/AndroidManifest.xml
+++ b/samples/BuildMinimalMaterial/BuildMinimalMaterial/Properties/AndroidManifest.xml
@@ -4,5 +4,5 @@
 		HeifWriter minSDK=28
 	-->
 	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="29" />
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:largeHeap="true"></application>
 </manifest>

--- a/samples/BuildMinimalMaterial/ClassLibrary/ClassLibrary.csproj
+++ b/samples/BuildMinimalMaterial/ClassLibrary/ClassLibrary.csproj
@@ -17,6 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -34,6 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat.csproj
+++ b/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat.csproj
@@ -26,6 +26,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat.csproj
+++ b/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat.csproj
@@ -26,7 +26,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EnableProguard>true</EnableProguard>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -44,6 +44,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -61,6 +62,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidEnableDesugar>true</AndroidEnableDesugar>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/Properties/AndroidManifest.xml
+++ b/samples/BuildMinimalMaterialAppCompat/BuildMinimalMaterialAppCompat/Properties/AndroidManifest.xml
@@ -4,5 +4,5 @@
 		HeifWriter minSDK=28
 	-->
 	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="29" />
-	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:largeHeap="true"></application>
 </manifest>

--- a/samples/BuildMinimalMaterialAppCompat/ClassLibrary/ClassLibrary.csproj
+++ b/samples/BuildMinimalMaterialAppCompat/ClassLibrary/ClassLibrary.csproj
@@ -19,6 +19,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,6 +29,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -36,6 +38,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/BuildXamarinFormsApp.Android.csproj
+++ b/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/BuildXamarinFormsApp.Android.csproj
@@ -22,6 +22,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/BuildXamarinFormsApp.Android.csproj
+++ b/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/BuildXamarinFormsApp.Android.csproj
@@ -22,7 +22,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/Properties/AndroidManifest.xml
+++ b/samples/BuildXamarinFormsApp/BuildXamarinFormsApp/BuildXamarinFormsApp.Android/Properties/AndroidManifest.xml
@@ -4,6 +4,6 @@
 		HeifWriter minSDK=28
 	-->
 	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="28" />
-	<application android:label="BuildXamarinFormsApp.Android"></application>
+	<application android:label="BuildXamarinFormsApp.Android" android:largeHeap="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/samples/dotnet/BuildAllDotNet/AndroidManifest.xml
+++ b/samples/dotnet/BuildAllDotNet/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true">
+  <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:largeHeap="true">
   </application>
   <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
+++ b/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
@@ -18,7 +18,7 @@
     <!-- Prevent linking, since that would remove ~everything -->
     <PublishTrimmed>False</PublishTrimmed>
     <RunAOTCompilation>False</RunAOTCompilation>
-    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+    <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
   </PropertyGroup>
   
   <Import Project="..\..\..\output\AllPackages.targets" />

--- a/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
+++ b/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
@@ -18,7 +18,7 @@
     <!-- Prevent linking, since that would remove ~everything -->
     <PublishTrimmed>False</PublishTrimmed>
     <RunAOTCompilation>False</RunAOTCompilation>
-    
+    <JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
   </PropertyGroup>
   
   <Import Project="..\..\..\output\AllPackages.targets" />

--- a/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
+++ b/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
@@ -27,6 +27,12 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<PropertyGroup
+		Condition="$(TargetFramework.EndsWith('-android')) == true"
+		>
+		<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -63,7 +69,7 @@
 	[./samples/dotnet/BuildAllMauiApp.sln]
 	-->
 	<ItemGroup
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.EndsWith('-android')) == true"
 		>
 		<PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="[1.1.0.1-alpha06]" />
 		<PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto.Ktx" Version="[1.1.0.1-alpha06]" />

--- a/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
+++ b/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
@@ -30,7 +30,7 @@
 	<PropertyGroup
 		Condition="$(TargetFramework.EndsWith('-android')) == true"
 		>
-		<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+		<JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
+++ b/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup
 		Condition="$(TargetFramework.EndsWith('-android')) == true"
 		>
-		<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+		<JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
+++ b/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
@@ -1,8 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android31</TargetFramework>
+    <TargetFrameworks>net6.0-android;net7.0-android</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+
+  <PropertyGroup
+		Condition="$(TargetFramework.EndsWith('-android')) == true"
+		>
+		<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+	</PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2578" />  
     <PackageReference Include="Xamarin.Essentials" Version="1.7.7" />

--- a/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/Properties/AndroidManifest.xml
+++ b/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.buildallxamarinforms">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
-	<application android:label="BuildAllXamarinForms.Android" android:theme="@style/MainTheme"></application>
+	<application android:label="BuildAllXamarinForms.Android" android:theme="@style/MainTheme" android:largeHeap="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
CI builds for samples on windows after tagging and merging into main fail with error on Windows only:

```
D8 : error : java.lang.OutOfMemoryError: Java heap space 
[C:\a\_work\1\s\samples\dotnet\BuildAllDotNet\BuildAllDotNet.csproj::TargetFramework=net7.0-android]
C:\hostedtoolcache\windows\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.95\tools\Xamarin.Android.D8.targets(81[C:\a\_work\1\s\samples\dotnet\BuildAllDotNet\BuildAllDotNet.csproj::TargetFramework=net7.0-android]
MSBUILD : java.exe error JAVA0000: java.lang.OutOfMemoryError [C:\a\_work\1\s\samples\dotnet\BuildAllDotNet\BuildAllDotNet.csproj::TargetFramework=net7.0-android]
MSBUILD : java.exe error JAVA0000:  Java heap space [C:\a\_work\1\s\samples\dotnet\BuildAllDotNet\BuildAllDotNet.csproj::TargetFramework=net7.0-android]
MSBUILD : java.exe error JAVA0000:  [C:\a\_work\1\s\samples\dotnet\BuildAllDotNet\BuildAllDotNet.csproj::TargetFramework=net7.0-android]
```

### Does this change any of the generated binding API's?

No.

### Describe your contribution

- `JavaMaximumHeapSize` added to samples cspojs and `android:largeHeap="true"` i `AndroidManifest.xml` added