### PR TITLE
[binderator] Generate 'THIRD-PARTY-NOTICES' from POM information.

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,6 +34,10 @@
       {
         "templateFile": "source/AndroidXDirectoryBuildRsp.cshtml",
         "outputFileRule": "generated/{groupid}.{artifactid}/Directory.Build.rsp"
+      },
+      {
+        "templateFile": "source/ThirdPartyNotices.cshtml",
+        "outputFileRule": "generated/{groupid}.{artifactid}/External-Dependency-Info.txt"
       }
     ],
     "artifacts": [
@@ -2423,7 +2427,11 @@
         "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "dependencyOnly": false,
-        "templateSet": "auto-value"
+        "templateSet": "auto-value",
+        "overrideLicenses": [
+          "Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+        ],
+        "comments": "License is specified in parent POM"
       },
       {
         "groupId": "com.google.code.gson",
@@ -2468,7 +2476,11 @@
         "nugetVersion": "1.0.2.6",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "dependencyOnly": false,
-        "templateSet": "guava"
+        "templateSet": "guava",
+        "overrideLicenses": [
+          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+        ],
+        "comments": "License is specified in parent POM"
       },
       {
         "groupId": "com.google.guava",
@@ -2478,7 +2490,11 @@
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
-        "templateSet": "guava"
+        "templateSet": "guava",
+        "overrideLicenses": [
+          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+        ],
+        "comments": "License is specified in parent POM"
       },
       {
         "groupId": "com.google.guava",
@@ -2487,7 +2503,11 @@
         "nugetVersion": "1.0.0.22",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "dependencyOnly": false,
-        "templateSet": "guava"
+        "templateSet": "guava",
+        "overrideLicenses": [
+          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+        ],
+        "comments": "License is specified in parent POM"
       },
       {
         "groupId": "com.google.j2objc",
@@ -2992,6 +3012,63 @@
         "nugetVersion": "1.0.10",
         "nugetId": "Xamarin.AndroidX.Migration",
         "dependencyOnly": true
+      }
+    ],
+    "licenses": [
+      {
+        "name": "Android Software Development Kit License",
+        "file": "templates/licenses/android-sdk.txt",
+        "proprietary": true
+      },
+      {
+        "name": "Apache 2.0",
+        "file": "templates/licenses/apache-2.0.txt",
+        "spdx": "Apache-2.0"
+      },
+      {
+        "name": "Apache License, Version 2.0",
+        "file": "templates/licenses/apache-2.0.txt",
+        "spdx": "Apache-2.0"
+      },
+      {
+        "name": "Apache-2.0",
+        "file": "templates/licenses/apache-2.0.txt",
+        "spdx": "Apache-2.0"
+      },
+      {
+        "name": "BSD License",
+        "file": "templates/licenses/bsd.txt",
+        "spdx": "BSD-3-Clause"
+      },
+      {
+        "name": "MIT-0",
+        "file": "templates/licenses/mit-0.txt",
+        "spdx": "MIT-0"
+      },
+      {
+        "name": "SIL Open Font License, Version 1.1",
+        "file": "templates/licenses/sil-1.1.txt",
+        "spdx": "OFL-1.1"
+      },
+      {
+        "name": "The Apache License, Version 2.0",
+        "file": "templates/licenses/apache-2.0.txt",
+        "spdx": "Apache-2.0"
+      },
+      {
+        "name": "The Apache Software License, Version 2.0",
+        "file": "templates/licenses/apache-2.0.txt",
+        "spdx": "Apache-2.0"
+      },
+      {
+        "name": "The MIT License",
+        "file": "templates/licenses/mit.txt",
+        "spdx": "MIT"
+      },
+      {
+        "name": "Unicode, Inc. License",
+        "file": "templates/licenses/unicode.txt",
+        "comments": "spdx is 'Unicode-3.0', but .NET 8 NuGet 'pack' doesn't support it yet"
       }
     ],
     "templateSets": [

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -35,7 +35,13 @@
 @(!string.IsNullOrWhiteSpace(Model.MavenDescription) ? $"Library description: {Model.MavenDescription}" : string.Empty)
     </Description>
     <PackageTags>xamarin artifact=@(Model.MavenGroupId):@(Model.Name) artifact_versioned=@(Model.MavenGroupId):@(Model.Name):@(Model.GetArtifactVersion())</PackageTags>
-    <PackageLicenseExpression>MIT AND Apache-2.0</PackageLicenseExpression>
+@if (Model.CanUseSpdx)
+{
+    <PackageLicenseExpression>@Model.GetSpdxExpression()</PackageLicenseExpression>
+} else
+{
+  <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+}
     <PackageIcon>icon.png</PackageIcon>
     <PackageVersion>@(Model.NuGetVersion)$(PackageVersionSuffix)</PackageVersion>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
@@ -48,7 +54,7 @@
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(AndroidXNuGetTargetFolders)" />
     }
     <None Include="..\..\source\PackageLicense.md" Pack="True" PackagePath="LICENSE.md" />
