### PR TITLE
Fix update script to handle misnamed guava Java versions.

### DIFF
--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -181,8 +181,9 @@ public static SemanticVersion GetLatestVersion (Artifact artifact, bool includeP
 {
 	var versions = artifact.Versions.Select(v => GetVersion (v));
 
+	// Handle 'com.google.guava.guava' which ships its release packages as ex: '33.1.0-android'
 	if (!includePrerelease)
-		versions = versions.Where (v => !v.IsPrerelease);
+		versions = versions.Where (v => !v.IsPrerelease || v.Release == "android");
 
 	if (!versions.Any ())
 		return null;

--- a/config.json
+++ b/config.json
@@ -2169,8 +2169,8 @@
       {
         "groupId": "com.google.guava",
         "artifactId": "guava",
-        "version": "32.0.1-android",
-        "nugetVersion": "32.0.1.2",
+        "version": "33.1.0-android",
+        "nugetVersion": "33.1.0",
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
@@ -2523,8 +2523,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.23.0",
-        "nugetVersion": "2.23.0.1",
+        "version": "2.26.1",
+        "nugetVersion": "2.26.1",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": true
       },


### PR DESCRIPTION
We have missed several new versions of `com.google.guava.guava` because they name their release packages like `33.1.0-android`.  Traditionally, adding any sort of label after a hyphen indicates that the package is a pre-release version so we ignore it.  Thus we have been ignoring their new versions.

Fix our update script to allow a pre-release tag of `-android` to count as a stable release version so we will process `guava` updates.

Additionally, go ahead and bump `guava` to the latest version available. Note we remove the `-android` from the NuGet version, as it is not a pre-release package.