### PR TITLE
Move first batch of GPS package-specific templates to AndroidX default template.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -60,6 +60,8 @@
       must be used before `com.google.`
     -->
     <AndroidNamespaceReplacement Include='com.google.common.flogger' Replacement='Xamarin.Google.Flogger' />
+    <AndroidNamespaceReplacement Include='com.google.inject' Replacement='Xamarin.Google.Inject' />
+    <AndroidNamespaceReplacement Include='com.google.errorprone' Replacement='Xamarin.Google.ErrorProne' />
 
     <!-- Company namespace changes -->
     <AndroidNamespaceReplacement Include='androidx.' Replacement='AndroidX' />
@@ -75,6 +77,9 @@
     <AndroidNamespaceReplacement Include='io.reactivex.' Replacement='ReactiveX' />
     <AndroidNamespaceReplacement Include='kotlinx' Replacement='KotlinX' />
     <AndroidNamespaceReplacement Include='support_lib_boundary' Replacement='ChromiumLibBoundary' />
+    <AndroidNamespaceReplacement Include='org.aopalliance.' Replacement='Xamarin.AopAlliance' />
+    <AndroidNamespaceReplacement Include='org.objectweb.' Replacement='Xamarin.ObjectWeb' />
+    <AndroidNamespaceReplacement Include='javax.inject' Replacement='JavaX.Inject' />
 
     <!-- Remove some redundant words -->
     <AndroidNamespaceReplacement Include='androidx.dynamicanimation.animation' Replacement='AndroidX.DynamicAnimation' />