-    <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
+    <None Include=".\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     <None Include="..\..\build\icon.png" Pack="True" PackagePath="icon.png" />
     <None Include=".\readme.md" Pack="True" PackagePath="readme.md" />
   </ItemGroup>

--- a/source/ThirdPartyNotices.cshtml
+++ b/source/ThirdPartyNotices.cshtml
@@ -1,0 +1,21 @@
+@model AndroidBinderator.BindingProjectModel
+@using System
+@using System.Linq
+@using Microsoft.AspNetCore.Html
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+This binding package incorporates third-party material. The license(s) under 
+which Microsoft received such third party material are set forth below.  
+Microsoft reserves all other rights not expressly granted, whether by 
+implication, estoppel or otherwise.
+
+@foreach (var license in Model.Licenses) {
+@:############################################################
+@:# @license.Name
+@:# @license.Url
+@:############################################################
+
+@Raw(System.Environment.NewLine + license.Text + System.Environment.NewLine);
+
+}

--- a/templates/licenses/android-sdk.txt
+++ b/templates/licenses/android-sdk.txt
@@ -1,0 +1,338 @@
+Terms and conditions
+
+This is the Android Software Development Kit License Agreement
+
+1. Introduction
+
+1.1 The Android Software Development Kit (referred to in the License Agreement
+as the "SDK" and specifically including the Android system files, packaged APIs,
+and Google APIs add-ons) is licensed to you subject to the terms of the License
+Agreement. The License Agreement forms a legally binding contract between you
+and Google in relation to your use of the SDK.
+
+1.2 "Android" means the Android software stack for devices, as made available
+under the Android Open Source Project, which is located at the following URL:
+https://source.android.com/, as updated from time to time.
+
+1.3 A "compatible implementation" means any Android device that (i) complies
+with the Android Compatibility Definition document, which can be found at the
+Android compatibility website (https://source.android.com/compatibility) and
+which may be updated from time to time; and (ii) successfully passes the Android
+Compatibility Test Suite (CTS).
+
+1.4 "Google" means Google LLC, organized under the laws of the State of
+Delaware, USA, and operating under the laws of the USA with principal place of
+business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA.
+
+
+2. Accepting this License Agreement
+
+2.1 In order to use the SDK, you must first agree to the License Agreement. You
+may not use the SDK if you do not accept the License Agreement.
+
+2.2 By clicking to accept and/or using this SDK, you hereby agree to the terms
+of the License Agreement.
+
+2.3 You may not use the SDK and may not accept the License Agreement if you are
+a person barred from receiving the SDK under the laws of the United States or
+other countries, including the country in which you are resident or from which
+you use the SDK.
+
+2.4 If you are agreeing to be bound by the License Agreement on behalf of your
+employer or other entity, you represent and warrant that you have full legal
+authority to bind your employer or such entity to the License Agreement. If you
+do not have the requisite authority, you may not accept the License Agreement or
+use the SDK on behalf of your employer or other entity.
+
+
+3. SDK License from Google
+
+3.1 Subject to the terms of the License Agreement, Google grants you a limited,
+worldwide, royalty-free, non-assignable, non-exclusive, and non-sublicensable
+license to use the SDK solely to develop applications for compatible
+implementations of Android.
+
+3.2 You may not use this SDK to develop applications for other platforms
+(including non-compatible implementations of Android) or to develop another SDK.
+You are of course free to develop applications for other platforms, including
+non-compatible implementations of Android, provided that this SDK is not used
+for that purpose.
+
+3.3 You agree that Google or third parties own all legal right, title and
+interest in and to the SDK, including any Intellectual Property Rights that
+subsist in the SDK. "Intellectual Property Rights" means any and all rights
+under patent law, copyright law, trade secret law, trademark law, and any and
+all other proprietary rights. Google reserves all rights not expressly granted
+to you.
+
+3.4 You may not use the SDK for any purpose not expressly permitted by the
+License Agreement.  Except to the extent required by applicable third party
+licenses, you may not copy (except for backup purposes), modify, adapt,
+redistribute, decompile, reverse engineer, disassemble, or create derivative
+works of the SDK or any part of the SDK.
+
+3.5 Use, reproduction and distribution of components of the SDK licensed under
+an open source software license are governed solely by the terms of that open
+source software license and not the License Agreement.
+
+3.6 You agree that the form and nature of the SDK that Google provides may
+change without prior notice to you and that future versions of the SDK may be
+incompatible with applications developed on previous versions of the SDK. You
+agree that Google may stop (permanently or temporarily) providing the SDK (or
+any features within the SDK) to you or to users generally at Google's sole
+discretion, without prior notice to you.
+
+3.7 Nothing in the License Agreement gives you a right to use any of Google's
+trade names, trademarks, service marks, logos, domain names, or other
+distinctive brand features.
+
+3.8 You agree that you will not remove, obscure, or alter any proprietary rights
+notices (including copyright and trademark notices) that may be affixed to or
+contained within the SDK.
+
+
+4. Use of the SDK by You
+
+4.1 Google agrees that it obtains no right, title or interest from you (or your
+licensors) under the License Agreement in or to any software applications that
+you develop using the SDK, including any intellectual property rights that
+subsist in those applications.
+
+4.2 You agree to use the SDK and write applications only for purposes that are
+permitted by (a) the License Agreement and (b) any applicable law, regulation or
+generally accepted practices or guidelines in the relevant jurisdictions
+(including any laws regarding the export of data or software to and from the
+United States or other relevant countries).
+
+4.3 You agree that if you use the SDK to develop applications for general public
+users, you will protect the privacy and legal rights of those users. If the
+users provide you with user names, passwords, or other login information or
+personal information, you must make the users aware that the information will be
+available to your application, and you must provide legally adequate privacy
+notice and protection for those users. If your application stores personal or
+sensitive information provided by users, it must do so securely. If the user
+provides your application with Google Account information, your application may
+only use that information to access the user's Google Account when, and for the
+limited purposes for which, the user has given you permission to do so.
+
+4.4 You agree that you will not engage in any activity with the SDK, including
+the development or distribution of an application, that interferes with,
+disrupts, damages, or accesses in an unauthorized manner the servers, networks,
+or other properties or services of any third party including, but not limited
+to, Google or any mobile communications carrier.
+
+4.5 You agree that you are solely responsible for (and that Google has no
+responsibility to you or to any third party for) any data, content, or resources
+that you create, transmit or display through Android and/or applications for
+Android, and for the consequences of your actions (including any loss or damage
+which Google may suffer) by doing so.
+
+4.6 You agree that you are solely responsible for (and that Google has no
+responsibility to you or to any third party for) any breach of your obligations
+under the License Agreement, any applicable third party contract or Terms of
+Service, or any applicable law or regulation, and for the consequences
+(including any loss or damage which Google or any third party may suffer) of any
+such breach.
+
+
+5. Your Developer Credentials
+
+5.1 You agree that you are responsible for maintaining the confidentiality of
+any developer credentials that may be issued to you by Google or which you may
+choose yourself and that you will be solely responsible for all applications
+that are developed under your developer credentials.
+
+
+6. Privacy and Information
+
+6.1 In order to continually innovate and improve the SDK, Google may collect
+certain usage statistics from the software including but not limited to a unique
+identifier, associated IP address, version number of the software, and
+information on which tools and/or services in the SDK are being used and how
+they are being used. Before any of this information is collected, the SDK will
+notify you and seek your consent. If you withhold consent, the information will
+not be collected.
+
+6.2 The data collected is examined in the aggregate to improve the SDK and is
+maintained in accordance with Google's Privacy Policy, which is located at the
+following URL: https://policies.google.com/privacy
+
+6.3 Anonymized and aggregated sets of the data may be shared with Google
+partners to improve the SDK.
+
+7. Third Party Applications
+
+7.1 If you use the SDK to run applications developed by a third party or that
+access data, content or resources provided by a third party, you agree that
+Google is not responsible for those applications, data, content, or resources.
+You understand that all data, content or resources which you may access through
+such third party applications are the sole responsibility of the person from
+which they originated and that Google is not liable for any loss or damage that
+you may experience as a result of the use or access of any of those third party
+applications, data, content, or resources.
+
+7.2 You should be aware the data, content, and resources presented to you
+through such a third party application may be protected by intellectual property
+rights which are owned by the providers (or by other persons or companies on
+their behalf). You may not modify, rent, lease, loan, sell, distribute or create
+derivative works based on these data, content, or resources (either in whole or
+in part) unless you have been specifically given permission to do so by the
+relevant owners.
+
+7.3 You acknowledge that your use of such third party applications, data,
+content, or resources may be subject to separate terms between you and the
+relevant third party. In that case, the License Agreement does not affect your
+legal relationship with these third parties.
+
+
+8. Using Android APIs
+
+8.1 Google Data APIs
+
+8.1.1 If you use any API to retrieve data from Google, you acknowledge that the
+data may be protected by intellectual property rights which are owned by Google
+or those parties that provide the data (or by other persons or companies on
+their behalf). Your use of any such API may be subject to additional Terms of
+Service. You may not modify, rent, lease, loan, sell, distribute or create
+derivative works based on this data (either in whole or in part) unless allowed
+by the relevant Terms of Service.
+
+8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge
+and agree that you shall retrieve data only with the user's explicit consent and
+only when, and for the limited purposes for which, the user has given you
+permission to do so. If you use the Android Recognition Service API, documented
+at the following URL:
+https://developer.android.com/reference/android/speech/RecognitionService, as
+updated from time to time, you acknowledge that the use of the API is subject to
+the Data Processing Addendum for Products where Google is a Data Processor,
+which is located at the following URL:
+https://privacy.google.com/businesses/gdprprocessorterms/, as updated from time
+to time. By clicking to accept, you hereby agree to the terms of the Data
+Processing Addendum for Products where Google is a Data Processor.
+
+
+
+9. Terminating this License Agreement
+
+9.1 The License Agreement will continue to apply until terminated by either you
+or Google as set out below.
+
+9.2 If you want to terminate the License Agreement, you may do so by ceasing
+your use of the SDK and any relevant developer credentials.
+
+9.3 Google may at any time, terminate the License Agreement with you if:
+(A) you have breached any provision of the License Agreement; or
+(B) Google is required to do so by law; or
+(C) the partner with whom Google offered certain parts of SDK (such as APIs) to
+you has terminated its relationship with Google or ceased to offer certain parts
+of the SDK to you; or
+(D) Google decides to no longer provide the SDK or certain parts of the SDK to
+users in the country in which you are resident or from which you use the
+service, or the provision of the SDK or certain SDK services to you by Google
+is, in Google's sole discretion, no longer commercially viable.
+
+9.4 When the License Agreement comes to an end, all of the legal rights,
+obligations and liabilities that you and Google have benefited from, been
+subject to (or which have accrued over time whilst the License Agreement has
+been in force) or which are expressed to continue indefinitely, shall be
+unaffected by this cessation, and the provisions of paragraph 14.7 shall
+continue to apply to such rights, obligations and liabilities indefinitely.
+
+
+10. DISCLAIMER OF WARRANTIES
+
+10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SDK IS AT YOUR SOLE
+RISK AND THAT THE SDK IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTY OF
+ANY KIND FROM GOOGLE.
+
+10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED
+THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY
+RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF
+DATA THAT RESULTS FROM SUCH USE.
+
+10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY
+KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED
+WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+AND NON-INFRINGEMENT.
+
+
+11. LIMITATION OF LIABILITY
+
+11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND
+AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF
+LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR
+EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA,
+WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE
+BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
+
+
+12. Indemnification
+
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and
+hold harmless Google, its affiliates and their respective directors, officers,
+employees and agents from and against any and all claims, actions, suits or
+proceedings, as well as any and all losses, liabilities, damages, costs and
+expenses (including reasonable attorneys fees) arising out of or accruing from
+(a) your use of the SDK, (b) any application you develop on the SDK that
+infringes any copyright, trademark, trade secret, trade dress, patent or other
+intellectual property right of any person or defames any person or violates
+their rights of publicity or privacy, and (c) any non-compliance by you with the
+License Agreement.
+
+
+13. Changes to the License Agreement
+
+13.1 Google may make changes to the License Agreement as it distributes new
+versions of the SDK. When these changes are made, Google will make a new version
+of the License Agreement available on the website where the SDK is made
+available.
+
+
+14. General Legal Terms
+
+14.1 The License Agreement constitutes the whole legal agreement between you and
+Google and governs your use of the SDK (excluding any services which Google may
+provide to you under a separate written agreement), and completely replaces any
+prior agreements between you and Google in relation to the SDK.
+
+14.2 You agree that if Google does not exercise or enforce any legal right or
+remedy which is contained in the License Agreement (or which Google has the
+benefit of under any applicable law), this will not be taken to be a formal
+waiver of Google's rights and that those rights or remedies will still be
+available to Google.
+
+14.3 If any court of law, having the jurisdiction to decide on this matter,
+rules that any provision of the License Agreement is invalid, then that
+provision will be removed from the License Agreement without affecting the rest
+of the License Agreement. The remaining provisions of the License Agreement will
+continue to be valid and enforceable.
+
+14.4 You acknowledge and agree that each member of the group of companies of
+which Google is the parent shall be third party beneficiaries to the License
+Agreement and that such other companies shall be entitled to directly enforce,
+and rely upon, any provision of the License Agreement that confers a benefit on
+(or rights in favor of) them. Other than this, no other person or company shall
+be third party beneficiaries to the License Agreement.
+
+14.5 EXPORT RESTRICTIONS. THE SDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND
+REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND
+REGULATIONS THAT APPLY TO THE SDK. THESE LAWS INCLUDE RESTRICTIONS ON
+DESTINATIONS, END USERS AND END USE.
+
+14.6 The rights granted in the License Agreement may not be assigned or
+transferred by either you or Google without the prior written approval of the
+other party. Neither you nor Google shall be permitted to delegate their
+responsibilities or obligations under the License Agreement without the prior
+written approval of the other party.
+
+14.7 The License Agreement, and your relationship with Google under the License
+Agreement, shall be governed by the laws of the State of California without
+regard to its conflict of laws provisions. You and Google agree to submit to the
+exclusive jurisdiction of the courts located within the county of Santa Clara,
+California to resolve any legal matter arising from the License Agreement.
+Notwithstanding this, you agree that Google shall still be allowed to apply for
+injunctive remedies (or an equivalent type of urgent legal relief) in any
+jurisdiction.
+
+
+July 27, 2021

--- a/templates/licenses/apache-2.0.txt
+++ b/templates/licenses/apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/templates/licenses/bsd.txt
+++ b/templates/licenses/bsd.txt
@@ -1,0 +1,24 @@
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/templates/licenses/mit-0.txt
+++ b/templates/licenses/mit-0.txt
@@ -1,0 +1,14 @@
+MIT No Attribution
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/licenses/mit.txt
+++ b/templates/licenses/mit.txt
@@ -1,0 +1,16 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/licenses/sil-1.1.txt
+++ b/templates/licenses/sil-1.1.txt
@@ -1,0 +1,91 @@
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/templates/licenses/unicode.txt
+++ b/templates/licenses/unicode.txt
@@ -1,0 +1,39 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
@@ -32,7 +32,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "1.0.2",
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			};
 
 			await Engine.BinderateAsync(config);
