### PR TITLE
Make assemblies deterministic.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,9 @@
     <!-- Mark .NET6+ packages as supporting trimming -->
     <IsTrimmable>true</IsTrimmable>
 
+    <!-- Assemblies should be deterministic -->
+    <Deterministic>true</Deterministic>
+    
     <!-- Generate NRT annotations -->
     <Nullable Condition=" '$(Nullable)' == '' ">enable</Nullable>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/3554

Creating "reproducible builds" is the current industry best practice for shipping software.

https://reproducible-builds.org/

We should enable `<Deterministic>` to meet this recommendation.