### PR TITLE
Add SetId to AndroidX.Media3.Session.Builder

### DIFF
--- a/source/androidx.media3/media3-session/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-session/Transforms/Metadata.xml
@@ -1,4 +1,4 @@
-﻿<metadata>
+<metadata>
     <remove-node
         path="/api/package[@name='androidx.media3.session']/class[@name='MediaLibraryService.MediaLibrarySession.Builder']/method[@name='setSessionActivity' and count(parameter)=1 and parameter[1][@type='android.app.PendingIntent']]"        
         />
@@ -17,9 +17,12 @@
     <remove-node
         path="/api/package[@name='androidx.media3.session']/class[@name='MediaSession.Builder']/method[@name='setSessionActivity' and count(parameter)=1 and parameter[1][@type='android.app.PendingIntent']]"
         />
-    <remove-node
-        path="/api/package[@name='androidx.media3.session']/class[@name='MediaSession.Builder']/method[@name='setId' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-        />
+    <attr
+        path="/api/package[@name='androidx.media3.session']/class[@name='MediaSession.Builder']/method[@name='setId' and count(parameter)=1 and parameter[1][@name='p0']]"
+        name="managedName"
+		    >
+		    Id
+	  </attr>
     <remove-node
         path="/api/package[@name='androidx.media3.session']/class[@name='MediaSession.Builder']/method[@name='setExtras' and count(parameter)=1 and parameter[1][@type='android.os.Bundle']]"
         />


### PR DESCRIPTION
This fixes an issue where `SetId` was removed and could not be used by developers who need more than a single instance of the exoplayer class.

### Support Libraries Version (eg: 23.3.0):


### Does this change any of the generated binding API's?
Yes

### Describe your contribution
I added back `AndroidX.Media3.Session.Builder` class method `SetID` which allows a developer to set the `Id` for `AndroidX.Media3.Exoplayer.Player`. This allows you to have more than a single instance of the player. Previously it had been removed from bindings. This restores it and I have tested it against the community toolkit which has both a `CollectionView` and a `CarouselView` which use multiple instances of `Exoplayer`.