### PR TITLE
Weekly stable updates 20240503

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -272,6 +272,8 @@ Task ("binderate")
     var configFile = MakeAbsolute(new FilePath("./config.json")).FullPath;
     var basePath = MakeAbsolute(new DirectoryPath ("./")).FullPath;
 
+    Information("xamarin-android-binderator" +
+        $"--config=\"{configFile}\" --basepath=\"{basePath}\"");
     // Run the dotnet tool for binderator
     RunProcess("xamarin-android-binderator",
         $"--config=\"{configFile}\" --basepath=\"{basePath}\"");

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1125,9 +1125,9 @@
         "maven": {
           "artifactId": "core-animation",
           "groupId": "androidx.core",
-          "version": "1.0.0-alpha02",
+          "version": "1.0.0",
           "nuGetId": "Xamarin.AndroidX.Core.Animation",
-          "nuGetVersion": "1.0.0.22-alpha02"
+          "nuGetVersion": "1.0.0"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -2724,9 +2724,9 @@
         "maven": {
           "artifactId": "vectordrawable",
           "groupId": "androidx.vectordrawable",
-          "version": "1.1.0",
+          "version": "1.2.0",
           "nuGetId": "Xamarin.AndroidX.VectorDrawable",
-          "nuGetVersion": "1.1.0.24"
+          "nuGetVersion": "1.2.0"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -728,8 +728,8 @@
       {
         "groupId": "androidx.core",
         "artifactId": "core-animation",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0",
+        "version": "1.0.0-alpha02",
+        "nugetVersion": "1.0.0.22-alpha02",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
@@ -1713,8 +1713,8 @@
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
-        "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "version": "1.1.0",
+        "nuGetVersion": "1.1.0.24",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },

--- a/config.json
+++ b/config.json
@@ -728,8 +728,8 @@
       {
         "groupId": "androidx.core",
         "artifactId": "core-animation",
-        "version": "1.0.0-alpha02",
-        "nugetVersion": "1.0.0.22-alpha02",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.AndroidX.Core.Animation",
         "dependencyOnly": false
       },
@@ -1713,8 +1713,8 @@
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.24",
+        "version": "1.2.0",
+        "nugetVersion": "1.2.0",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },

--- a/config.json
+++ b/config.json
@@ -1714,7 +1714,7 @@
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.1.0",
-        "nuGetVersion": "1.1.0.24",
+        "nugetVersion": "1.1.0.24",
         "nugetId": "Xamarin.AndroidX.VectorDrawable",
         "dependencyOnly": false
       },

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -91,7 +91,7 @@
 |  84|androidx.contentpager:contentpager                                    |1.0.0               |Xamarin.AndroidX.ContentPager                                         |1.0.0.24            |
 |  85|androidx.coordinatorlayout:coordinatorlayout                          |1.2.0               |Xamarin.AndroidX.CoordinatorLayout                                    |1.2.0.12            |
 |  86|androidx.core:core                                                    |1.13.1              |Xamarin.AndroidX.Core                                                 |1.13.1              |
-|  87|androidx.core:core-animation                                          |1.0.0-alpha02       |Xamarin.AndroidX.Core.Animation                                       |1.0.0.22-alpha02    |
+|  87|androidx.core:core-animation                                          |1.0.0               |Xamarin.AndroidX.Core.Animation                                       |1.0.0               |
 |  88|androidx.core:core-google-shortcuts                                   |1.1.0               |Xamarin.AndroidX.Core.GoogleShortcuts                                 |1.1.0.9             |
 |  89|androidx.core:core-ktx                                                |1.13.1              |Xamarin.AndroidX.Core.Core.Ktx                                        |1.13.1              |
 |  90|androidx.core:core-role                                               |1.0.0               |Xamarin.AndroidX.Core.Role                                            |1.0.0.22            |
@@ -214,7 +214,7 @@
 | 207|androidx.tracing:tracing                                              |1.2.0               |Xamarin.AndroidX.Tracing.Tracing                                      |1.2.0.2             |
 | 208|androidx.transition:transition                                        |1.5.0               |Xamarin.AndroidX.Transition                                           |1.5.0               |
 | 209|androidx.tvprovider:tvprovider                                        |1.0.0               |Xamarin.AndroidX.TvProvider                                           |1.0.0.26            |
