### PR TITLE
Fix duplicate DataStore.Core.[Android|Jvm] code.

### DIFF
--- a/config.json
+++ b/config.json
@@ -841,7 +841,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore",
         "dependencyOnly": false
       },
@@ -849,7 +849,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-android",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Android",
         "dependencyOnly": false
       },
@@ -857,7 +857,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core",
         "dependencyOnly": false
       },
@@ -865,7 +865,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-android",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Android",
         "dependencyOnly": false
       },
@@ -873,15 +873,17 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-jvm",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Jvm",
-        "dependencyOnly": false
+        "extraDependencies": "androidx.datastore.datastore-core-android",
+        "dependencyOnly": false,
+        "comments": "Empty package we want to redirect to Xamarin.AndroidX.DataStore.Core.Android because it is a superset of this package, causing conflicts."
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO",
         "dependencyOnly": false
       },
@@ -889,7 +891,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio-jvm",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO.Jvm",
         "dependencyOnly": false
       },
@@ -897,7 +899,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences",
         "dependencyOnly": false
       },
@@ -905,7 +907,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-android",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Android",
         "dependencyOnly": false
       },
@@ -913,7 +915,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core",
         "dependencyOnly": false
       },
@@ -921,7 +923,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core-jvm",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core.Jvm",
         "dependencyOnly": false
       },
@@ -929,7 +931,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava2",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava2",
         "dependencyOnly": false
       },
@@ -937,7 +939,7 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava3",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava3",
         "dependencyOnly": false
       },

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -39,7 +39,14 @@
       {
           artifact_version += "-" + artifact_version_parts[1];
       }
+      
+      // Whether to bind the Java .jar/.aar
+      var bind_native_lib = Model.NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm";
+      
+      // Whether to include the Java .jar/.aar
+      var include_native_lib = Model.NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm";
   }
+  
   <PropertyGroup>
     <PackageId>@(Model.NuGetPackageId)</PackageId>
     <Title>.NET for Android (formerly Xamarin.Android) AndroidX - @(Model.Name)</Title>
@@ -54,7 +61,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    @if (include_native_lib) {
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
+    }
     <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
     <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="..\..\icons\Xamarin.AndroidX_nuget.png" Pack="True" PackagePath="icon.png" />
@@ -98,6 +107,10 @@
 
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
+      if (!bind_native_lib) {
+        continue;
+      }
+      
       if (art.MavenArtifactPackaging == "aar") {
     <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar\@(art.MavenGroupId).@(art.MavenArtifactId).aar" />
       } else {
@@ -111,6 +124,10 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts)
     {
+      if (!include_native_lib) {
+        continue;
+      }
+      
       if (art.MavenArtifactPackaging == "aar")
       {
     <InputJar 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/GooglePlayServicesComponents/issues/880

If you try to consume the package `Xamarin.AndroidX.DataStore.Preferences`, you get the following error:

```
JAVA0000: Error in C:\.tools\.nuget\packages\xamarin.androidx.datastore.core.jvm\1.1.1.2\buildTransitive\net8.0-android34.0\..\..\jar\androidx.datastore.datastore-core-jvm.jar:androidx/datastore/core/Actual_jvmKt.class:
JAVA0000: Type androidx.datastore.core.Actual_jvmKt is defined multiple times: 
- C:\.tools\.nuget\packages\xamarin.androidx.datastore.core.jvm\1.1.1.2\buildTransitive\net8.0-android34.0\..\..\jar\androidx.datastore.datastore-core-jvm.jar:androidx/datastore/core/Actual_jvmKt.class, 
- obj\Release\net8.0-android\lp\30\jl\classes.jar:androidx/datastore/core/Actual_jvmKt.class
```

This is because through the complex set of dependencies, you end up using these 2 packages:

- `Xamarin.AndroidX.DataStore.Core.Android`
- `Xamarin.AndroidX.DataStore.Core.Jvm`

These packages contain the same Java code, the `Android` one seems to be a superset of the `Jvm` one:

![image](https://github.com/xamarin/AndroidX/assets/179295/cf40d9e5-bc26-4811-bbb9-793b28e4d83b)

Thus we believe the solution is to redirect the `Jvm` package to the `Android` one.  That is, anytime the `Jvm` package is requested we are going to give it the `Android` one instead.

We will accomplish this via:

- Adding `Xamarin.AndroidX.DataStore.Core.Android` as a dependency of `Xamarin.AndroidX.DataStore.Core.Jvm`.  This means anytime `Jvm` is requested `Android` will also be added.
- Removing the `Jvm` Java library and its bindings from `Xamarin.AndroidX.DataStore.Core.Jvm` so that it will no longer duplicate the bindings and Java library in `Android`.

With these changes, we no longer see the conflict errors when consuming the `Xamarin.AndroidX.DataStore.Preferences*` packages in the `ExtendedTests` suite.

Additionally, bump all the `androidx.datastore` packages so that this new version will get picked up.