### PR TITLE
[ci] Use managed identity for API scan.

### DIFF
--- a/build/ci/api-scan.yml
+++ b/build/ci/api-scan.yml
@@ -43,7 +43,7 @@ steps:
     toolVersion: Latest
   condition: and(succeeded(), eq('refs/heads/${{ parameters.mainBranchName }}', variables['Build.SourceBranch']))
   env:
-    AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+    AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTManagedId)
 
 - task: SdtReport@2
   displayName: Guardian Export - Security Report


### PR DESCRIPTION
Configures a new [managed identity][0] (MSI) for API Scan, which
allows us to enable a more modern authentication approach when running
API Scan on the `MAUI-1ESPT` agent pool.

A new `$(ApiScanMAUI1ESPTManagedId)` variable has been configured in the
pipeline settings to pass the app ID for this MSI to the API Scan task.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourcegroups/1esobjects/providers/microsoft.managedidentity/userassignedidentities/maui1esptapiscanidentity/overview

Successful CI test run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9310159&view=results