### PR TITLE
Weekly stable updates 20240226

### DIFF
--- a/config.json
+++ b/config.json
@@ -280,144 +280,144 @@
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple.Android",
         "dependencyOnly": false
       },
@@ -456,208 +456,208 @@
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-livedata",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.LiveData",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util-android",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util.Android",
         "dependencyOnly": false
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-viewbinding",
-        "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "version": "1.6.2",
+        "nugetVersion": "1.6.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.ViewBinding",
         "dependencyOnly": false
       },

--- a/utilities.cake
+++ b/utilities.cake
@@ -1518,21 +1518,28 @@ Task("tools-executive-oreder-csv-and-markdown")
                 Arguments = process_args,
                 RedirectStandardOutput = true,
             };
-			exitCodeWithoutArguments = StartProcess(process, process_settings, out redirectedStandardOutput);
-            foreach (string line in redirectedStandardOutput.ToList())
+            try
             {
-                string tool = null;
-                string version = null;
-
-                if
-                    (
-                        line.Contains("NuGet Version: ")
-                    )
+                exitCodeWithoutArguments = StartProcess(process, process_settings, out redirectedStandardOutput);
+                foreach (string line in redirectedStandardOutput.ToList())
                 {
-                    tool = line.Replace("NuGet Version: ", "");
-                    version = tool;
-                    sb.AppendLine($"nuget, {version}");
+                    string tool = null;
+                    string version = null;
+
+                    if
+                        (
+                            line.Contains("NuGet Version: ")
+                        )
+                    {
+                        tool = line.Replace("NuGet Version: ", "");
+                        version = tool;
+                        sb.AppendLine($"nuget, {version}");
+                    }
                 }
+            }
+            catch
+            {
+                sb.AppendLine($"NuGet package manager, Not installed");
             }
 
             /*


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

updates

- `androidx.compose.animation:animation-` - 1.6.1 -> 1.6.2
- `androidx.compose.animation:animation-android` - 1.6.1 -> 1.6.2
- `androidx.compose.animation:animation-core` - 1.6.1 -> 1.6.2
- `androidx.compose.animation:animation-core-android` - 1.6.1 -> 1.6.2
- `androidx.compose.animation:animation-graphics` - 1.6.1 -> 1.6.2
- `androidx.compose.animation:animation-graphics-android` - 1.6.1 -> 1.6.2
- `androidx.compose.foundation:foundation` - 1.6.1 -> 1.6.2
- `androidx.compose.foundation:foundation-android` - 1.6.1 -> 1.6.2
- `androidx.compose.foundation:foundation-layout` - 1.6.1 -> 1.6.2
- `androidx.compose.foundation:foundation-layoutandroid` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-android` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-icons-core` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-icons-coreandroid` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-icons-extended` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-icons-extendedandroid` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-ripple` - 1.6.1 -> 1.6.2
- `androidx.compose.material:material-rippleandroid` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-android` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-livedata` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-rxjava2` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-rxjava3` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-saveable` - 1.6.1 -> 1.6.2
- `androidx.compose.runtime:runtime-saveable-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-geometry` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-geometry-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-graphics` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-graphics-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-text` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-text-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling-data` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling-data-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling-preview` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-tooling-preview-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-unit` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-unit-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-util` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-util-android` - 1.6.1 -> 1.6.2
- `androidx.compose.ui:ui-viewbinding` - 1.6.1 -> 1.6.2
