### PR TITLE
[AndroidX.Browser] Obsolete CustomTabsActivityManager.From with message describing its shortcomings.

### DIFF
--- a/source/androidx.browser/browser/Additions/CustomTabsActivityManager.cs
+++ b/source/androidx.browser/browser/Additions/CustomTabsActivityManager.cs
@@ -9,8 +9,10 @@ namespace AndroidX.Browser.CustomTabs
 {
     public class CustomTabsActivityManager
     {
-        static CustomTabsActivityManager instance;
-        public static CustomTabsActivityManager From (Activity parentActivity, string servicePackageName = null)
+        static CustomTabsActivityManager? instance;
+
+        [Obsolete ("This method only supports a single parentActivity and caches a reference to it forever. It is recommended to use the CustomTabsActivityManager constructor instead and implement any desired caching in the consuming application.")]
+        public static CustomTabsActivityManager From (Activity parentActivity, string? servicePackageName = null)
         {
             if (instance == null) {
                 instance = new CustomTabsActivityManager (parentActivity);
@@ -22,8 +24,8 @@ namespace AndroidX.Browser.CustomTabs
         public Activity ParentActivity { get; private set; }
         public CustomTabsClient Client { get; private set; }
 
-        CustomTabsSession session = null;
-        public CustomTabsSession Session { 
+        CustomTabsSession? session = null;
+        public CustomTabsSession? Session { 
             get {
                 if (Client == null) {
                     return null;


### PR DESCRIPTION
Fixes https://github.com/xamarin/AndroidX/issues/873

The method `CustomTabsActivityManager.From (Activity parentActivity, string? servicePackageName = null)` caches the passed in `parentActivity` forever, which can cause a memory leak.

Additionally, only the first `parentActivity` passed in supported.  Subsequent `parentActivity` arguments are ignored and the first one is always reused.

Mark this helper method as `[Obsolete]` and recommend consumers implement any desired caching themselves in a way that respects the parent activity(ies) and their lifetimes properly for the relevant application.