### PR TITLE
Bump to .NET 8 '8.0.204' generator.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
     <!-- Use an updated 'generator' -->
     <!-- It's ok to use "Windows" here because we only use managed code from this package -->
-    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.43/tools/</_BindingsToolsLocation>
+    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.95/tools/</_BindingsToolsLocation>
     
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@
 #tool nuget:?package=vswhere&version=3.1.7
 
 #tool nuget:?package=Cake.CoreCLR
-#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.43
+#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.95
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=7.0.0


### PR DESCRIPTION
Update the version of `generator` used to build the `net7.0-android` version of our packages.

This should contain https://github.com/xamarin/java.interop/pull/1202, which is needed for binding AndroidX Media3.