### PR TITLE
Convert "all packages" "samples" to proper unit tests.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
   # Variables only used by AndroidX go here
   - name: skipUnitTests
     value: false
+  - name: skipSamplesTests
+    value: true
 
 resources:
   repositories:
@@ -73,9 +75,16 @@ extends:
             vmImage: $(macosImage)
             os: macOS
 
+    - template: build/ci/stage-standard-tests.yml@self
+      parameters:
+        buildPool:
+          name: $(windowsAgentPoolName)
+          image: $(windowsImage)
+          os: windows
+
     - template: build/ci/stage-extended-tests.yml@self
       parameters:
-        stageCondition: and(succeeded(), eq('${{ parameters.RunExtendedTests }}', 'true'))
+        stageCondition: and(succeeded(), ne('$(skipUnitTests)', 'true'), eq('${{ parameters.RunExtendedTests }}', 'true'))
         buildPool:
           name: $(windowsAgentPoolName)
           image: $(windowsImage)

--- a/build/ci/build-and-test.yml
+++ b/build/ci/build-and-test.yml
@@ -43,6 +43,7 @@ steps:
         --configuration="$(configuration)" `
         --verbosity="$(verbosity)"
     displayName: 'Build samples'
+    condition: ne(variables['skipSamplesTests'], 'true')
     env:
       JavaSdkDirectory: $(JAVA_HOME)
       RepositoryCommit: $(Build.SourceVersion)

--- a/build/ci/job-extended-tests.yml
+++ b/build/ci/job-extended-tests.yml
@@ -5,6 +5,8 @@ parameters:
   buildPool:                                      # VM pool information
   agentCount:                                     # Agents to run in parallel
   testFilter:                                     # Test category filter 
+  testProject:                                    # The test .csproj to build
+  testAssembly:                                   # The test .dll to execute
   
   tools:                                          # Additional .NET global tools to install
   - 'dotnet-test-slicer' : '0.1.0-alpha7'
@@ -32,18 +34,18 @@ jobs:
     displayName: Build unit tests
     inputs:
       command: build
-      projects: $(testAssemblyProject)
+      projects: ${{ parameters.testProject }}
       arguments: -c $(configuration)
   
   # Figure out which tests this slice is running
   - pwsh: >-
       dotnet-test-slicer 
       slice
-      --test-assembly="$(testAssembly)"
+      --test-assembly="${{ parameters.testAssembly }}"
       --test-filter="${{ parameters.testFilter }}"
       --slice-number=$(System.JobPositionInPhase)
       --total-slices=$(System.TotalJobsInPhase)
-      --outfile="$(testAssembly).runsettings"
+      --outfile="${{ parameters.testAssembly }}.runsettings"
     displayName: Slice unit tests
     failOnStderr: true      
     
@@ -51,9 +53,9 @@ jobs:
   - task: DotNetCoreCLI@2
     inputs:
       command: test
-      projects: $(testAssembly)
+      projects: ${{ parameters.testAssembly }}
       arguments: >-
-        --settings "$(testAssembly).runsettings"
+        --settings "${{ parameters.testAssembly }}.runsettings"
       publishTestResults: true
       testRunTitle: ${{ parameters.jobName }} Package Tests - $(System.JobPositionInPhase)
     displayName: Run unit tests

--- a/build/ci/stage-extended-tests.yml
+++ b/build/ci/stage-extended-tests.yml
@@ -15,13 +15,18 @@ stages:
   - template: job-extended-tests.yml
     parameters:
       jobName: Android
-      agentCount: 6
+      agentCount: 10
       testFilter: cat = Android
+      testProject: $(extendedTestProject)
+      testAssembly: $(extendedTestAssembly)
       buildPool: ${{ parameters.buildPool }}
   
-  - template: job-extended-tests.yml
-    parameters:
-      jobName: MAUI
-      agentCount: 10
-      testFilter: cat = MAUI
-      buildPool: ${{ parameters.buildPool }}
+# Disabled because of too many failures until MAUI updates its AndroidX packages
+#  - template: job-extended-tests.yml
+#    parameters:
+#      jobName: MAUI
+#      agentCount: 10
+#      testFilter: cat = MAUI
+#      testProject: $(extendedTestProject)
+#      testAssembly: $(extendedTestAssembly)
+#      buildPool: ${{ parameters.buildPool }}

--- a/build/ci/stage-standard-tests.yml
+++ b/build/ci/stage-standard-tests.yml
@@ -1,0 +1,22 @@
+# Runs standard unit test(s)
+
+parameters:
+  buildPool:                                                        # VM pool information
+  stageCondition: and(succeeded(), ne('$(skipUnitTests)', 'true'))  # When to run this stage
+  
+stages:
+- stage: standard_tests
+  displayName: Standard Tests
+  dependsOn: build_windows
+  condition: ${{ parameters.stageCondition }}
+  
+  jobs:
+  
+  - template: job-extended-tests.yml
+    parameters:
+      jobName: Standard
+      agentCount: 1
+      testFilter: cat != dummy
+      testProject: $(standardTestProject)
+      testAssembly: $(standardTestAssembly)
+      buildPool: ${{ parameters.buildPool }}

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -25,6 +25,11 @@ variables:
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'                           # NuGet.org URL to find workloads
   dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'                       # .NET engineering URL to find workloads
 
+  # Standard test variables
+  standardTestProject: tests/allpackages/AllPackagesTests.csproj                              # Standard tests project file
+  standardTestAssembly: tests/allpackages/bin/$(configuration)/net8.0/AllPackagesTests.dll    # Standard tests compiled binary
+
   # Extended test variables
-  testAssemblyProject: tests/extended/ExtendedTests.csproj                              # Extended tests project file
-  testAssembly: tests/extended/bin/$(configuration)/net8.0/ExtendedTests.dll            # Extended tests compiled binary
+  extendedTestProject: tests/extended/ExtendedTests.csproj                              # Extended tests project file
+  extendedTestAssembly: tests/extended/bin/$(configuration)/net8.0/ExtendedTests.dll    # Extended tests compiled binary
+

--- a/tests/allpackages/AllPackagesTests.csproj
+++ b/tests/allpackages/AllPackagesTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(_DefaultNetTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CliWrap" Version="3.6.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/allpackages/AllPackagesTests.sln
+++ b/tests/allpackages/AllPackagesTests.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34902.84
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AllPackagesTests", "AllPackagesTests.csproj", "{CB699113-2DD2-49D2-84F4-F6738E76D10D}"
+EndProject
+Global
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {32519318-4EF6-4DCE-9E70-381F824180F5}
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB699113-2DD2-49D2-84F4-F6738E76D10D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB699113-2DD2-49D2-84F4-F6738E76D10D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB699113-2DD2-49D2-84F4-F6738E76D10D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB699113-2DD2-49D2-84F4-F6738E76D10D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/allpackages/BinderatorConfigFileParser.cs
+++ b/tests/allpackages/BinderatorConfigFileParser.cs
@@ -1,0 +1,195 @@
+#nullable disable
+
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace AllPackagesTests;
+
+public class BinderatorConfigFileParser
+{
+	public static async Task<List<MyArray>> ParseConfigurationFile (string filename)
+	{
+		string json;
+
+		if (filename.StartsWith ("http")) {
+
+			// Configuration file URL
+			using (var client = new HttpClient ())
+				json = await client.GetStringAsync (filename);
+
+		} else {
+
+			// Local configuration file
+			if (string.IsNullOrWhiteSpace (filename) || !File.Exists (filename)) {
+				Console.WriteLine ($"Could not find configuration file: '{filename}'");
+				Environment.Exit (-1);
+			}
+
+			json = File.ReadAllText (filename);
+		}
+
+		return JsonConvert.DeserializeObject<List<MyArray>> (json);
+	}
+
+	static async Task<List<ArtifactModel>> GetExternalDependencies (Options options)
+	{
+		var list = new List<ArtifactModel> ();
+
+		foreach (var file in options.DependencyConfigs) {
+			var config = await ParseConfigurationFile (file);
+
+			list.AddRange (config.SelectMany (arr => arr.Artifacts.Where (a => !a.DependencyOnly)));
+		}
+
+		return list;
+	}
+
+	// Configuration File Model
+	public class Template
+	{
+		[JsonProperty ("templateFile")]
+		public string TemplateFile { get; set; }
+
+		[JsonProperty ("outputFileRule")]
+		public string OutputFileRule { get; set; }
+	}
+
+	public class TemplateSetModel
+	{
+		[JsonProperty ("name")]
+		public string Name { get; set; }
+
+		[JsonProperty ("mavenRepositoryType")]
+		public MavenRepoType? MavenRepositoryType { get; set; }
+
+		[JsonProperty ("mavenRepositoryLocation")]
+		public string MavenRepositoryLocation { get; set; } = null;
+
+		[JsonProperty ("templates")]
+		public List<Template> Templates { get; set; } = new List<Template> ();
+	}
+
+	public class ArtifactModel
+	{
+		[JsonProperty ("groupId")]
+		public string GroupId { get; set; }
+
+		[JsonProperty ("artifactId")]
+		public string ArtifactId { get; set; }
+
+		[JsonProperty ("version")]
+		public string Version { get; set; }
+
+		[JsonProperty ("nugetVersion")]
+		public string NugetVersion { get; set; }
+
+		[JsonProperty ("nugetId")]
+		public string NugetId { get; set; }
+
+		[DefaultValue ("")]
+		[JsonProperty ("dependencyOnly")]
+		public bool DependencyOnly { get; set; }
+
+		[JsonProperty ("frozen")]
+		public bool Frozen { get; set; }
+
+		[JsonProperty ("excludedRuntimeDependencies")]
+		public string ExcludedRuntimeDependencies { get; set; }
+
+		[JsonProperty ("templateSet")]
+		public string TemplateSet { get; set; }
+
+		[JsonProperty ("metadata")]
+		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
+
+		public bool ShouldSerializeMetadata () => Metadata.Any ();
+	}
+
+	public class MyArray
+	{
+		[JsonProperty ("mavenRepositoryType")]
+		public MavenRepoType MavenRepositoryType { get; set; }
+
+		[JsonProperty ("mavenRepositoryLocation")]
+		public string MavenRepositoryLocation { get; set; }
+
+		[JsonProperty ("slnFile")]
+		public string SlnFile { get; set; }
+
+		[JsonProperty ("strictRuntimeDependencies")]
+		public bool StrictRuntimeDependencies { get; set; }
+
+		[JsonProperty ("excludedRuntimeDependencies")]
+		public string ExcludedRuntimeDependencies { get; set; }
+
+		[JsonProperty ("additionalProjects")]
+		public List<string> AdditionalProjects { get; set; }
+
+		[JsonProperty ("templates")]
+		public List<Template> Templates { get; set; }
+
+		[JsonProperty ("artifacts")]
+		public List<ArtifactModel> Artifacts { get; set; }
+
+		[JsonProperty ("templateSets")]
+		public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel> ();
+
+		public TemplateSetModel GetTemplateSet (string name)
+		{
+			// If an artifact doesn't specify a template set, first try using the original
+			// single template list if it exists.  If not, look for a template set called "default".
+			if (string.IsNullOrEmpty (name)) {
+				if (Templates.Any ())
+					return new TemplateSetModel { Templates = Templates };
+
+				name = "default";
+			}
+
+			var set = TemplateSets.FirstOrDefault (s => s.Name == name);
+
+			if (set == null)
+				throw new ArgumentException ($"Could not find requested template set '{name}'");
+
+			return set;
+		}
+	}
+
+	public class Root
+	{
+		[JsonProperty ("MyArray")]
+		public List<MyArray> MyArray { get; set; }
+	}
+
+	public enum MavenRepoType
+	{
+		Url,
+		Directory,
+		Google,
+		MavenCentral
+	}
+
+	public class Options
+	{
+		public string ConfigFile { get; }
+		public bool Update { get; }
+		public bool Bump { get; }
+		public bool Sort { get; }
+		public bool Published { get; }
+		public List<string> DependencyConfigs { get; }
+
+		public Options (IList<string> args)
+		{
+			// Config file must always be the first argument
+			ConfigFile = args [0];
+
+			Update = args.Any (a => a.ToLowerInvariant () == "update");
+			Bump = args.Any (a => a.ToLowerInvariant () == "bump");
+			Sort = args.Any (a => a.ToLowerInvariant () == "sort");
+			Published = args.Any (a => a.ToLowerInvariant () == "published");
+
+			DependencyConfigs = args.Where (a => a.StartsWith ("-dep:")).Select (a => a.Substring (5)).ToList ();
+		}
+
+		public bool ShouldWriteOutput => Update || Bump || Sort;
+	}
+}

--- a/tests/allpackages/CanonicalError.cs
+++ b/tests/allpackages/CanonicalError.cs
@@ -1,0 +1,412 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+#nullable disable
+
+namespace AllPackagesTests
+{
+	/// <summary>
+	/// Functions for dealing with the specially formatted errors returned by
+	/// build tools.
+	/// </summary>
+	/// <remarks>
+	/// Various tools produce and consume CanonicalErrors in various formats.
+	///
+	/// DEVENV Format When Clicking on Items in the Output Window
+	/// (taken from env\msenv\core\findutil.cpp ParseLocation function)
+	///
+	///      v:\dir\file.ext (loc) : msg
+	///      \\server\share\dir\file.ext(loc):msg
+	///      url
+	///
+	///      loc:
+	///      (line)
+	///      (line-line)
+	///      (line,col)
+	///      (line,col-col)
+	///      (line,col,len)
+	///      (line,col,line,col)
+	///
+	/// DevDiv Build Process
+	/// (taken from tools\devdiv2.def)
+	///
+	///      To echo warnings and errors to the build console, the
+	///      "description block" must be recognized by build. To do this,
+	///      add a $(ECHO_COMPILING_COMMAND) or $(ECHO_PROCESSING_COMMAND)
+	///      to the first line of the description block, e.g.
+	///
+	///          $(ECHO_COMPILING_CMD) Resgen_$&lt;
+	///
+	///      Errors must have the format:
+	///
+	///          &lt;text&gt; : error [num]: &lt;msg&gt;
+	///
+	///      Warnings must have the format:
+	///
+	///          &lt;text&gt; : warning [num]: &lt;msg&gt;
+	/// </remarks>
+	internal static class CanonicalError
+	{
+		// Defines the main pattern for matching messages.
+		private static readonly Lazy<Regex> s_originCategoryCodeTextExpression = new Lazy<Regex> (
+		    () => new Regex
+			(
+			// Beginning of line and any amount of whitespace.
+			@"^\s*"
+			// Match a [optional project number prefix 'ddd>'], single letter + colon + remaining filename, or
+			// string with no colon followed by a colon.
+			+ @"(((?<ORIGIN>(((\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)"
+			// Origin may also be empty. In this case there's no trailing colon.
+			+ "|())"
+			// Match the empty string or a string without a colon that ends with a space
+			+ "(?<SUBCATEGORY>(()|([^:]*? )))"
+			// Match 'error' or 'warning'.
+			+ @"(?<CATEGORY>(error|warning))"
+			// Match anything starting with a space that's not a colon/space, followed by a colon.
+			// Error code is optional in which case "error"/"warning" can be followed immediately by a colon.
+			+ @"( \s*(?<CODE>[^: ]*))?\s*:"
+			// Whatever's left on this line, including colons.
+			+ "(?<TEXT>.*)$",
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		private static readonly Lazy<Regex> s_originCategoryCodeTextExpression2 = new Lazy<Regex> (
+	    () => new Regex
+		(
+		@"^\s*(?<ORIGIN>(?<FILENAME>.*):(?<LOCATION>(?<LINE>[0-9]*):(?<COLUMN>[0-9]*))):(?<CATEGORY> error| warning):(?<TEXT>.*)",
+		RegexOptions.IgnoreCase | RegexOptions.Compiled
+	    ));
+
+		// Matches and extracts filename and location from an 'origin' element.
+		private static readonly Lazy<Regex> s_filenameLocationFromOrigin = new Lazy<Regex> (
+		    () => new Regex
+			(
+			"^" // Beginning of line
+			+ @"(\d+>)?" // Optional ddd> project number prefix
+			+ "(?<FILENAME>.*)" // Match anything.
+			+ @"\(" // Find a parenthesis.
+			+ @"(?<LOCATION>[\,,0-9,-]*)" // Match any combination of numbers and ',' and '-'
+			+ @"\)\s*" // Find the closing paren then any amount of spaces.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		// Matches location that is a simple number.
+		private static readonly Lazy<Regex> s_lineFromLocation = new Lazy<Regex> (
+		    () => new Regex // Example: line
+			(
+			"^" // Beginning of line
+			+ "(?<LINE>[0-9]*)" // Match any number.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		// Matches location that is a range of lines.
+		private static readonly Lazy<Regex> s_lineLineFromLocation = new Lazy<Regex> (
+		    () => new Regex // Example: line-line
+			(
+			"^" // Beginning of line
+			+ "(?<LINE>[0-9]*)" // Match any number.
+			+ "-" // Dash
+			+ "(?<ENDLINE>[0-9]*)" // Match any number.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		// Matches location that is a line and column
+		private static readonly Lazy<Regex> s_lineColFromLocation = new Lazy<Regex> (
+		    () => new Regex // Example: line,col
+			(
+			"^" // Beginning of line
+			+ "(?<LINE>[0-9]*)" // Match any number.
+			+ "," // Comma
+			+ "(?<COLUMN>[0-9]*)" // Match any number.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		// Matches location that is a line and column-range
+		private static readonly Lazy<Regex> s_lineColColFromLocation = new Lazy<Regex> (
+		    () => new Regex // Example: line,col-col
+			(
+			"^" // Beginning of line
+			+ "(?<LINE>[0-9]*)" // Match any number.
+			+ "," // Comma
+			+ "(?<COLUMN>[0-9]*)" // Match any number.
+			+ "-" // Dash
+			+ "(?<ENDCOLUMN>[0-9]*)" // Match any number.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		// Matches location that is line,col,line,col
+		private static readonly Lazy<Regex> s_lineColLineColFromLocation = new Lazy<Regex> (
+		    () => new Regex // Example: line,col,line,col
+			(
+			"^" // Beginning of line
+			+ "(?<LINE>[0-9]*)" // Match any number.
+			+ "," // Comma
+			+ "(?<COLUMN>[0-9]*)" // Match any number.
+			+ "," // Dash
+			+ "(?<ENDLINE>[0-9]*)" // Match any number.
+			+ "," // Dash
+			+ "(?<ENDCOLUMN>[0-9]*)" // Match any number.
+			+ "$", // End-of-line
+			RegexOptions.IgnoreCase | RegexOptions.Compiled
+			));
+
+		/// <summary>
+		/// Represents the parts of a decomposed canonical message.
+		/// </summary>
+		internal sealed class Parts
+		{
+			/// <summary>
+			/// Defines the error category\severity level.
+			/// </summary>
+			internal enum Category
+			{
+				Warning,
+				Error
+			}
+
+			/// <summary>
+			/// Value used for unspecified line and column numbers, which are 1-relative.
+			/// </summary>
+			internal const int numberNotSpecified = 0;
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="Parts"/> class.
+			/// </summary>
+			internal Parts ()
+			{
+			}
+
+			/// <summary>
+			/// Name of the file or tool (not localized)
+			/// </summary>
+			internal string origin;
+
+			/// <summary>
+			/// The line number.
+			/// </summary>
+			internal int line = numberNotSpecified;
+
+			/// <summary>
+			/// The column number.
+			/// </summary>
+			internal int column = numberNotSpecified;
+
+			/// <summary>
+			/// The ending line number.
+			/// </summary>
+			internal int endLine = numberNotSpecified;
+
+			/// <summary>
+			/// The ending column number.
+			/// </summary>
+			internal int endColumn = numberNotSpecified;
+
+			/// <summary>
+			/// The category/severity level
+			/// </summary>
+			internal Category category;
+
+			/// <summary>
+			/// The sub category (localized)
+			/// </summary>
+			internal string subcategory;
+
+			/// <summary>
+			/// The error code (not localized)
+			/// </summary>
+			internal string code;
+
+			/// <summary>
+			/// The error message text (localized)
+			/// </summary>
+			internal string text;
+		}
+
+		/// <summary>
+		/// A small custom int conversion method that treats invalid entries as missing (0). This is done to work around tools
+		/// that don't fully conform to the canonical message format - we still want to salvage what we can from the message.
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns>'value' converted to int or 0 if it can't be parsed or is negative</returns>
+		private static int ConvertToIntWithDefault (string value)
+		{
+			int result;
+			var success = int.TryParse (value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+			if (!success || result < 0) {
+				result = Parts.numberNotSpecified;
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// Decompose an error or warning message into constituent parts. If the message isn't in the canonical form, return null.
+		/// </summary>
+		/// <remarks>This method is thread-safe, because the Regex class is thread-safe (per MSDN).</remarks>
+		/// <param name="message"></param>
+		/// <returns>Decomposed canonical message, or null.</returns>
+		internal static Parts Parse (string message)
+		{
+			// An unusually long string causes pathologically slow Regex back-tracking.
+			// To avoid that, only scan the first 400 characters. That's enough for
+			// the longest possible prefix: MAX_PATH, plus a huge subcategory string, and an error location.
+			// After the regex is done, we can append the overflow.
+			var messageOverflow = string.Empty;
+			if (message.Length > 400) {
+				messageOverflow = message.Substring (400);
+				message = message.Substring (0, 400);
+			}
+
+			// If a tool has a large amount of output that isn't an error or warning (eg., "dir /s %hugetree%")
+			// the regex below is slow. It's faster to pre-scan for "warning" and "error"
+			// and bail out if neither are present.
+			if (message.IndexOf ("warning", StringComparison.OrdinalIgnoreCase) == -1 &&
+			    message.IndexOf ("error", StringComparison.OrdinalIgnoreCase) == -1) {
+				return null;
+			}
+
+			var parsedMessage = new Parts ();
+
+			// First, split the message into three parts--Origin, Category, Code, Text.
+			// Example,
+			//      Main.cs(17,20):Command line warning CS0168: The variable 'foo' is declared but never used
+			//      -------------- ------------ ------- ------  ----------------------------------------------
+			//      Origin         SubCategory  Cat.    Code    Text
+			//
+			// To accommodate absolute filenames in Origin, tolerate a colon in the second position
+			// as long as its preceded by a letter.
+			//
+			// Localization Note:
+			//  Even in foreign-language versions of tools, the category field needs to be in English.
+			//  Also, if origin is a tool name, then that needs to be in English.
+			//
+			//  Here's an example from the Japanese version of CL.EXE:
+			//   cl : ???? ??? warning D4024 : ?????????? 'AssemblyInfo.cs' ?????????????????? ???????????
+			//
+			//  Here's an example from the Japanese version of LINK.EXE:
+			//   AssemblyInfo.cpp : fatal error LNK1106: ???????????? ??????????????: 0x6580 ??????????
+			//
+			var match = s_originCategoryCodeTextExpression.Value.Match (message);
+			string category;
+			if (!match.Success) {
+				// try again with the Clang/GCC matcher
+				// Example,
+				//       err.cpp:6:3: error: use of undeclared identifier 'force_an_error'
+				//       -----------  -----  ---------------------------------------------
+				//       Origin       Cat.   Text
+				match = s_originCategoryCodeTextExpression2.Value.Match (message);
+				if (!match.Success) {
+					return null;
+				}
+
+				category = match.Groups ["CATEGORY"].Value.Trim ();
+				if (string.Equals (category, "error", StringComparison.OrdinalIgnoreCase)) {
+					parsedMessage.category = Parts.Category.Error;
+				} else if (string.Equals (category, "warning", StringComparison.OrdinalIgnoreCase)) {
+					parsedMessage.category = Parts.Category.Warning;
+				} else {
+					// Not an error\warning message.
+					return null;
+				}
+				parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+				parsedMessage.column = ConvertToIntWithDefault (match.Groups ["COLUMN"].Value.Trim ());
+				parsedMessage.text = (match.Groups ["TEXT"].Value + messageOverflow).Trim ();
+				parsedMessage.origin = match.Groups ["FILENAME"].Value.Trim ();
+
+				var explodedText = parsedMessage.text.Split ('\'', StringSplitOptions.RemoveEmptyEntries);
+				if (explodedText.Length > 0) {
+					parsedMessage.code = "G" + explodedText [0].GetHashCode ().ToString ("X8");
+				} else {
+					parsedMessage.code = "G00000000";
+				}
+
+				return parsedMessage;
+			}
+
+			var origin = match.Groups ["ORIGIN"].Value.Trim ();
+			category = match.Groups ["CATEGORY"].Value.Trim ();
+			parsedMessage.code = match.Groups ["CODE"].Value.Trim ();
+			parsedMessage.text = (match.Groups ["TEXT"].Value + messageOverflow).Trim ();
+			parsedMessage.subcategory = match.Groups ["SUBCATEGORY"].Value.Trim ();
+
+			// Next, see if category is something that is recognized.
+			if (string.Equals (category, "error", StringComparison.OrdinalIgnoreCase)) {
+				parsedMessage.category = Parts.Category.Error;
+			} else if (string.Equals (category, "warning", StringComparison.OrdinalIgnoreCase)) {
+				parsedMessage.category = Parts.Category.Warning;
+			} else {
+				// Not an error\warning message.
+				return null;
+			}
+
+			// Origin is not a simple file, but it still could be of the form,
+			//  foo.cpp(location)
+			match = s_filenameLocationFromOrigin.Value.Match (origin);
+
+			if (match.Success) {
+				// The origin is in the form,
+				//  foo.cpp(location)
+				// Assume the filename exists, but don't verify it. What else could it be?
+				var location = match.Groups ["LOCATION"].Value.Trim ();
+				parsedMessage.origin = match.Groups ["FILENAME"].Value.Trim ();
+
+				// Now, take apart the location. It can be one of these:
+				//      loc:
+				//      (line)
+				//      (line-line)
+				//      (line,col)
+				//      (line,col-col)
+				//      (line,col,len)
+				//      (line,col,line,col)
+				if (location.Length > 0) {
+					match = s_lineFromLocation.Value.Match (location);
+					if (match.Success) {
+						parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+					} else {
+						match = s_lineLineFromLocation.Value.Match (location);
+						if (match.Success) {
+							parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+							parsedMessage.endLine = ConvertToIntWithDefault (match.Groups ["ENDLINE"].Value.Trim ());
+						} else {
+							match = s_lineColFromLocation.Value.Match (location);
+							if (match.Success) {
+								parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+								parsedMessage.column = ConvertToIntWithDefault (match.Groups ["COLUMN"].Value.Trim ());
+							} else {
+								match = s_lineColColFromLocation.Value.Match (location);
+								if (match.Success) {
+									parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+									parsedMessage.column = ConvertToIntWithDefault (match.Groups ["COLUMN"].Value.Trim ());
+									parsedMessage.endColumn = ConvertToIntWithDefault (match.Groups ["ENDCOLUMN"].Value.Trim ());
+								} else {
+									match = s_lineColLineColFromLocation.Value.Match (location);
+									if (match.Success) {
+										parsedMessage.line = ConvertToIntWithDefault (match.Groups ["LINE"].Value.Trim ());
+										parsedMessage.column = ConvertToIntWithDefault (match.Groups ["COLUMN"].Value.Trim ());
+										parsedMessage.endLine = ConvertToIntWithDefault (match.Groups ["ENDLINE"].Value.Trim ());
+										parsedMessage.endColumn = ConvertToIntWithDefault (match.Groups ["ENDCOLUMN"].Value.Trim ());
+									}
+								}
+							}
+						}
+					}
+				}
+			} else {
+				// The origin does not fit the filename(location) pattern.
+				parsedMessage.origin = origin;
+			}
+
+			return parsedMessage;
+		}
+	}
+}


### PR DESCRIPTION
Convert our existing `BuildAllDotNet`/`BuildAllMauiApp` samples to NUnit based unit tests.  These tests use `dotnet new android|maui` instead of committed projects so that we always ensure we are testing against the current templates that our users will be using.

Additionally, move these tests to another stage, so they can run in parallel with other [test suite(s)](https://github.com/xamarin/AndroidX/pull/892).

This PR does not remove the existing `BuildAll*` samples, those will be removed in a future PR.