### PR TITLE
[binderator] Tweaks to `update-config` console output.

### DIFF
--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/ConfigUpdater.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/ConfigUpdater.cs
@@ -65,10 +65,6 @@ public class ConfigUpdater
 
 	static bool HasUpdate (MavenArtifactConfig model, Artifact artifact)
 	{
-		// Don't update package if it's "Frozen"
-		if (model.Frozen)
-			return false;
-
 		// Get latest stable version
 		var latest = GetLatestVersion (artifact);
 


### PR DESCRIPTION
Make 2 tweaks to the `update-config` console output.  Note these do not affect anything that is written to `config.json`, just what is written to the console.

- Add number of packages and dependencies to table header:

```console
| 340 Packages (* = Has Update)                              | Currently Bound   | Latest Stable   |
|------------------------------------------------------------|-------------------|-----------------|
| androidx.activity.activity                                 | 1.9.1             | 1.9.1           |
...

| 18 Dependencies (* = Has Update)                           | Current Reference | Latest Publish  |
|------------------------------------------------------------|-------------------|-----------------|
| Xamarin.GooglePlayServices.Ads.Identifier                  | 118.1.0.1         | 118.1.0.1       |
...
```

- Show if there are updates available for "Frozen" packages.  Previously it would just show as frozen and not show if there were updates available.

```console
// Previous behavior
| # com.google.android.material.material                     | 1.11.0            | 1.11.0          |

// New behavior
| #* com.google.android.material.material                    | 1.11.0            | 1.12.0          |
```