### PR TITLE
[NuGet.config] Remove wildcard from nuget.org.

### DIFF
--- a/samples/NuGet.config
+++ b/samples/NuGet.config
@@ -4,62 +4,46 @@
         <clear />
         <add key="Local Output" value="../output" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        <!--
-        -->
     </packageSources>
+    
     <!--
         https://docs.microsoft.com/en-us/nuget/consume-packages/package-source-mapping
         Define mappings by adding package patterns beneath the target source.
     -->
     <packageSourceMapping>
-        <!-- key value for <packageSource> should match key values from <packageSources> element -->
-        <!--
-        packages restored from "Local Output":
-        -->
+        <!-- Get everything possible from the packages we built in this repo -->
         <packageSource key="Local Output">
-            <package pattern="Xamarin.AndroidX.*" />
-            <package pattern="Xamarin.AndroidX.Security.SecurityCrypto" />
-            <package pattern="Xamarin.Google.Android.Material" />
-            <package pattern="Xamarin.Kotlin.*" />
-            <package pattern="Xamarin.KotlinX.*" />
-            <package pattern="Xamarin.Google.AutoValue.Annotations" />
-            <package pattern="GoogleGson" />
-            <package pattern="Xamarin.Google.Guava" />
-            <package pattern="Xamarin.Google.Guava.*" />
-            <package pattern="Xamarin.AndroidX.*" />
-            <package pattern="Xamarin.Google.Crypto.Tink.Android" />             
-            <package pattern="Xamarin.Google.J2Objc.Annotations" />
-            <package pattern="Xamarin.Flogger" />
-            <package pattern="Xamarin.Flogger.*" />
-            <package pattern="Xamarin.Google.Assistant.AppActions.*" />
-            <package pattern="Xamarin.Google.Android.InstallReferrer" />
-            <package pattern="Xamarin.CheckerFramework.CheckerQual" />
-            <package pattern="Xamarin.AAkira.*" />
-            <package pattern="Xamarin.CheckerFramework.*" />
-            <package pattern="Xamarin.Google.Accompanist.*" />
-            <package pattern="Xamarin.Google.Android.Material.*" />
-            <package pattern="Xamarin.Dev.ChrisBanes.Snapper" />
-            <package pattern="Xamarin.Android.ReactiveX.*" />
-            <package pattern="Xamarin.Android.ReactiveStreams" />
-            <package pattern="Xamarin.Jetbrains.*" />
-            <package pattern="Xamarin.GoogleAndroid.Libraries.*" />
-        </packageSource>
-        <!--
-        packages restored from nuget.org:
-            everything else        
-        -->
-        <packageSource key="nuget.org">         
             <package pattern="*" />
-            <package pattern="Xamarin.AndroidX.*" />
-            <package pattern="Xamarin.AndroidX.Security.SecurityCrypto" />
+        </packageSource>
+        
+        <!-- Only get explicitly needed packages from nuget.org -->
+        <packageSource key="nuget.org">        
+            <!-- External packages -->
+            <package pattern="Microsoft.Android.Ref.*" />
+            <package pattern="Microsoft.Android.Runtime.*" />
+            <package pattern="Microsoft.Maui.*" />
+            <package pattern="Microsoft.NET.*" />
+            <package pattern="Microsoft.Extensions.*" />
+            
+            <!-- GPS packages -->
+            <package pattern="Xamarin.Android.Glide*" />
+            <package pattern="Xamarin.Google.Code.FindBugs.*" />
+            <package pattern="Xamarin.Google.ErrorProne.*" />
+            <package pattern="Xamarin.GoogleAndroid.*" />
             <package pattern="Xamarin.GoogleAndroid.Libraries.Identity.GoogleId" />
-            <!--
-                9999.0.0 published, but delisted
-            -->
+            <package pattern="Xamarin.GooglePlayServices.*" />
+            
+            <!-- Not part of bindings, grab the published version -->
+            <package pattern="Xamarin.Build.Download" />
+            
+            <!-- Need the 9999.0.0 version from NuGet -->
             <package pattern="Xamarin.Google.Guava.ListenableFuture" />
-            <package pattern="Xamarin.Google.Android.Material" />
+            
+            <!-- Need the unstable version from NuGet -->
+            <package pattern="Xamarin.AndroidX.Security.SecurityCrypto" />
         </packageSource>
     </packageSourceMapping>
+    
     <config>
         <add key="globalPackagesFolder" value="../packages" />
     </config>


### PR DESCRIPTION
In order to ensure we are testing the packages built during CI/local build we need to remove the wildcard from `nuget.org`.

With the `nuget.org` wildcard it means that anything that cannot be found locally will be pulled from published packages.  We will never know if we are accidentally pulling a published package instead of the intended local one.