### PR TITLE
Add TypeForwards for `Xamarin.AndroidX.Collection`.

### DIFF
--- a/config.json
+++ b/config.json
@@ -257,7 +257,7 @@
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.Collection",
         "dependencyOnly": false
       },

--- a/source/androidx.collection/collection/Additions/TypeForwards.cs
+++ b/source/androidx.collection/collection/Additions/TypeForwards.cs
@@ -1,0 +1,10 @@
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.ArrayMap))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.ArraySet))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.CircularArray))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.CircularIntArray))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.LongSparseArray))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.LruCache))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.SimpleArrayMap))]
+[assembly: TypeForwardedTo (typeof (AndroidX.Collection.SparseArrayCompat))]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/AndroidX/issues/821
Fixes: https://github.com/xamarin/AndroidX/issues/807

In version `1.3.0`, Google moved all the types in `Xamarin.AndroidX.Collection` to `Xamarin.AndroidX.Collection.Jvm`.  While this  is a source compatible change for users, it is not a binary compatible change for users that are relying on NuGets or assemblies that have not been recompiled.

These types will continue to work in Debug builds, but the linker and AOT compiler steps run for Release builds are unable to resolve the moved types, causing unfixable errors (other than recompiling all assemblies).

Adding `[TypeForwardedToAttribute]` attributes allows the linker and AOT to succeed without recompiling old assemblies.

Note this does not imply that we have tooling that can automatically detect these cases or that we will be proactive about adding type forwards, but we can manually add reported instances that are problematic like this one.