### PR TITLE
[ci] Ensure logs and artifacts get published on failed builds.

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -44,6 +44,7 @@ jobs:
     - output: pipelineArtifact
       targetPath: ${{ parameters.artifactsPath }}
       artifactName: output-${{ parameters.name }}
+      condition: always()
       
   steps:
     - template: setup-environment.yml


### PR DESCRIPTION
After [migrating to the 1ES template](https://github.com/xamarin/AndroidX/pull/844), when our build fails, no logs or artifacts are retained, making it very hard to diagnose the issue.  Add an `always` condition to the output upload so these will get saved.

Example build demonstrating artifacts are uploaded on failure:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9440304&view=results