@@ -87,7 +88,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "1.0.2",
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			};
 
 			await Engine.BinderateAsync(config);
@@ -125,7 +127,8 @@ namespace Xamarin.AndroidBinderator.Tests
 							{ "More", "Yay!" }
 						}
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -170,7 +173,8 @@ namespace Xamarin.AndroidBinderator.Tests
 							{ "Again", "Good Value" },
 						}
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -222,7 +226,8 @@ namespace Xamarin.AndroidBinderator.Tests
 							{ "Again", "Good Value" },
 						}
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -256,7 +261,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 						NugetVersion = "1.2.3",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -287,7 +293,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "1.0.2",
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -318,7 +325,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "1.0.2",
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -350,7 +358,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						NugetPackageId = "Xamarin.AndroidX.Annotation",
 						NugetVersion = "1.2.3",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -394,7 +403,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "2.0.1",
 						NugetPackageId = "Xamarin.AndroidX.Arch.Core.Common",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -443,7 +453,8 @@ namespace Xamarin.AndroidBinderator.Tests
 						Version = "2.0.1",
 						NugetPackageId = "Xamarin.AndroidX.Arch.Core.Common",
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -509,7 +520,8 @@ namespace Xamarin.AndroidBinderator.Tests
 							{ "Second", "2" },
 						},
 					}