-| 210|androidx.vectordrawable:vectordrawable                                |1.1.0               |Xamarin.AndroidX.VectorDrawable                                       |1.1.0.24            |
+| 210|androidx.vectordrawable:vectordrawable                                |1.2.0               |Xamarin.AndroidX.VectorDrawable                                       |1.2.0               |
 | 211|androidx.vectordrawable:vectordrawable-animated                       |1.1.0               |Xamarin.AndroidX.VectorDrawable.Animated                              |1.1.0.24            |
 | 212|androidx.versionedparcelable:versionedparcelable                      |1.2.0               |Xamarin.AndroidX.VersionedParcelable                                  |1.2.0.2             |
 | 213|androidx.viewpager:viewpager                                          |1.0.0               |Xamarin.AndroidX.ViewPager                                            |1.0.0.24            |


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Yes. Updates + new bindings().

### Describe your contribution

- `androidx.compose.animation:animation` - 1.6.6 -> 1.6.7
- `androidx.compose.animation:animation-android` - 1.6.6 -> 1.6.7
- `androidx.compose.animation:animation-core` - 1.6.6 -> 1.6.7
- `androidx.compose.animation:animation-core-android` - 1.6.6 -> 1.6.7
- `androidx.compose.animation:animation-graphics` - 1.6.6 -> 1.6.7
- `androidx.compose.animation:animation-graphics-android` - 1.6.6 -> 1.6.7
- `androidx.compose.foundation:foundation` - 1.6.6 -> 1.6.7
- `androidx.compose.foundation:foundation-android` - 1.6.6 -> 1.6.7
- `androidx.compose.foundation:foundation-layout` - 1.6.6 -> 1.6.7
- `androidx.compose.foundation:foundation-layout-android` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-android` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-icons-core` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-icons-core-android` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-icons-extended` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-icons-extended-android` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-ripple` - 1.6.6 -> 1.6.7
- `androidx.compose.material:material-ripple-android` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-android` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-livedata` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-rxjava2` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-rxjava3` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-saveable` - 1.6.6 -> 1.6.7
- `androidx.compose.runtime:runtime-saveable-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-geometry` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-geometry-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-graphics` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-graphics-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-text` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-text-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling-data` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling-data-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling-preview` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-tooling-preview-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-unit` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-unit-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-util` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-util-android` - 1.6.6 -> 1.6.7
- `androidx.compose.ui:ui-viewbinding` - 1.6.6 -> 1.6.7
- `androidx.core:core` - 1.13.0 -> 1.13.1
- `androidx.core:core-animation` - 1.0.0alpha02 -> 1.0.0
- `androidx.core:core-ktx` - 1.13.0 -> 1.13.1
- `androidx.databinding:databinding-adapters` - 8.3.2 -> 8.4.0
- `androidx.databinding:databinding-common` - 8.3.2 -> 8.4.0
- `androidx.databinding:databinding-runtime` - 8.3.2 -> 8.4.0
- `androidx.databinding:viewbinding` - 8.3.2 -> 8.4.0
- `androidx.datastore:datastore` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-android` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-core` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-core-android` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-core-jvm` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-core-okio` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-core-okiojvm` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-preferences` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-preferences-android` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-preferences-core` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-preferences-core-jvm` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-rxjava2` - 1.1.0 -> 1.1.1
- `androidx.datastore:datastore-rxjava3` - 1.1.0 -> 1.1.1
- `androidx.emoji2:emoji2-bundled` -  -> 1.4.0
- `androidx.emoji2:emoji2-emojipicker` -  -> 1.4.0
- `androidx.emoji2:emoji2-views` -  -> 1.4.0
- `androidx.fragment:fragment` - 1.6.2 -> 1.7.0
- `androidx.fragment:fragment-ktx` - 1.6.2 -> 1.7.0
- `androidx.transition:transition` - 1.4.1 -> 1.5.0
- `androidx.vectordrawable:vectordrawable` - 1.1.0 -> 1.2.0
- `androidx.webkit:webkit` - 1.10.0 -> 1.11.0
- `com.google.guava:guava` - 33.1.0android -> 33.2.0android
- `org.checkerframework:checkerqual` - 3.42.0 -> 3.43.0
- `org.jetbrains.kotlinx:atomicfu` - 0.17.0 -> 0.18.5
- `org.jetbrains.kotlinx:atomicfu-jvm` - 0.17.0 -> 0.18.5
- `androidx.emoji2:emoji2` -  -> 1.2.0
