### PR TITLE
Use `<AndroidLibrary>` rather than `.targets` files.

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -61,17 +61,25 @@
     <None Include=".\readme.md" Pack="True" PackagePath="readme.md" />
   </ItemGroup>
 
-  @if (@Model.MavenArtifacts.Count > 0) {
-  <ItemGroup>
+  <!-- For some reason, having a different .aar name from our legacy packages causes AAPT2 errors.
+       Use this for now to rename them back to the previous format: '{GroupId}.{ArtifactId}.[aar|jar]'.
+       Eventually this should probably move into binderator. -->
+  <Target 
+    Name="_RenameLibraries" 
+    BeforeTargets="_CategorizeAndroidLibraries">
+    
     @foreach (var art in @Model.MavenArtifacts) {
-      if (art.ProguardFile != null) {
-    <None Include="..\..\@(art.ProguardFile)" Pack="True" PackagePath="proguard/" />
-      }
-    }
-  </ItemGroup>
-  }
-
-  <ItemGroup>
+    <Copy 
+      SourceFiles="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).@(art.MavenArtifactPackaging)" 
+      DestinationFiles="..\..\externals\@(art.MavenGroupId)\@(art.MavenGroupId).@(art.MavenArtifactId).@(art.MavenArtifactPackaging)" />
+      
+    <ItemGroup>  
+      <AndroidLibrary Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenGroupId).@(art.MavenArtifactId).@(art.MavenArtifactPackaging)" />
+    </ItemGroup>
+    }  
+  </Target>
+  
+  <ItemGroup>    
     <!-- Include AssemblyInfo.cs -->
     <Compile Include="..\..\source\AssemblyInfo.cs" />
     
@@ -95,40 +103,6 @@
       <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
     </TransformFile>
   </ItemGroup>
-
-  <ItemGroup>
-    @foreach (var art in @Model.MavenArtifacts) {
-      if (art.MavenArtifactPackaging == "aar") {
-    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar\@(art.MavenGroupId).@(art.MavenArtifactId).aar" />
-      } else {
-    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar" />
-      }
-    }
-  </ItemGroup>
-
-
-  @if (@Model.MavenArtifacts.Count > 0) {
-  <ItemGroup>
-    @foreach (var art in @Model.MavenArtifacts)
-    {
-      if (art.MavenArtifactPackaging == "aar")
-      {
-    <InputJar 
-      Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\classes.jar')"
-      Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\classes.jar" />
-    <!-- For those artifacts with lib/ folder -->
-    <InputJar
-      Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\libs\')"
-      Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\libs\*.jar"
-      />
-      }
-      else
-      {
-    <InputJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" />
-      }
-    }
-  </ItemGroup>
-  }
 
   <ItemGroup>
     <!-- ProjectReference -->

--- a/source/AndroidXTargets.cshtml
+++ b/source/AndroidXTargets.cshtml
@@ -16,44 +16,10 @@
   }
 }
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  @if (@Model.MavenArtifacts.Count > 0) {
 
-  <ItemGroup>
-    @foreach (var art in @Model.MavenArtifacts) {
-      if (art.ProguardFile != null) {
-    <ProguardConfiguration Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt">
-      <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
-    </ProguardConfiguration>
-      }
-    }
-  </ItemGroup>
-  }
-
-  <PropertyGroup>
-    <AndroidManifestMerger Condition=" '$(AndroidManifestMerger)' == '' ">manifestmerger.jar</AndroidManifestMerger>
-  </PropertyGroup>  
   <PropertyGroup>
       <AndroidFragmentType>AndroidX.Fragment.App.Fragment</AndroidFragmentType> 
   </PropertyGroup>
-  
-  <ItemGroup>
-    @foreach (var art in @Model.MavenArtifacts) {
-      if ($"{art.MavenGroupId}.{art.MavenArtifactId}" == "androidx.multidex.multidex") {
-        // multidex is a special case that only includes the aar conditionally
-        continue;
-      }
-
-      if (art.MavenArtifactPackaging == "aar") {
-    <AndroidAarLibrary Include="$(MSBuildThisFileDirectory)..\..\aar\@(art.MavenGroupId).@(art.MavenArtifactId).aar">
-      <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
-    </AndroidAarLibrary>
-      } else {
-    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\@(art.MavenGroupId).@(art.MavenArtifactId).jar">
-      <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
-    </AndroidJavaLibrary>
-      }
-    }   
-  </ItemGroup>
 
 @{
   string mergeTargets = Path.Combine(Model.Config.BasePath, "source", Model.MavenGroupId, Model.Name, "merge.targets");


### PR DESCRIPTION
Previously, our template would create bindings using `<InputJar>`, then manually add the `jar`/`aar` and any Proguard files to the `.nupgk`, and then use a `.targets` file to add these payloads to the Android application.

This was likely done for 2 reasons:
- Better build performance by not needing to extract an embedded `.jar`/`.aar`.
- Poor initial support for the other files contained in `.aar` files. (Proguard, etc.)

In .NET times, both of these issues have been resolved, and we can replace our custom hacks with the built-in `<AndroidLibrary>` build item, reducing the maintenance burden of custom solutions.

--- 

Note there is an issue with resources if the name of the included `.aar` is different from what our previous package versions named it:

```
error APT2260: resource style/TextAppearance.Compat.Notification.Info (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Info) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Info (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Info) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Info (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Info) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Time (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Time) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Time (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Time) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Time (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Time) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Title (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Title) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Title (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Title) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2260: resource style/TextAppearance.Compat.Notification.Title (aka com.companyname.BuildAllDotNet:style/TextAppearance.Compat.Notification.Title) not found. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
error APT2062: failed linking references. [/Users/runner/work/1/s/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj]
```

I was unable to find the root cause of this, so I added a workaround to rename the Java library the same as we previously used.  (`@(art.MavenGroupId).@(art.MavenArtifactId).[jar|aar]`)