### PR TITLE
Manual updates 20240216 - automatic version checks and updates version bumps

### DIFF
--- a/.github/workflows/new-releases-check.yml
+++ b/.github/workflows/new-releases-check.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x.x
         
@@ -39,7 +39,7 @@ jobs:
 
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         commit-message: Weekly stable updates
         branch-suffix: timestamp
@@ -47,6 +47,7 @@ jobs:
         title: 'Weekly stable updates'
         body: |
             Update to latest stable versions of components:
+            
             - androidx.example.example - 1.0.0 -> 1.1.0
 
             Checklist


### PR DESCRIPTION
Automatic updates fail with:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-dotnet@v3, peter-evans/create-pull-request@v5. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

### Does this change any of the generated binding API's?

No.

### Describe your contribution

Bumped github action versions.
