### PR TITLE
﻿Move functionality from `update-config.csx` to `binderator`.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,6 +117,22 @@ dotnet cake -t=clean && dotnet cake -t=ci && dotnet cake nuget-diff.cake && dotn
 *   `ci`
 
     Builds projects on CI (`libs`, `nuget`, `samples`).
+    
+*   `update-config`
+
+    Updates config.json to the latest versions found in Maven.
+    
+*   `bump-config`
+
+    Increments the NuGet patch version of all packages in config.json.
+    
+*   `sort-config`
+
+    Sorts config.json file using the canonical sort.
+    
+*   `published-config`
+
+    Shows which NuGet package versions in config.json have been published to NuGet.org.
 
 #### Nuget API diff (`nuget-diff.cake`)
 

--- a/build.cake
+++ b/build.cake
@@ -14,6 +14,8 @@
 // #addin nuget:?package=NuGet.Versioning&loaddependencies=true&version=5.6.0
 // #addin nuget:?package=Microsoft.Extensions.Logging&loaddependencies=true&version=3.0.0
 
+#load "build/cake/update-config.cake"
+
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;

--- a/build/cake/update-config.cake
+++ b/build/cake/update-config.cake
@@ -1,0 +1,54 @@
+// Contains tasks for updating/modifying the config.json used by binderator
+
+var binderator_project = "util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj";
+var gps_config = "https://raw.githubusercontent.com/xamarin/GooglePlayServicesComponents/main/config.json";
+
+// Updates config.json to the latest versions found in Maven
+Task ("update-config")
+    .Does (() =>
+{
+    var args = new ProcessArgumentBuilder ()
+        .Append ("update")
+        .Append ("--config-file")
+        .Append ("config.json")
+        .Append ("--dependency-file")
+        .Append (gps_config);
+    
+    DotNetRun (binderator_project, args);
+});
+
+// Increments the NuGet patch version of all packages in config.json
+Task ("bump-config")
+    .Does (() =>
+{
+    var args = new ProcessArgumentBuilder ()
+        .Append ("bump")
+        .Append ("--config-file")
+        .Append ("config.json");
+    
+    DotNetRun (binderator_project, args);
+});
+
+// Sorts config.json file using the canonical sort
+Task ("sort-config")
+    .Does (() =>
+{
+    var args = new ProcessArgumentBuilder ()
+        .Append ("sort")
+        .Append ("--config-file")
+        .Append ("config.json");
+    
+    DotNetRun (binderator_project, args);
+});
+
+// Shows which NuGet package versions in config.json have been published to NuGet.org
+Task ("published-config")
+    .Does (() =>
+{
+    var args = new ProcessArgumentBuilder ()
+        .Append ("published")
+        .Append ("--config-file")
+        .Append ("config.json");
+    
+    DotNetRun (binderator_project, args);
+});

--- a/util/Directory.Build.props
+++ b/util/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- This Directory.Build.props is to prevent the one in the root from being used,
+  which is tuned for building bindings packages. -->
+</Project>

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
@@ -524,14 +524,14 @@ namespace Xamarin.AndroidBinderator.Tests
 </Project>");
 		}
 
