### PR TITLE
Fixes for issue 940 [AndroidX.Media3.Transformer] `EditedMediaItem.Bulder` missing

### DIFF
--- a/source/androidx.media3/media3-effect/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-effect/Transforms/Metadata.xml
@@ -79,13 +79,13 @@
     <remove-node
         path="/api/package[@name='androidx.media3.effect']/class[@name='Presentation']/implements"
         />
-    -->
     <remove-node
         path="/api/package[@name='androidx.media3.effect']/class[@name='ScaleAndRotateTransformation']/implements"
         />
     <remove-node
         path="/api/package[@name='androidx.media3.effect']/class[@name='Contrast']/implements"
         />
+    -->
 
     <attr
         path="/api/package[@name='androidx.media3.effect']/class[@name='SingleColorLut']/method[@name='toGlShaderProgram' and count(parameter)=2 and parameter[1][@type='android.content.Context'] and parameter[2][@type='boolean']]"


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Fix for 

https://github.com/xamarin/AndroidX/issues/940

https://github.com/xamarin/AndroidX/issues/940#issuecomment-2350937220

Yes. Surfaces missing API.

### Describe your contribution

Fixed metadata that was removing too much API