### PR TITLE
Fix issue causing `nuget-diff.md` noisiness.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -22,7 +22,7 @@ parameters:
   - 'xamarin.androidbinderator.tool': '0.5.7'
   - 'Cake.Tool': '4.0.0'
   - 'boots': '1.1.0.712-preview2'
-  - 'private-api-tools': '1.0.1'
+  - 'private-api-tools': '1.0.2'
 
   # Build Parameters
   verbosity: 'normal'                                       # the build verbosity: 'minimal', 'normal', 'diagnostic'


### PR DESCRIPTION
Changing a NuGet version results in the following `nuget-diff` output:

```
## Xamarin.AndroidX.Compose.Animation.Android

### Changed Metadata

- <description>.NET for Android (formerly Xamarin.Android) bindings for AndroidX - animation-android (bindings without managed callable wrappers (C#) and are only used for including Java files) artifact=androidx.compose.animation:animation-android artifact_versioned=androidx.compose.animation:animation-android:1.6.1</description>
+ <description>.NET for Android (formerly Xamarin.Android) bindings for AndroidX - animation-android (bindings without managed callable wrappers (C#) and are only used for including Java files) artifact=androidx.compose.animation:animation-android artifact_versioned=androidx.compose.animation:animation-android:1.6.2</description>
```

We have code that prevents this difference from being reported in the `<tags>` metadata:
https://github.com/mattleibow/Mono.ApiTools.NuGetDiff/pull/17/files#diff-c5198c01355b93901ed282c06486717664977778fc50e66fbad36b28e1f37f73R58-R66

However this template also puts `artifact_versioned` in the `<description>` which we weren't scrubbing.  Update to a new version of `private-api-tools` which additionally scrubs `artifact_versioned` from `<description>`.