### PR TITLE
[private-api-tools] Ignore duplicate "for" package tag.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -22,7 +22,7 @@ parameters:
   - 'xamarin.androidbinderator.tool': '0.5.7'
   - 'Cake.Tool': '4.0.0'
   - 'boots': '1.1.0.712-preview2'
-  - 'private-api-tools': '1.0.2'
+  - 'private-api-tools': '1.0.3'
   
   # Reporting/Analysis Parameters
   artifactsPath: 'output'                                           # Path to the NuGet packages that need to be signed, verified and published


### PR DESCRIPTION
The NuGet metadata compare for GPS is reporting this diff on nearly every package:

    ## Xamarin.Firebase.Common

    ### Changed Metadata

    ```
    - <tags>.NET for Android Xamarin.Android Bindings Google Play Services artifact=com.google.firebase:firebase-common:[Version] artifact_versioned=com.google.firebase:firebase-common:[Version]</tags>
    + <tags>.NET for Android Xamarin.Android Bindings for Google Play Services artifact=com.google.firebase:firebase-common:[Version] artifact_versioned=com.google.firebase:firebase-common:[Version]</tags>
    ```

It would seem that NuGet.org strips duplicate tags when a package is published, which removes our duplicate `for` tag.  Update our compare to ignore the `for` tag.