--- a/config.json
+++ b/config.json
@@ -2297,6 +2297,16 @@
         "dependencyOnly": false
       },
       {
+        "groupId": "aopalliance",
+        "artifactId": "aopalliance",
+        "version": "1.0",
+        "nugetVersion": "1.0.0.3",
+        "nugetId": "Xamarin.AopAlliance",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
         "groupId": "com.android.installreferrer",
         "artifactId": "installreferrer",
         "version": "1.1.2",
@@ -2408,6 +2418,16 @@
         "mavenRepositoryType": "MavenCentral"
       },
       {
+        "groupId": "com.google.android",
+        "artifactId": "annotations",
+        "version": "4.1.1.4",
+        "nugetVersion": "4.1.1.17",
+        "nugetId": "Xamarin.GoogleAndroid.Annotations",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter",
         "version": "1.1.18",
@@ -2468,6 +2488,17 @@
         "comments": "License is specified in parent POM"
       },
       {
+        "groupId": "com.google.code.findbugs",
+        "artifactId": "jsr305",
+        "version": "3.0.2",
+        "nugetVersion": "3.0.2.15",
+        "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
+        "dependencyOnly": false,
+        "assemblyName": "Jsr305Binding",
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.11.0",
@@ -2483,6 +2514,26 @@
         "version": "1.14.1",
         "nugetVersion": "1.14.1.1",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
+        "groupId": "com.google.dagger",
+        "artifactId": "dagger",
+        "version": "2.52",
+        "nugetVersion": "2.52.0",
+        "nugetId": "Xamarin.Google.Dagger",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
+        "groupId": "com.google.errorprone",
+        "artifactId": "error_prone_annotations",
+        "version": "2.29.2",
+        "nugetVersion": "2.29.2",
+        "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": false,
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2544,6 +2595,20 @@
         "templateSet": "guava",
         "overrideLicenses": [
           "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+        ],
+        "comments": "License is specified in parent POM"
+      },
+      {
+        "groupId": "com.google.inject",
+        "artifactId": "guice",
+        "version": "7.0.0",
+        "nugetVersion": "7.0.0.1",
+        "nugetId": "Xamarin.Google.Inject.Guice",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral",
+        "overrideLicenses": [
+          "The Apache Software License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
         ],
         "comments": "License is specified in parent POM"
       },
@@ -2643,6 +2708,26 @@
         "version": "3.0.1",
         "nugetVersion": "3.0.1.14",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxKotlin",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
+        "groupId": "jakarta.inject",
+        "artifactId": "jakarta.inject-api",
+        "version": "2.0.1",
+        "nugetVersion": "2.0.1.1",
+        "nugetId": "Xamarin.Jakarta.Inject.InjectApi",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
+        "groupId": "javax.inject",
+        "artifactId": "javax.inject",
+        "version": "1",
+        "nugetVersion": "1.0.0.15",
+        "nugetId": "Xamarin.JavaX.Inject",
         "dependencyOnly": false,
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2885,6 +2970,16 @@
         "templateSet": "kotlinx"
       },
       {
+        "groupId": "org.ow2.asm",
+        "artifactId": "asm",
+        "version": "9.7",
+        "nugetVersion": "9.7.0.1",
+        "nugetId": "Xamarin.OW2.ASM",
+        "dependencyOnly": false,
+        "type": "androidlibrary",
+        "mavenRepositoryType": "MavenCentral"
+      },
+      {
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.4",
@@ -3023,22 +3118,6 @@
         "dependencyOnly": true
       },
       {
-        "groupId": "com.google.code.findbugs",
-        "artifactId": "jsr305",
-        "version": "3.0.2",
-        "nugetVersion": "3.0.2.15",
-        "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.errorprone",
-        "artifactId": "error_prone_annotations",
-        "version": "2.29.2",
-        "nugetVersion": "2.29.2",
-        "nugetId": "Xamarin.Google.ErrorProne.Annotations",
-        "dependencyOnly": true
-      },
-      {
         "groupId": "com.squareup.okio",
         "artifactId": "okio",
         "version": "3.9.0",
@@ -3095,9 +3174,19 @@
         "spdx": "BSD-3-Clause"
       },
       {
+        "name": "BSD-3-Clause",
+        "file": "templates/licenses/bsd.txt",
+        "spdx": "BSD-3-Clause"
+      },
+      {
         "name": "MIT-0",
         "file": "templates/licenses/mit-0.txt",
         "spdx": "MIT-0"
+      },
+      {
+        "name": "Public Domain",
+        "file": "templates/licenses/public-domain.txt",
+        "comments": "There is no spdx for generic 'Public Domain' as it isn't actually a license"
       },
       {
         "name": "SIL Open Font License, Version 1.1",

--- a/nuget-diff.cake
+++ b/nuget-diff.cake
@@ -26,7 +26,7 @@ if (!nupkgs.Any()) {
 } else {
 	Parallel.ForEach (nupkgs, nupkg => {
 		// See https://github.com/xamarin/AndroidX/issues/916
-		if (nupkg.FullPath.Contains ("Xamarin.AndroidX.Car.App.App"))
+		if (nupkg.FullPath.Contains ("Xamarin.AndroidX.Car.App.App") || nupkg.FullPath.Contains ("Xamarin.AndroidX.Fragment") || nupkg.FullPath.Contains ("Xamarin.AndroidX.Lifecycle.LiveData.Core"))
 		  return;
 		var version = "--latest";
 		var versionFile = nupkg.FullPath + ".baseversion";

--- a/published-namespaces.txt
+++ b/published-namespaces.txt
@@ -1,4 +1,5 @@
 _COROUTINE
+Android.Annotation
 Android.Support.CustomTabs
 Android.Support.Customtabs.Trusted
 Android.Support.V4.App
@@ -493,6 +494,10 @@ AndroidX.Work.Impl.Utils.Futures
 AndroidX.Work.Impl.Utils.TaskExecutor
 AndroidX.Work.Impl.Workers
 AndroidX.Work.MultiProcess
+Dagger
+Dagger.Assisted
+Dagger.Internal
+Dagger.Multibindings
 Google.Android.Libraries.AppActions.Service
 Google.Android.Material.Animation
 Google.Android.Material.AppBar
@@ -564,7 +569,12 @@ GoogleGson.Annotations
 GoogleGson.Reflect
 GoogleGson.Stream
 IntelliJ.Lang.Annotations
+Jakarta.Inject
 Java.Interop
+Javax.Annotation
+Javax.Annotation.Concurrent
+Javax.Annotation.Meta
+JavaX.Inject
 JetBrains.Annotations
 Kotlin
 Kotlin.Annotation
@@ -694,6 +704,8 @@ ReactiveX.Subjects
 ReactiveX.Subscribers
 Xamarin.Android.InstallReferrer.Api
 Xamarin.Android.InstallReferrer.Commons
+Xamarin.AopAlliance.Aop
+Xamarin.AopAlliance.Intercept
 Xamarin.Dev.ChrisBanes.Snapper
 Xamarin.Google.Android.Finsky.ExternalReferrer
 Xamarin.Google.Crypto.Tink
@@ -728,6 +740,8 @@ Xamarin.Google.Crypto.Tink.Subtle.Prf
 Xamarin.Google.Crypto.Tink.Tinkkey
 Xamarin.Google.Crypto.Tink.Tinkkey.Internal
 Xamarin.Google.Crypto.Tink.Util
+Xamarin.Google.ErrorProne.Annotations
+Xamarin.Google.ErrorProne.Annotations.Concurrent
 Xamarin.Google.Flogger
 Xamarin.Google.Flogger.Backend
 Xamarin.Google.Flogger.Backend.System
@@ -735,6 +749,15 @@ Xamarin.Google.Flogger.Context
 Xamarin.Google.Flogger.Parameter
 Xamarin.Google.Flogger.Parser
 Xamarin.Google.Flogger.Util
+Xamarin.Google.Inject
+Xamarin.Google.Inject.Binder
+Xamarin.Google.Inject.Internal.Aop
+Xamarin.Google.Inject.Internal.Util
+Xamarin.Google.Inject.Matcher
+Xamarin.Google.Inject.Multibindings
+Xamarin.Google.Inject.Name
+Xamarin.Google.Inject.Spi
+Xamarin.Google.Inject.Util
 Xamarin.IO.AntMedia.Rtmp.Client
 Xamarin.KotlinX.Coroutines
 Xamarin.KotlinX.Coroutines.Channels
@@ -752,3 +775,5 @@ Xamarin.KotlinX.Coroutines.Stream
 Xamarin.KotlinX.Coroutines.Sync
 Xamarin.KotlinX.Coroutines.Tasks
 Xamarin.KotlinX.Coroutines.Time
+Xamarin.ObjectWeb.Asm
+Xamarin.ObjectWeb.Asm.Signature

--- a/source/com.google.dagger/dagger/Additions/Additions.cs
+++ b/source/com.google.dagger/dagger/Additions/Additions.cs
@@ -1,0 +1,30 @@
+using System;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Dagger.Internal
+{
+    partial class MapFactory
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Dictionary as Java.Lang.Object;
+        }
+    }
+
+    partial class SetFactory
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Collection as Java.Lang.Object;
+        }
+    }
+
+    partial class ProviderOfLazy
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Lazy as Java.Lang.Object;
+        }
+    }
+}