-				}
+				},
+				Licenses = { CreateLicense () }
 			}, @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
@@ -539,6 +551,21 @@ namespace Xamarin.AndroidBinderator.Tests
 
 			var actual = File.ReadAllText(outputFile);
 			Assert.Equal(output, actual);
+		}
+
+		LicenseConfig CreateLicense ()
+		{
+			var path = Path.Combine (RootDirectory, "licenses");
+			Directory.CreateDirectory (path);
+			path = Path.Combine (path, "LICENSE.txt");
+
+			if (!File.Exists (path))
+				File.WriteAllText (path, "Apache License 2.0 Example Text");
+
+			return new LicenseConfig {
+				Name = "The Apache Software License, Version 2.0",
+				File = path
+			};
 		}
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -87,6 +87,9 @@ namespace AndroidBinderator
 		[JsonProperty ("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 
+		[JsonProperty ("licenses")]
+		public List<LicenseConfig> Licenses { get; set; } = new List<LicenseConfig> ();
+
 		[JsonProperty("templateSets")]
 		public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel>();
 
@@ -132,6 +135,9 @@ namespace AndroidBinderator
 			// - groupid
 			// - artifactid
 			config.MavenArtifacts.Sort ((MavenArtifactConfig a, MavenArtifactConfig b) => string.Compare ($"{a.DependencyOnly}-{a.GroupId} {a.ArtifactId}", $"{b.DependencyOnly}-{b.GroupId} {b.ArtifactId}"));
+
+			// Licenses are sorted by name
+			config.Licenses.Sort ((LicenseConfig a, LicenseConfig b) => string.Compare (a.Name, b.Name));
 
 			return config;
 		}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/LicenseConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/LicenseConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace AndroidBinderator;
+
+public class LicenseConfig
+{
+	[JsonProperty ("name")]
+	public string Name { get; set; } = string.Empty;
+
+	[JsonProperty ("file")]
+	public string File { get; set; } = string.Empty;
+
+	[DefaultValue ("")]
+	[JsonProperty ("spdx")]
+	public string Spdx { get; set; } = string.Empty;
+
+	[JsonProperty ("proprietary")]
+	public bool Proprietary { get; set; } 
+
+	[DefaultValue ("")]
+	[JsonProperty ("comments")]
+	public string Comments { get; set; } = string.Empty;
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -58,6 +58,11 @@ namespace AndroidBinderator
 		[JsonProperty("templateSet")]
 		public string? TemplateSet { get; set; }
 
+		public bool ShouldSerializeOverrideLicenses () => OverrideLicenses.Count > 0;
+
+		[JsonProperty ("overrideLicenses")]
+		public List<string> OverrideLicenses { get; set; } = new List<string> ();
+
 		[JsonProperty ("comments")]
 		public string? Comments { get; set; }
 


### PR DESCRIPTION
Instead of manually maintaining licensing information for packages, pull the license information from the package's POM file.  This information looks like:

```xml
<licenses>
  <license>
    <name>The Apache Software License, Version 2.0</name>
    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    <distribution>repo</distribution>
  </license>
</licenses>
```

We need to be able to "understand" this license and properties about it, like its SPDX identifier and whether it is proprietary or not.  To do this, we match the license name to a new section in `config.json`:

```json
"licenses": [
  {
    "name": "The Apache Software License, Version 2.0",
    "file": "templates/licenses/apache-2.0.txt",
    "spdx": "Apache-2.0",
    "proprietary": false
  }, ...
]
```

Note there may be multiple entries for the "same" license, as different POM files may give it a slightly different name.

These license entries also point to a local copy of the license text that we can use to build `THIRD-PARTY-NOTICES.txt` when `binderator` runs.

Modify the project template to include the generated `THIRD-PARTY-NOTICES.txt` which contains the correct notices for each package rather than the generic repo `External-Dependency-Info.txt` which was not correct for packages not licensed under Apache-2.0.

Finally, if the package is open source and all its license(s) have valid SPDX identifiers, calculate the compound SPDX expression and apply it to the package with `<PackageLicenseExpression>`. If not, use `<PackageLicenseFile>` instead.  (SPDX doesn't allow a "proprietary" identifier.)

Note in some cases we may not be able to automatically pull license information from the POM. In these cases we can override the POM information with a new `overrideLicenses` entry on an artifact in `config.json`:

```json
"overrideLicenses": [
  "Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
],
```

The format is `{license name}|{license url}`.