-		public async Task ProcessAndAssertTemplate(string input, BindingConfig config, string output, Dictionary<string, string> metadata = null)
+		async Task ProcessAndAssertTemplate(string input, BindingConfig config, string output, Dictionary<string, string> metadata = null)
 		{
 			var generated = Path.Combine(RootDirectory, "generated");
 			var outputFile = Path.Combine(generated, "Generated.csproj");
 			var templateFile = CreateTemplate(input);
 
 			config.BasePath = RootDirectory;
-			config.Templates.Add(new TemplateConfig(templateFile, outputFile) { Metadata = metadata });
+			config.Templates.Add(new TemplateConfig(templateFile, outputFile) { Metadata = metadata ?? [] });
 
 			await Engine.BinderateAsync(config);
 

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Nullable>disable</Nullable>

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BinderateCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BinderateCommand.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using AndroidBinderator;
+using Newtonsoft.Json;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+static class BinderateCommand
+{
+	public static Command Build ()
+	{
+		var binderate_command = new Command ("binderate", "Run the binderator process.");
+
+		var config_file_option = new Option<string []> (["--config-file", "-c", "-config="], "JSON config file(s)") { AllowMultipleArgumentsPerToken = true, IsRequired = true };
+		var base_dir_option = new Option<string?> (["--base-path", "-b", "-basepath="], "Default base path");
+
+		binderate_command.Add (config_file_option);
+		binderate_command.Add (base_dir_option);
+
+		binderate_command.SetHandler (
+			RunBinderateVerb,
+			config_file_option, base_dir_option
+		);
+
+		return binderate_command;
+	}
+
+	public static async Task RunBinderateVerb (string [] configFiles, string? basePath)
+	{
+		Console.WriteLine ("Arguments:");
+
+		foreach (var c in configFiles)
+			Console.WriteLine ($"- Config File: {c}");
+		Console.WriteLine ($"- Default Base Path: {basePath}");
+		Console.WriteLine ();
+
+		basePath ??= "AppDomain.CurrentDomain.BaseDirectory";
+
+		try {
+			foreach (var config in configFiles) {
+				var cfgs = JsonConvert.DeserializeObject<List<BindingConfig>> (File.ReadAllText (config));
+
+				foreach (var c in cfgs ?? []) {
+					if (string.IsNullOrEmpty (c.BasePath))
+						c.BasePath = basePath;
+
+					await Engine.BinderateAsync (c);
+				}
+			}
+		} catch (AggregateException exc_a) {
+			var sb = new StringBuilder ();
+
+			sb.AppendLine ();
+			sb.AppendLine ($"Dependency errors : {exc_a.InnerExceptions.Count}");
+
+			var i = 1;
+
+			foreach (var exc in exc_a.InnerExceptions) {
+				sb.AppendLine ($"{i}");
+				sb.AppendLine ($"	{exc.ToString ()}");
+				i++;
+			}
+
+			Trace.WriteLine (sb.ToString ());
+		}
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
@@ -1,0 +1,58 @@
+using System.CommandLine;
+using System.Linq;
+using System.Threading.Tasks;
+using AndroidBinderator;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+static class BumpCommand
+{
+	public static Command Build ()
+	{
+		var update_command = new Command ("bump", "Increments the NuGet patch version of all packages in a config.json file.");
+
+		var config_file_option = new Option<string> (["--config-file", "-c", "-config="], "JSON config file") { IsRequired = true };
+
+		update_command.Add (config_file_option);
+
+		update_command.SetHandler (
+			RunBumpCommand,
+			config_file_option
+		);
+
+		return update_command;
+	}
+
+	static async Task RunBumpCommand (string configFile)
+	{
+		var config = await BindingConfig.Load (configFile);
+
+		foreach (var art in config.MavenArtifacts) {
+			var version = "";
+			var release = "";
+			var revision = 0;
+
+			var str = art.NugetVersion ?? string.Empty;
+
+			if (str.Contains ('-')) {
+				release = str.Substring (str.IndexOf ('-'));
+				str = str.Substring (0, str.LastIndexOf ('-'));
+			}
+
+			var period_count = str.Count (c => c == '.');
+
+			if (period_count == 2) {
+				version = str;
+				revision = 1;
+			} else if (period_count == 3) {
+				version = str.Substring (0, str.LastIndexOf ('.'));
+				revision = int.Parse (str.Substring (str.LastIndexOf ('.') + 1));
+				revision++;
+			}
+
+			art.NugetVersion = $"{version}.{revision}{release}";
+		}
+
+		config.Save (configFile);
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/LegacyCommandLine.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/LegacyCommandLine.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mono.Options;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+class LegacyCommandLine
+{
+	public static async Task Run (string [] args)
+	{
+		var configs = new List<string> ();
+		string? basePath = null;
+		var shouldShowHelp = false;
+
+		// thses are the available options, not that they set the variables
+		var options = new OptionSet {
+			{ "c|config=", "JSON Config File.", configs.Add },
+			{ "b|basepath=", "Default Base Path.", (string b) => basePath= b },
+			{ "h|help", "show this message and exit", h => shouldShowHelp = h != null },
+		};
+
+		List<string> extra;
+
+		try {
+			// parse the command line
+			extra = options.Parse (args);
+		} catch (OptionException e) {
+			// output some error message
+			Console.Write ("android-binderator: ");
+			Console.WriteLine (e.Message);
+			Console.WriteLine ("Try `android-binderator --help' for more information.");
+			return;
+		}
+
+		if (shouldShowHelp) {
+			options.WriteOptionDescriptions (Console.Out);
+			return;
+		}
+
+		await BinderateCommand.RunBinderateVerb (configs.ToArray (), basePath);
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/PublishedCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/PublishedCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.CommandLine;
+using System.Linq;
+using System.Threading.Tasks;
+using AndroidBinderator;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+static class PublishedCommand
+{
+	public static Command Build ()
+	{
+		var update_command = new Command ("published", "Shows which NuGet package versions in a config.json have been published to NuGet.org.");
+
+		var config_file_option = new Option<string> (["--config-file", "-c", "-config="], "JSON config file") { IsRequired = true };
+
+		update_command.Add (config_file_option);
+
+		update_command.SetHandler (
+			RunPublishedCommand,
+			config_file_option
+		);
+
+		return update_command;
+	}
+
+	static async Task RunPublishedCommand (string configFile)
+	{
+		var config = await BindingConfig.Load (configFile);
+
+		var column1 = "Package".PadRight (58);
+		var column2 = "Version".PadRight (17);
+		var column3 = "Status".PadRight (15);
+
+		Console.WriteLine ($"| {column1} | {column2} | {column3} |");
+		Console.WriteLine ("|------------------------------------------------------------|-------------------|-----------------|");
+
+		foreach (var art in config.MavenArtifacts.Where (a => !a.DependencyOnly)) {
+			if (art.NugetPackageId is null || art.NugetVersion is null)
+				continue;
+
+			var status = (await ConfigUpdater.DoesNuGetPackageAlreadyExist (art.NugetPackageId, art.NugetVersion)) ? "Published" : "Not Published";
+			Console.WriteLine ($"| {art.NugetPackageId.PadRight (58)} | {art.NugetVersion.PadRight (17)} | {status.PadRight (15)} |");
+		}
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/SortCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/SortCommand.cs
@@ -1,0 +1,32 @@
+using System.CommandLine;
+using System.Threading.Tasks;
+using AndroidBinderator;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+static class SortCommand
+{
+	public static Command Build ()
+	{
+		var update_command = new Command ("sort", "Sorts a config.json file using the canonical sort.");
+
+		var config_file_option = new Option<string> (["--config-file", "-c", "-config="], "JSON config file") { IsRequired = true };
+
+		update_command.Add (config_file_option);
+
+		update_command.SetHandler (
+			RunSortCommand,
+			config_file_option
+		);
+
+		return update_command;
+	}
+
+	static async Task RunSortCommand (string configFile)
+	{
+		// BindingConfig.Load automatically sorts the file, so we just need to write the file back to disk
+		var config = await BindingConfig.Load (configFile);
+
+		config.Save (configFile);
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/UpdateCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/UpdateCommand.cs
@@ -1,0 +1,89 @@
+using System;
+using System.CommandLine;
+using System.Linq;
+using System.Threading.Tasks;
+using AndroidBinderator;
+
+namespace Xamarin.AndroidBinderator.Tool;
+
+static class UpdateCommand
+{
+	public static Command Build ()
+	{
+		var update_command = new Command ("update", "Updates a config.json to the latest versions found in Maven.");
+
+		var config_file_option = new Option<string> (["--config-file", "-c", "-config="], "JSON config file") { IsRequired = true };
+		var dependency_file_option = new Option<string []> (["--dependency-file", "-d"], "Dependency JSON config file") { AllowMultipleArgumentsPerToken = true };
+
+		update_command.Add (config_file_option);
+		update_command.Add (dependency_file_option);
+
+		update_command.SetHandler (
+			RunUpdateCommand,
+			config_file_option,
+			dependency_file_option
+		);
+
+		return update_command;
+	}
+
+	static async Task RunUpdateCommand (string configFile, string [] dependencyFiles)
+	{
+		var config = await BindingConfig.Load (configFile);
+
+		await ConfigUpdater.Update (config, dependencyFiles.ToList ());
+
+		OutputArtifactTable (config);
+		Console.WriteLine ();
+		OutputDependencyTable (config);
+
+		// Write updated values back to original locations so they get serialized
+		foreach (var a in config.MavenArtifacts) {
+			a.Version = a.LatestVersion;
+			a.NugetVersion = a.LatestNuGetVersion;
+		}
+
+		config.Save (configFile);
+	}
+
+	static void OutputArtifactTable (BindingConfig config)
+	{
+		var column1 = "Package (* = Has Update)".PadRight (58);
+		var column2 = "Currently Bound".PadRight (17);
+		var column3 = "Latest Stable".PadRight (15);
+
+		Console.WriteLine ($"| {column1} | {column2} | {column3} |");
+		Console.WriteLine ("|------------------------------------------------------------|-------------------|-----------------|");
+
+		foreach (var art in config.MavenArtifacts.Where (a => !a.DependencyOnly)) {
+			var package_name = $"{art.GroupId}.{art.ArtifactId}";
+
+			if (art.NewVersionAvailable)
+				package_name = "* " + package_name;
+
+			if (art.Frozen)
+				package_name = "# " + package_name;
+
+			Console.WriteLine ($"| {package_name.PadRight (58)} | {art.Version.PadRight (17)} | {art.LatestVersion.PadRight (15)} |");
+		}
+	}
+
+	static void OutputDependencyTable (BindingConfig config)
+	{
+		var column1 = "Dependencies (* = Has Update)".PadRight (58);
+		var column2 = "Current Reference".PadRight (17);
+		var column3 = "Latest Publish".PadRight (15);
+
+		Console.WriteLine ($"| {column1} | {column2} | {column3} |");
+		Console.WriteLine ("|------------------------------------------------------------|-------------------|-----------------|");
+
+		foreach (var art in config.MavenArtifacts.Where (a => a.DependencyOnly)) {
+			var package_name = art.NugetPackageId ?? $"{art.GroupId}.{art.ArtifactId}";
+
+			if (art.NewNuGetVersionAvailable)
+				package_name = "* " + package_name;
+
+			Console.WriteLine ($"| {package_name.PadRight (58)} | {art.NugetVersion.OrEmpty ().PadRight (17)} | {art.LatestNuGetVersion.PadRight (15)} |");
+		}
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Program.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Program.cs
@@ -1,88 +1,31 @@
-﻿using AndroidBinderator;
-using Mono.Options;
 using System;
-using System.Collections.Generic;
+using System.CommandLine;
 using System.Diagnostics;
-using System.IO;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 
-namespace Xamarin.AndroidBinderator.Tool
+namespace Xamarin.AndroidBinderator.Tool;
+
+class Program
 {
-    class Program
-    {
-        public static async Task Main(string[] args)
-        {
-            Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
+	static async Task Main (params string [] args)
+	{
+		Trace.Listeners.Add (new TextWriterTraceListener (Console.Out));
 
-            var configs = new List<string>();
-            var basePath = string.Empty;
-            var shouldShowHelp = false;
+		var root_command = new RootCommand ("Utilities for working with Android binding libraries.");
 
-            // thses are the available options, not that they set the variables
-            var options = new OptionSet {
-                { "c|config=", "JSON Config File.", n => configs.Add (n) },
-                { "b|basepath=", "Default Base Path.", (string b) => basePath= b },
-                { "h|help", "show this message and exit", h => shouldShowHelp = h != null },
-            };
+		root_command.AddCommand (BinderateCommand.Build ());
+		root_command.AddCommand (UpdateCommand.Build ());
+		root_command.AddCommand (BumpCommand.Build ());
+		root_command.AddCommand (SortCommand.Build ());
+		root_command.AddCommand (PublishedCommand.Build ());
 
-            List<string> extra;
-            try
-            {
-                // parse the command line
-                extra = options.Parse(args);
-            }
-            catch (OptionException e)
-            {
-                // output some error message
-                System.Console.Write("android-binderator: ");
-                System.Console.WriteLine(e.Message);
-                System.Console.WriteLine("Try `android-binderator --help' for more information.");
-                return;
-            }
+		// If not using new command verbs, fallback to old legacy command line handling
+		if (args.Any () && !root_command.Subcommands.Select (c => c.Name).Any (c => c == args [0])) {
+			await LegacyCommandLine.Run (args);
+			return;
+		}
 
-            if (shouldShowHelp)
-            {
-                options.WriteOptionDescriptions(System.Console.Out);
-                return;
-            }
-
-            try
-            {
-                foreach (var config in configs)
-                {
-                    var cfgs = Newtonsoft.Json.JsonConvert.DeserializeObject<List<BindingConfig>>(File.ReadAllText(config));
-
-                    foreach (var c in cfgs)
-                    {
-
-                        if (string.IsNullOrEmpty(c.BasePath))
-                        {
-                            if (!string.IsNullOrEmpty(basePath))
-                                c.BasePath = basePath;
-                            else
-                                c.BasePath = AppDomain.CurrentDomain.BaseDirectory;
-                        }
-
-                        await Engine.BinderateAsync(c);
-                    }
-                }
-            }
-            catch (AggregateException exc_a)
-            {
-                StringBuilder sb = new StringBuilder();
-                sb.AppendLine("");
-                sb.AppendLine($"Dependency errors : {exc_a.InnerExceptions.Count}");
-
-                int i = 1;
-                foreach (Exception exc in exc_a.InnerExceptions)
-                {
-                    sb.AppendLine($"{i}");
-                    sb.AppendLine($"	{exc.ToString()}");
-                    i++;
-                }
-                Trace.WriteLine(sb.ToString());
-            }
-        }
-    }
+		await root_command.InvokeAsync (args);
+	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -1,15 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ToolCommandName>xamarin-android-binderator</ToolCommandName>
     <AssemblyName>Xamarin.AndroidBinderator.Tool</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <RollForward>Major</RollForward>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -18,7 +19,7 @@
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>
-    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2100608</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -28,9 +29,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-  </ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+ </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator.csproj" />

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -1,77 +1,96 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace AndroidBinderator
 {
 	public class BindingConfig
 	{
-		[JsonProperty("basePath")]
-		public string BasePath { get; set; } = null;
+		static HttpClient? client;
 
-		[JsonProperty("downloadExternalsWithFullName")]
-		public bool DownloadExternalsWithFullName { get; set; } = false;
+		[JsonProperty("basePath")]
+		public string? BasePath { get; set; }
 
 		[JsonProperty("mavenRepositoryType")]
 		public MavenRepoType MavenRepositoryType { get; set; } = MavenRepoType.Google;
 
 		[JsonProperty("mavenRepositoryLocation")]
-		public string MavenRepositoryLocation { get; set; } = null;
+		public string? MavenRepositoryLocation { get; set; }
 
-		[JsonProperty("generatedDir")]
+		[JsonProperty("slnFile")]
+		public string? SolutionFile { get; set; }
+
+		/// True to consider 'Runtime' dependencies from a POM file, False to ignore them.
+		[JsonProperty ("strictRuntimeDependencies")]
+		public bool StrictRuntimeDependencies { get; set; }
+
+		[JsonProperty ("excludedRuntimeDependencies")]
+		public string? ExcludedRuntimeDependencies { get; set; }
+
+		[JsonProperty ("additionalProjects")]
+		public List<string> AdditionalProjects { get; set; } = new List<string> ();
+
+		[JsonProperty ("downloadExternalsWithFullName")]
+		public bool DownloadExternalsWithFullName { get; set; } = false;
+
+		[DefaultValue ("generated")]
+		[JsonProperty ("generatedDir")]
 		public string GeneratedDir { get; set; } = "generated";
 
-		[JsonProperty("downloadExternals")]
+		[DefaultValue (true)]
+		[JsonProperty ("downloadExternals")]
 		public bool DownloadExternals { get; set; } = true;
 
-		[JsonProperty("downloadJavaSourceJars")]
+		[DefaultValue (true)]
+		[JsonProperty ("downloadJavaSourceJars")]
 		public bool DownloadJavaSourceJars { get; set; } = true;
 
-		[JsonProperty("downloadJavaDocJars")]
+		[DefaultValue (true)]
+		[JsonProperty ("downloadJavaDocJars")]
 		public bool DownloadJavaDocJars { get; set; } = true;
 
-		[JsonProperty("downloadMetadataFiles")]
+		[DefaultValue (true)]
+		[JsonProperty ("downloadMetadataFiles")]
 		public bool DownloadMetadataFiles { get; set; } = true;
 
+		[DefaultValue(true)]
 		[JsonProperty("downloadPoms")]
 		public bool DownloadPoms { get; set; } = true;
 
-		[JsonProperty("externalsDir")]
+		[DefaultValue ("externals")]
+		[JsonProperty ("externalsDir")]
 		public string ExternalsDir { get; set; } = "externals";
 
-		[JsonProperty("templates")]
-		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig>();
-
 		[JsonProperty("nugetVersionSuffix")]
-		public string NugetVersionSuffix { get; set; } = null;
+		public string? NugetVersionSuffix { get; set; }
 
-		[JsonProperty("slnFile")]
-		public string SolutionFile { get; set; } = null;
-
-		[JsonProperty("artifacts")]
-		public List<MavenArtifactConfig> MavenArtifacts { get; set; } = new List<MavenArtifactConfig>();
+		public bool ShouldSerializeDebug () => false;
 
 		[JsonProperty("debug")]
 		public BindingConfigDebug Debug { get; set; } = new BindingConfigDebug();
 
-		[JsonProperty("additionalProjects")]
-		public List<string> AdditionalProjects { get; set; } = new List<string>();
+		[JsonProperty("templates")]
+		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig>();
 
-		/// True to consider 'Runtime' dependencies from a POM file, False to ignore them.
-		[JsonProperty("strictRuntimeDependencies")]
-		public bool StrictRuntimeDependencies { get; set; }
+		[JsonProperty("artifacts")]
+		public List<MavenArtifactConfig> MavenArtifacts { get; set; } = new List<MavenArtifactConfig>();
 
-		[JsonProperty("excludedRuntimeDependencies")]
-		public string ExcludedRuntimeDependencies { get; set; }
+		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
 
-		[JsonProperty("metadata")]
+		[JsonProperty ("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 
 		[JsonProperty("templateSets")]
 		public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel>();
 
-		public TemplateSetModel GetTemplateSet(string name)
+		public TemplateSetModel GetTemplateSet(string? name)
 		{
 			// If an artifact doesn't specify a template set, first try using the original
 			// single template list if it exists.  If not, look for a template set called "default".
@@ -88,6 +107,44 @@ namespace AndroidBinderator
 				throw new ArgumentException($"Could not find requested template set '{name}'");
 
 			return set;
+		}
+
+		/// <summary>
+		/// Load a config.json file from disk or a URL
+		/// </summary>
+		public static async Task<BindingConfig> Load (string path)
+		{
+			string? json;
+
+			if (path.StartsWith ("http")) {
+				// Remote configuration file URL
+				client ??= new HttpClient();
+				json = await client.GetStringAsync (path);
+			} else {
+				json = File.ReadAllText (path);
+			}
+
+			var config_list = JsonConvert.DeserializeObject<List<BindingConfig>> (json) ?? throw new InvalidOperationException ("Could not deserialize config file");
+			var config = config_list.First ();
+
+			// Keep file sorted by:
+			// - Is dependency only
+			// - groupid
+			// - artifactid
+			config.MavenArtifacts.Sort ((MavenArtifactConfig a, MavenArtifactConfig b) => string.Compare ($"{a.DependencyOnly}-{a.GroupId} {a.ArtifactId}", $"{b.DependencyOnly}-{b.GroupId} {b.ArtifactId}"));
+
+			return config;
+		}
+
+		public void Save (string path)
+		{
+			var serializer_settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
+			serializer_settings.Converters.Add (new Newtonsoft.Json.Converters.StringEnumConverter ());
+
+			// Write updated config.json back to disk
+			List<BindingConfig> config = [this];
+			var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
+			File.WriteAllText (path, output + Environment.NewLine);
 		}
 	}
 

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.ComponentModel;
 using Newtonsoft.Json;
 
 namespace AndroidBinderator
@@ -9,7 +10,7 @@ namespace AndroidBinderator
 		{
 		}
 
-		public MavenArtifactConfig(string groupId, string artifactId, string version, string nugetPackageId = null, string nugetVersion = null)
+		public MavenArtifactConfig(string groupId, string artifactId, string version, string? nugetPackageId = null, string? nugetVersion = null)
 		{
 			GroupId = groupId;
 			ArtifactId = artifactId;
@@ -19,43 +20,67 @@ namespace AndroidBinderator
 		}
 
 		[JsonProperty("groupId")]
-		public string GroupId { get; set; }
+		public string? GroupId { get; set; }
 
 		[JsonProperty("artifactId")]
-		public string ArtifactId { get; set; }
+		public string? ArtifactId { get; set; }
 
-		[JsonProperty("version")]
-		public string Version { get; set; }
+		[JsonProperty ("version")]
+		public string Version { get; set; } = string.Empty;
 
-		string nugetVersion = null;
+		string? nugetVersion = null;
 
 		[JsonProperty("nugetVersion")]
-		public string NugetVersion {
+		public string? NugetVersion {
 			get { return nugetVersion ?? Version; }
 			set { nugetVersion = value; }
 		}
 
 		[JsonProperty("nugetId")]
-		public string NugetPackageId { get; set; }
+		public string? NugetPackageId { get; set; }
 
-		[JsonProperty("dependencyOnly")]
+		[DefaultValue ("")]
+		[JsonProperty ("dependencyOnly")]
 		public bool DependencyOnly { get; set; } = false;
 
-		[JsonProperty("assemblyName")]
-		public string AssemblyName { get; set; } = null;
+		[JsonProperty ("frozen")]
+		public bool Frozen { get; set; }
+
+		[JsonProperty ("assemblyName")]
+		public string? AssemblyName { get; set; }
+
+		[JsonProperty("excludedRuntimeDependencies")]
+		public string? ExcludedRuntimeDependencies { get; set; }
+
+		[JsonProperty("extraDependencies")]
+		public string? ExtraDependencies { get; set; }
+
+		[JsonProperty("templateSet")]
+		public string? TemplateSet { get; set; }
+
+		[JsonProperty ("comments")]
+		public string? Comments { get; set; }
+
+		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
 
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 
-		[JsonProperty("excludedRuntimeDependencies")]
-		public string ExcludedRuntimeDependencies { get; set; }
+		// The latest version available in Maven
+		[JsonIgnore]
+		public string LatestVersion { get; set; } = string.Empty;
 
-		[JsonProperty("extraDependencies")]
-		public string ExtraDependencies { get; set; }
+		// NuGet version to match Maven LatestVersion
+		[JsonIgnore]
+		public string LatestNuGetVersion { get; set; } = string.Empty;
 
-		[JsonProperty("templateSet")]
-		public string TemplateSet { get; set; }
-
+		[JsonIgnore]
 		public string GroupAndArtifactId => $"{GroupId}.{ArtifactId}";
+
+		[JsonIgnore]
+		public bool NewVersionAvailable => LatestVersion != Version;
+
+		[JsonIgnore]
+		public bool NewNuGetVersionAvailable => LatestNuGetVersion != NugetVersion;
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/TemplateConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/TemplateConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -18,13 +18,15 @@ namespace AndroidBinderator
 		}
 
 		[JsonProperty("templateFile")]
-		public string TemplateFile { get; set; }
+		public string TemplateFile { get; set; } = string.Empty;
 
 		[JsonProperty("outputFileRule")]
-		public string OutputFileRule { get; set; }
+		public string OutputFileRule { get; set; } = string.Empty;
 
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
 
 		public string GetOutputFile(BindingConfig config, BindingProjectModel model)
 		{
@@ -35,7 +37,7 @@ namespace AndroidBinderator
 					 .Replace("{name}", model.Name)
 					 .Replace("{nugetid}", model.NuGetPackageId);
 
-			return System.IO.Path.Combine(config.BasePath, p);
+			return System.IO.Path.Combine(config.BasePath!, p);
 		}
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/ConfigUpdater.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/ConfigUpdater.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MavenNet.Models;
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+
+namespace AndroidBinderator;
+
+public class ConfigUpdater
+{
+	static HttpClient? client;
+
+	public static async Task Update (BindingConfig config, List<string> dependencyConfigs)
+	{
+		await MavenFactory.Initialize (config);
+
+		// Check for artifact updates
+		foreach (var art in config.MavenArtifacts.Where (a => !a.DependencyOnly)) {
+			art.LatestVersion = art.Version;
+			art.LatestNuGetVersion = art.NugetVersion ?? string.Empty;
+
+			var a = FindMavenArtifact (config, art);
+
+			if (a is null)
+				continue;
+
+			if (HasUpdate (art, a)) {
+				var new_version = GetLatestVersion (a)?.ToString ();
+				var prefix = art.NugetVersion?.StartsWith ("1" + art.Version + ".") == true ? "1" : string.Empty;
+
+				art.LatestVersion = new_version ?? string.Empty;
+				art.LatestNuGetVersion = prefix + new_version;
+			}
+		}
+
+		// Check for artifact dependency updates
+		var dependencies = await GetExternalDependencies (dependencyConfigs);
+
+		foreach (var art in config.MavenArtifacts.Where (a => a.DependencyOnly)) {
+			art.LatestVersion = art.Version;
+			art.LatestNuGetVersion = art.NugetVersion ?? string.Empty;
+
+			var dep = dependencies.FirstOrDefault (d => d.NugetPackageId == art.NugetPackageId);
+
+			if (dep is null)
+				continue;
+
+			// We need to ensure the NuGet dependency has actually been published
+			if (dep.NugetPackageId is not null && dep.NugetVersion is not null && await DoesNuGetPackageAlreadyExist (dep.NugetPackageId, dep.NugetVersion)) {
+				art.LatestVersion = dep.Version;
+				art.LatestNuGetVersion = dep.NugetVersion;
+			}
+		}
+	}
+
+	static Artifact? FindMavenArtifact (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		var repo = MavenFactory.GetMavenRepository (config, artifact);
+		var group = repo.Groups.FirstOrDefault (g => artifact.GroupId == g.Id);
+
+		return group?.Artifacts?.FirstOrDefault (a => artifact.ArtifactId == a.Id);
+	}
+
+	static bool HasUpdate (MavenArtifactConfig model, Artifact artifact)
+	{
+		// Don't update package if it's "Frozen"
+		if (model.Frozen)
+			return false;
+
+		// Get latest stable version
+		var latest = GetLatestVersion (artifact);
+
+		// No stable version
+		if (latest is null)
+			return false;
+
+		// Already on latest
+		var current = GetVersion (model.Version);
+
+		if (latest <= current)
+			return false;
+
+		return true;
+	}
+
+	static SemanticVersion? GetLatestVersion (Artifact artifact, bool includePrerelease = false)
+	{
+		var versions = artifact.Versions.Select (v => GetVersion (v));
+
+		// Handle 'com.google.guava.guava' which ships its release packages looking like prerelease, ex: '33.1.0-android'
+		if (!includePrerelease)
+			versions = versions.Where (v => !v.IsPrerelease || v.Release == "android");
+
+		if (!versions.Any ())
+			return null;
+
+		return versions.Max ();
+	}
+
+	static SemanticVersion GetVersion (string s)
+	{
+		var hyphen = s.IndexOf ('-');
+		var version = hyphen >= 0 ? s.Substring (0, hyphen) : s;
+		var tag = hyphen >= 0 ? s.Substring (hyphen) : string.Empty;
+
+		// Stuff like: 1.1.1d-alpha-1
+		if (version.Any (c => char.IsLetter (c)))
+			return new SemanticVersion (0, 0, 0);
+
+		if (version.Count (c => c == '.') == 0)
+			version += ".0.0";
+
+		if (version.Count (c => c == '.') == 1)
+			version += ".0";
+
+		// SemanticVersion can't handle more than 3 parts, like '0.11.91.1'
+		if (version.Count (c => c == '.') > 2)
+			return new SemanticVersion (0, 0, 0);
+
+		return SemanticVersion.Parse (version + tag);
+	}
+
+	static async Task<List<MavenArtifactConfig>> GetExternalDependencies (List<string> externalFiles)
+	{
+		var list = new List<MavenArtifactConfig> ();
+
+		foreach (var file in externalFiles) {
+			var config = await BindingConfig.Load (file);
+
+			list.AddRange (config.MavenArtifacts.Where (a => !a.DependencyOnly));
+		}
+
+		return list;
+	}
+
+	public static async Task<bool> DoesNuGetPackageAlreadyExist (string package, string version)
+	{
+		var url = $"https://www.nuget.org/api/v2/package/{package}/{version}";
+
+		client ??= new HttpClient ();
+
+		var result = await client.GetAsync (url);
+		return result.StatusCode != System.Net.HttpStatusCode.NotFound;
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -16,14 +16,16 @@ using MavenGroup = MavenNet.Models.Group;
 using System.Security.Cryptography;
 using System.Text;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AndroidBinderator
 {
 	public class Engine
 	{
-		public static Task BinderateAsync(string configFile, string basePath = null)
+		public static Task BinderateAsync(string configFile, string? basePath = null)
 		{
-			var config = Newtonsoft.Json.JsonConvert.DeserializeObject<BindingConfig>(File.ReadAllText(configFile));
+			var config = Newtonsoft.Json.JsonConvert.DeserializeObject<BindingConfig>(File.ReadAllText(configFile))
+				?? throw new ArgumentException ("Could not deserialize config file");
 
 			if (!string.IsNullOrEmpty(basePath))
 				config.BasePath = basePath;
@@ -38,7 +40,7 @@ namespace AndroidBinderator
 
 			if (config.DownloadExternals)
 			{
-				var artifactDir = Path.Combine(config.BasePath, config.ExternalsDir);
+				var artifactDir = Path.Combine(config.BasePath!, config.ExternalsDir);
 				if (!Directory.Exists(artifactDir))
 					Directory.CreateDirectory(artifactDir);
 			}
@@ -60,7 +62,7 @@ namespace AndroidBinderator
 
 				var mavenGroup = maven.Groups.FirstOrDefault(g => g.Id == artifact.GroupId);
 
-				Project project = null;
+				Project? project = null;
 
 				project = await maven.GetProjectAsync(artifact.GroupId, artifact.ArtifactId, artifact.Version);
 
@@ -77,7 +79,7 @@ namespace AndroidBinderator
 			var json = Newtonsoft.Json.JsonConvert.SerializeObject(models);
 
 			if (config.Debug.DumpModels)
-				File.WriteAllText(Path.Combine(config.BasePath, "models.json"), json);
+				File.WriteAllText(Path.Combine(config.BasePath!, "models.json"), json);
 
 			var engine = new RazorLightEngineBuilder()
 				.UseMemoryCachingProvider()
@@ -87,13 +89,13 @@ namespace AndroidBinderator
 				var template_set = config.GetTemplateSet(model.MavenArtifacts.FirstOrDefault()?.MavenArtifactConfig?.TemplateSet);
 
 				foreach (var template in template_set.Templates) {
-					var inputTemplateFile = Path.Combine(config.BasePath, template.TemplateFile);
+					var inputTemplateFile = Path.Combine(config.BasePath!, template.TemplateFile);
 					var templateSrc = File.ReadAllText(inputTemplateFile);
 
 					AssignMetadata(model, template);
 
-					var outputFile = new FileInfo (template.GetOutputFile (config, model));
-					if (!outputFile.Directory.Exists)
+					var outputFile = new FileInfo (template.GetOutputFile (config, model))!;
+					if (!outputFile.Directory!.Exists)
 						outputFile.Directory.Create();
 
 					string result = await engine.CompileRenderAsync(inputTemplateFile, templateSrc, model);
@@ -131,16 +133,19 @@ namespace AndroidBinderator
 					continue;
 
 				var artifactDir = Path.Combine(
-					config.BasePath,
+					config.BasePath!,
 					config.ExternalsDir,
-					mavenArtifact.GroupId);
+					mavenArtifact.GroupId!);
 
-				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId);
+				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId!);
 
 				Directory.CreateDirectory(artifactDir);
 				Directory.CreateDirectory(artifactExtractDir);
 
 				var mvnArt = maven.Groups.FirstOrDefault(g => g.Id == mavenArtifact.GroupId)?.Artifacts?.FirstOrDefault(a => a.Id == mavenArtifact.ArtifactId);
+
+				if (mvnArt is null)
+					throw new InvalidOperationException ($"Could not find artifact {mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}");
 
 				// Download artifact
 				var artifactFile = await DownloadPayload(mvnArt, mavenArtifact, mavenProject, artifactDir, config);
@@ -296,13 +301,13 @@ namespace AndroidBinderator
 				projectModels.Add(projectModel);
 
 
-				var artifactDir = Path.Combine(config.BasePath, config.ExternalsDir, mavenArtifact.GroupId);
+				var artifactDir = Path.Combine(config.BasePath!, config.ExternalsDir, mavenArtifact.GroupId!);
 				var artifactFile = Path.Combine(artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
 				var md5File = artifactFile + ".md5";
 				var sha256File = artifactFile + ".sha256";
 				var md5 = File.Exists(md5File) ? File.ReadAllText(md5File) : string.Empty;
 				var sha256 = File.Exists(sha256File) ? File.ReadAllText(sha256File) : string.Empty;
-				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId);
+				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId!);
 
 				var proguardFile = Path.Combine(artifactExtractDir, "proguard.txt");
 
@@ -314,7 +319,7 @@ namespace AndroidBinderator
 					MavenArtifactVersion = mavenArtifact.Version,
 					MavenArtifactMd5 = md5,
 					MavenArtifactSha256 = sha256,
-					ProguardFile = File.Exists(proguardFile) ? GetRelativePath(proguardFile, config.BasePath).Replace("/", "\\") : null,
+					ProguardFile = File.Exists(proguardFile) ? GetRelativePath(proguardFile, config.BasePath ?? "").Replace("/", "\\") : null,
 					MavenArtifactConfig = mavenArtifact
 				});
 
@@ -419,7 +424,7 @@ namespace AndroidBinderator
 			// Calculate metadata from the config file and template file
 			var baseMetadata = new Dictionary<string, string>();
 
-			MergeValues(baseMetadata, project.Config.Metadata);
+			MergeValues(baseMetadata, project.Config?.Metadata);
 			MergeValues(baseMetadata, template.Metadata);
 
 			// Add metadata for artifact
@@ -427,7 +432,7 @@ namespace AndroidBinderator
 			MergeValues(artifactMetadata, baseMetadata);
 
 			if (project.MavenArtifacts.FirstOrDefault() is MavenArtifactModel artifact)
-				MergeValues(artifactMetadata, artifact.MavenArtifactConfig.Metadata);
+				MergeValues(artifactMetadata, artifact.MavenArtifactConfig?.Metadata);
 
 			project.Metadata = artifactMetadata;
 
@@ -439,11 +444,11 @@ namespace AndroidBinderator
 			MergeValues(dependencyMetadata, baseMetadata);
 
 			if (project.NuGetDependencies.FirstOrDefault() is NuGetDependencyModel depMapping)
-				MergeValues(dependencyMetadata, depMapping.MavenArtifactConfig.Metadata);
+				MergeValues(dependencyMetadata, depMapping.MavenArtifactConfig?.Metadata);
 
 			foreach (var dep in project.NuGetDependencies) {
 				dep.Metadata = dependencyMetadata;
-				dep.MavenArtifact.Metadata = dependencyMetadata;
+				dep.MavenArtifact!.Metadata = dependencyMetadata;
 			}
 		}
 
@@ -482,7 +487,7 @@ namespace AndroidBinderator
 			return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', Path.DirectorySeparatorChar));
 		}
 
-		static Dictionary<string, string> MergeValues(Dictionary<string, string> dest, Dictionary<string, string> src)
+		static Dictionary<string, string> MergeValues(Dictionary<string, string>? dest, Dictionary<string, string>? src)
 		{
 			dest = dest ?? new Dictionary<string, string>();
 			if (src != null)
@@ -527,7 +532,8 @@ namespace AndroidBinderator
 			dependency.Version = version;
 		}
 
-		static string ReplaceVersionProperties(Project project, string version)
+		[return:NotNullIfNotNull (nameof (version))]
+		static string? ReplaceVersionProperties(Project project, string? version)
 		{
 			// Handle versions with Properties, like:
 			// <properties>
@@ -545,7 +551,7 @@ namespace AndroidBinderator
 				return version;
 
 			foreach (var prop in project.Properties.Any)
-				version = version.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
+				version = version!.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
 
 			return version;
 		}
@@ -568,7 +574,7 @@ namespace AndroidBinderator
 			return pom;
 		}
 
-		static IEnumerable<Dependency> ParseExtraDependencies(string dependencies)
+		static IEnumerable<Dependency> ParseExtraDependencies(string? dependencies)
 		{
 			if (string.IsNullOrWhiteSpace(dependencies))
 				yield break;

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
@@ -8,7 +8,7 @@ namespace AndroidBinderator
 {
 	public static class Extensions
 	{
-		public static string OrEmpty (this string value) => value ?? string.Empty;
+		public static string OrEmpty (this string? value) => value ?? string.Empty;
 
 		public static string GroupAndArtifactId (this Dependency dependency) => $"{dependency.GroupId}.{dependency.ArtifactId}";
 
@@ -16,7 +16,7 @@ namespace AndroidBinderator
 
 		public static bool IsRuntimeDependency (this Dependency dependency) => dependency?.Scope != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
 
-		public static Dependency FindParentDependency (this Project project, Dependency dependency)
+		public static Dependency? FindParentDependency (this Project project, Dependency dependency)
 		{
 			return project.DependencyManagement?.Dependencies?.FirstOrDefault (
 				d => d.GroupAndArtifactId () == dependency.GroupAndArtifactId () && d.Classifier != "sources");

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
@@ -48,16 +48,16 @@ namespace AndroidBinderator
 			var template = config.GetTemplateSet(artifact.TemplateSet);
 
 			if (template.MavenRepositoryType.HasValue)
-				return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation);
+				return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
 
-			return (config.MavenRepositoryType, config.MavenRepositoryLocation);
+			return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
 		}
 
 		static MavenRepository GetOrCreateRepository(MavenRepoType type, string location)
 		{
 			var key = $"{type}|{location}";
 
-			if (repositories.TryGetValue(key, out MavenRepository repository))
+			if (repositories.TryGetValue(key, out MavenRepository? repository))
 				return repository;
 
 			MavenRepository maven;

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace AndroidBinderator
@@ -7,22 +7,22 @@ namespace AndroidBinderator
 	{
 		public string Id { get; private set; } = Guid.NewGuid().ToString().ToUpperInvariant();
 
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
-		public string MavenGroupId { get; set; }
+		public string? MavenGroupId { get; set; }
 
 		public List<MavenArtifactModel> MavenArtifacts { get; set; } = new List<MavenArtifactModel>();
 
-		public string NuGetPackageId { get; set; }
-		public string NuGetVersionBase { get; set; }
-		public string NuGetVersionSuffix { get; set; }
+		public string? NuGetPackageId { get; set; }
+		public string? NuGetVersionBase { get; set; }
+		public string? NuGetVersionSuffix { get; set; }
 
-		public string NuGetVersion =>
+		public string? NuGetVersion =>
 			string.IsNullOrWhiteSpace(NuGetVersionSuffix)
 				? NuGetVersionBase
 				: NuGetVersionBase + NuGetVersionSuffix;
 
-		public string AssemblyName { get; set; }
+		public string? AssemblyName { get; set; }
 
 		public List<NuGetDependencyModel> NuGetDependencies { get; set; } = new List<NuGetDependencyModel>();
 
@@ -30,6 +30,6 @@ namespace AndroidBinderator
 
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 
-		public BindingConfig Config { get; set; }
+		public BindingConfig? Config { get; set; }
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
@@ -1,19 +1,19 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace AndroidBinderator
 {
 	public class MavenArtifactModel
 	{
-		public string MavenGroupId { get; set; }
-		public string MavenArtifactId { get; set; }
-		public string MavenArtifactVersion { get; set; }
-		public string MavenArtifactPackaging { get; set; }
-		public string MavenArtifactMd5 { get; set; }
-		public string MavenArtifactSha256 { get; set; }
-		public MavenArtifactConfig MavenArtifactConfig { get; set; }
+		public string? MavenGroupId { get; set; }
+		public string? MavenArtifactId { get; set; }
+		public string? MavenArtifactVersion { get; set; }
+		public string? MavenArtifactPackaging { get; set; }
+		public string? MavenArtifactMd5 { get; set; }
+		public string? MavenArtifactSha256 { get; set; }
+		public MavenArtifactConfig? MavenArtifactConfig { get; set; }
 
-		public string DownloadedArtifact { get; set; }
-		public string ProguardFile { get; set; }
+		public string? DownloadedArtifact { get; set; }
+		public string? ProguardFile { get; set; }
 
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 	}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace AndroidBinderator
 {
@@ -6,17 +6,17 @@ namespace AndroidBinderator
 	{
 		public bool IsProjectReference { get; set; }
 
-		public string NuGetPackageId { get; set; }
-		public string NuGetVersionBase { get; set; }
-		public string NuGetVersionSuffix { get; set; }
-		public MavenArtifactConfig MavenArtifactConfig { get; set; }
+		public string? NuGetPackageId { get; set; }
+		public string? NuGetVersionBase { get; set; }
+		public string? NuGetVersionSuffix { get; set; }
+		public MavenArtifactConfig? MavenArtifactConfig { get; set; }
 
-		public string NuGetVersion =>
+		public string? NuGetVersion =>
 			!IsProjectReference || string.IsNullOrWhiteSpace(NuGetVersionSuffix)
 				? NuGetVersionBase
 				: NuGetVersionBase + NuGetVersionSuffix;
 
-		public MavenArtifactModel MavenArtifact { get; set; }
+		public MavenArtifactModel? MavenArtifact { get; set; }
 
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 	}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
@@ -8,13 +8,13 @@ namespace AndroidBinderator
 	public class TemplateSetModel
 	{
 		[JsonProperty("name")]
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		[JsonProperty("mavenRepositoryType")]
 		public MavenRepoType? MavenRepositoryType { get; set; }
 
 		[JsonProperty("mavenRepositoryLocation")]
-		public string MavenRepositoryLocation { get; set; } = null;
+		public string? MavenRepositoryLocation { get; set; } = null;
 
 		[JsonProperty("templates")]
 		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig> ();

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/SolutionFileBuilder.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/SolutionFileBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,7 +16,7 @@ namespace AndroidBinderator
 			var csprojNamespaces = new XmlNamespaceManager(new NameTable());
 			csprojNamespaces.AddNamespace("ns", "http://schemas.microsoft.com/developer/msbuild/2003");
 
-			var slnFileInfo = new FileInfo(config.SolutionFile);
+			var slnFileInfo = new FileInfo(config.SolutionFile!);
 
 			// Collect all the projects to be added to the .sln
 			var allProjects = new List<(string guid, string name, string key)>();
@@ -24,7 +24,7 @@ namespace AndroidBinderator
 			// First go through additional projects specified in the config
 			foreach (var ap in config.AdditionalProjects)
 			{
-				var prjPath = Path.Combine(config.BasePath, ap);
+				var prjPath = Path.Combine(config.BasePath!, ap);
 				var prjPathFileInfo = new FileInfo(prjPath);
 
 				if (!File.Exists(prjPath))

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Util.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Util.cs
@@ -13,9 +13,11 @@ namespace AndroidBinderator
     {
         internal static string HashMd5(Stream value)
         {
-            using (var md5 = MD5.Create())
-                return BitConverter.ToString(md5.ComputeHash(value)).Replace("-", "").ToLowerInvariant();
-        }
+#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms - This is not used for cryptographic purposes
+	    using (var md5 = MD5.Create())
+	        return BitConverter.ToString(md5.ComputeHash(value)).Replace("-", "").ToLowerInvariant();
+#pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
+	}
 
         internal static string HashSha256(string value)
         {
@@ -24,6 +26,7 @@ namespace AndroidBinderator
 
         internal static string HashSha256(byte[] value)
         {
+#pragma warning disable SYSLIB0021 // Type or member is obsolete
             using (var sha256 = new SHA256Managed())
             {
                 var hash = new StringBuilder();
@@ -33,10 +36,12 @@ namespace AndroidBinderator
 
                 return hash.ToString();
             }
-        }
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+		}
 
         internal static string HashSha256(Stream value)
         {
+#pragma warning disable SYSLIB0021 // Type or member is obsolete
             using (var sha256 = new SHA256Managed())
             {
                 var hash = new StringBuilder();
@@ -46,6 +51,7 @@ namespace AndroidBinderator
 
                 return hash.ToString();
             }
-        }
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+		}
     }
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
-        <LangVersion>7.1</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12.0</LangVersion>
         <PreserveCompilationContext>true</PreserveCompilationContext>
         <RootNamespace>AndroidBinderator</RootNamespace>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);NU5104</NoWarn>
     </PropertyGroup>
 


### PR DESCRIPTION
As the scope of `update-config.csx` has grown, it has become more and more painful that it isn't in an actual project editable in an IDE, making it harder to update or debug.  As it shares code with `binderator`, like reading and writing `config.json`, move the functionality into `binderator`.

To help facilitate running this functionality, add new targets to `cake` for the various operations:

*   `update-config`

    Updates config.json to the latest versions found in Maven.
    
*   `bump-config`

    Increments the NuGet patch version of all packages in config.json.
    
*   `sort-config`

    Sorts config.json file using the canonical sort.
    
*   `published-config`

    Shows which NuGet package versions in config.json have been published to NuGet.org.

Note these run the in-tree version of `binderator`, there is no need to install the .NET Global tool version to run these targets.