--- a/source/com.google.dagger/dagger/Transforms/Metadata.xml
+++ b/source/com.google.dagger/dagger/Transforms/Metadata.xml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='MapFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetDictionary</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='MapProviderFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetDictionary</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='SetFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetCollection</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='ProviderOfLazy']/method[@name='get' and count(parameter)=0]" name="managedName">GetLazy</attr>
+
+
+    <!-- 
+    <remove-node path="/api/package[@name='dagger.internal']/class[@name='MapProviderFactory']/implements" />
+
+    <remove-node
+        path="/api/package[@name='dagger.internal']/class[@name='DoubleCheck']"
+        />
+    <remove-node
+        path="/api/package[@name='dagger.internal']/class[@name='SingleCheck']"
+        />
+    <remove-node
+        path="/api/package[@name='dagger.internal']/class[@name='LazyClassKeyMap']"
+        />
+    -->
+    <remove-node
+        path="/api/package[@name='dagger.internal']/class[@name='DoubleCheck']"
+        />
+    <remove-node
+        path="/api/package[@name='dagger.internal']/class[@name='SingleCheck']"
+        />
+    <attr 
+        path="/api/package[@name='dagger.internal']/class[@name='LazyClassKeyMap']/method[@name='entrySet' and count(parameter)=0]"
+        name="managedReturn"
+        >
+        System.Collections.ICollection
+    </attr>
+    <remove-node 
+        path="/api/package[@name='dagger.internal']/class[@name='LazyClassKeyMap']"
+        />
+    <remove-node 
+        path="/api/package[@name='dagger.internal']/class[@name='MapProviderFactory']"
+        />
+    <remove-node 
+        path="/api/package[@name='dagger.internal']/interface[@name='Provider']"
+        />
+        
+</metadata>

