### PR TITLE
Fix persistent `api-diff` issues.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -22,7 +22,7 @@ parameters:
   - 'xamarin.androidbinderator.tool': '0.5.7'
   - 'Cake.Tool': '4.0.0'
   - 'boots': '1.1.0.712-preview2'
-  - 'private-api-tools': '1.0.0'
+  - 'private-api-tools': '1.0.1'
 
   # Build Parameters
   verbosity: 'normal'                                       # the build verbosity: 'minimal', 'normal', 'diagnostic'

--- a/nuget-diff.cake
+++ b/nuget-diff.cake
@@ -36,6 +36,7 @@ if (!nupkgs.Any()) {
 				.AppendQuoted(nupkg.FullPath)
 				.Append(version)
 				.Append("--prerelease")
+				.Append("--prefer-released")
 				.Append("--group-ids")
 				.Append("--ignore-unchanged")
 				.Append("--compare-nuget-structure")

--- a/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
+++ b/source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj
@@ -33,7 +33,7 @@
     <PackageTags>Xamarin AndroidX Xamarin.AndroidX Support Google appcompat-resources</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageVersion>1.1.0.2</PackageVersion>
+    <PackageVersion>1.1.0.3</PackageVersion>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>


### PR DESCRIPTION
After a fresh bump of all packages, there are still 2 issues reported in `api-diff`/`nuget-diff`:

    ## Xamarin.AndroidX.AppCompat.Resources

    ### Added/Removed File(s)

    ```
    + lib/net7.0-android33.0/Xamarin.AndroidX.AppCompat.Resources.pdb
    + lib/net7.0-android33.0/Xamarin.AndroidX.AppCompat.Resources.dll
    + lib/net7.0-android33.0/Xamarin.AndroidX.AppCompat.Resources.xml
    ```

This is because this package is manually versioned in a `.csproj`.  Bump this version so we can release a new NuGet.

---

    # API diff: Xamarin.AndroidX.Security.SecurityCrypto.dll
    ...

This is because our comparison process compares against the highest versioned publicly available NuGet package.  Because we have released a `1.1.0.1-alpha06` version, this is what we compare against, even though we are binding `1.0.0.16` in `main`.

To fix this, add a new `--prefer-released` option to `api-diff` that will choose the highest *stable* package version if it exists and compare against it.  If there are no public stable releases, then we are likely binding a package that hasn't hit stable yet (like `Xamarin.AndroidX.Ads.Identifier`), and we will compare against the highest preview version.