### PR TITLE
[ci] Make "Sign Archive" a separate stage.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,13 +55,6 @@ extends:
             os: windows
           runAPIScan: true
 
-      - template: sign-artifacts/jobs/v2.yml@internal-templates
-        parameters:
-          artifactName: output-windows
-          usePipelineArtifactTasks: true
-          use1ESTemplate: true
-          condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-          
     - stage: build_mac
       displayName: Build - Mac
       dependsOn:
@@ -89,3 +82,5 @@ extends:
           name: $(windowsAgentPoolName)
           image: $(windowsImage)
           os: windows
+
+    - template: build/ci/stage-sign-artifacts.yml@self

--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -1,0 +1,15 @@
+# Signs artifacts on tags built for release
+  
+stages:
+- stage: sign_artifacts
+  displayName: Sign Artifacts
+  dependsOn: build_windows
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+  
+  jobs:
+  
+  - template: sign-artifacts/jobs/v2.yml@internal-templates
+    parameters:
+      artifactName: output-windows
+      usePipelineArtifactTasks: true
+      use1ESTemplate: true


### PR DESCRIPTION
Today, when preparing a publish release, the "Sign Archive" step always fails the first run, as it relies on the output from the "Build Windows" job, but does not specify the dependency, so it runs before the packages have been built.

Specifying the dependency is better, but it makes the "Build Windows" stage take a lot longer and the test stage(s) cannot run until it completes.

This PR moves the signing to its own stage with the proper dependency set, so it will not run until the packages are ready.  By moving it to its own stage it can also run in parallel with the test stage(s), reducing the overall CI time.

Test CI run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10231962