--- a/source/com.google.inject/guice/Transforms/Metadata.xml
+++ b/source/com.google.inject/guice/Transforms/Metadata.xml
@@ -1,0 +1,49 @@
+﻿<metadata>
+    <remove-node
+        path="/api/package[@name='com.google.inject.internal']/class[@name='ProviderMethod']/typeParameters"
+        />
+    <!-- 
+    <attr
+        path="/api/package[@name='com.google.inject.spi']/class[@name='Message']/method[@name='getSource' and count(parameter)=0]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>        
+    -->
+    <remove-node 
+        path="/api/package[@name='com.google.inject.internal']"
+        />
+
+    <attr
+        path="/api/package[@name='com.google.inject.spi']/interface[@name='ConvertedConstantBinding']/method[@name='getDependencies' and count(parameter)=0]"
+        name="managedReturn"
+        >
+        System.Collections.Generic.ICollection &lt; Dependency &gt;
+    </attr>
+    <remove-node
+        path="/api/package[@name='com.google.inject.matcher']/class[@name='AbstractMatcher']/typeParameters"
+        />
+
+    <attr
+        path="/api/package[@name='com.google.inject']/interface[@name='PrivateBinder']/method[@name='skipSources' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;?&gt;...']]"
+        name="managedReturn"
+        >
+        Xamarin.Google.Inject.IBinder
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.inject']/interface[@name='PrivateBinder']/method[@name='withSource' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+        name="managedReturn"
+        >
+        Xamarin.Google.Inject.IBinder
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.inject.spi']/class[@name='Message']/method[@name='getSource' and count(parameter)=0]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+    <remove-node 
+        path="/api/package[@name='com.google.inject.spi']/interface[@name='ConvertedConstantBinding']/typeParameters"
+        />
+
+</metadata>

--- a/templates/licenses/public-domain.txt
+++ b/templates/licenses/public-domain.txt
@@ -1,0 +1,1 @@
+This code is "Public Domain".

--- a/tests/common/NuGet.config
+++ b/tests/common/NuGet.config
@@ -15,6 +15,7 @@
         <packageSource key="Local Output">
             <package pattern="*" />
             <package pattern="Xamarin.AndroidX.Security.SecurityCrypto" />
+            <package pattern="Xamarin.GoogleAndroid.Annotations" />
         </packageSource>
         
         <!-- Only get explicitly needed packages from nuget.org -->
@@ -37,8 +38,6 @@
             <!-- GPS packages -->
             <package pattern="Square.OkIO*" />
             <package pattern="Xamarin.Android.Glide*" />
-            <package pattern="Xamarin.Google.Code.FindBugs.*" />
-            <package pattern="Xamarin.Google.ErrorProne.*" />
             <package pattern="Xamarin.GoogleAndroid.*" />
             <package pattern="Xamarin.GoogleAndroid.Libraries.Identity.GoogleId" />
             <package pattern="Xamarin.GooglePlayServices.*" />            


### PR DESCRIPTION
Move the packages in GPS that use the following package-specific templates to this repository and switch them to using the default template:

- annotations
- aopalliance
- dagger
- errorprone
- findbugs
- inject-guice
- jakarta
- javax-inject
- ow2-asm

Companion PR that removes them from GPS: https://github.com/xamarin/GooglePlayServicesComponents/pull/905