### PR TITLE
[binderator] Rebase on Java.Interop.Tools.Maven.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,8 @@
 // Tools needed by cake addins
 #tool nuget:?package=vswhere&version=3.1.7
 
-#tool nuget:?package=Cake.CoreCLR
+// Used by binderator, "Windows" is fine because we only use managed code from it
+#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=35.0.0-rc.1.80
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=7.0.0

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectConverter.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectConverter.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Java.Interop.Tools.Maven.Models;
+
+namespace AndroidBinderator;
+
+static class BindingProjectConverter
+{
+	public static List<BindingProjectModel> Convert (BindingConfig config)
+	{
+		var exceptions = new List<Exception> ();
+		var models = new List<BindingProjectModel> ();
+
+		foreach (var artifact in config.MavenArtifacts.Where (a => !a.DependencyOnly))
+			models.Add (ConvertArtifact (config, artifact, exceptions));
+
+		if (exceptions.Count > 0)
+			throw new AggregateException (exceptions);
+
+		return models;
+	}
+
+	// Converts an artifact from config.json to the model used to generate files
+	static BindingProjectModel ConvertArtifact (BindingConfig config, MavenArtifactConfig mavenArtifact, List<Exception> exceptions)
+	{
+		var mavenProject = MavenFactory2.GetPomForArtifact (config, mavenArtifact);
+
+		var projectModel = new BindingProjectModel {
+			Name = mavenArtifact.ArtifactId,
+			NuGetPackageId = mavenArtifact.NugetPackageId,
+			NuGetVersionBase = mavenArtifact.NugetVersion,
+			NuGetVersionSuffix = config.NugetVersionSuffix,
+			MavenGroupId = mavenArtifact.GroupId,
+			AssemblyName = mavenArtifact.AssemblyName,
+			Config = config,
+			MavenDescription = mavenProject.Description,
+			MavenUrl = mavenProject.Url,
+			JavaSourceRepository = mavenProject.Scm?.Url,
+			Type = mavenArtifact.BindingsType ?? config.DefaultBindingsType,
+			AllowPrereleaseDependencies = mavenArtifact.AllowPrereleaseDependencies,
+		};
+
+		foreach (var developer in mavenProject.Developers)
+			if (developer.Name is not null)
+				projectModel.Developers.Add (new MavenArtifactDeveloper (developer.Name));
+
+		ConvertPayload (config, projectModel, mavenArtifact, mavenProject);
+		ConvertLicenses (config, mavenArtifact, exceptions, mavenProject, projectModel);
+		ConvertDependencies (config, projectModel, mavenArtifact, mavenProject);
+
+		return projectModel;
+	}
+
+	private static void ConvertLicenses (BindingConfig config, MavenArtifactConfig mavenArtifact, List<Exception> exceptions, Project mavenProject, BindingProjectModel projectModel)
+	{
+		var licenses = mavenProject.Licenses;
+
+		// Override licenses ignore any licenses in the POM
+		if (mavenArtifact.OverrideLicenses.Count > 0) {
+			licenses = new Collection<License> ();
+
+			foreach (var l in mavenArtifact.OverrideLicenses) {
+				var parts = l.Split ('|');
+				licenses.Add (new License {
+					Name = parts [0],
+					Url = parts.Length > 1 ? parts [1] : string.Empty
+				});
+			}
+		}
+
+		// Verify that we have known licenses
+		foreach (var license in licenses) {
+			var license_config = config.Licenses.FirstOrDefault (l => string.Compare (l.Name, license.Name, true) == 0);
+
+			if (license_config is null) {
+				exceptions.Add (new Exception ($"Unknown license '{license.Name}' for artifact '{mavenArtifact.GroupAndArtifactId}'. This license must be added to 'config.json'."));
+				continue;
+			}
+
+			projectModel.Licenses.Add (new MavenArtifactLicense (license.Name ?? "", license.Url ?? "", license_config));
+		}
+
+		if (projectModel.Licenses.Count == 0)
+			exceptions.Add (new Exception ($"No license(s) could be found for artifact '{mavenArtifact.GroupAndArtifactId}'. Use 'overrideLicenses' in 'config.json' to specify with format 'name|url' ('url' is optional)."));
+
+		// Load license text
+		foreach (var license in projectModel.Licenses) {
+			var license_file = Path.Combine (config.BasePath!, license.LicenseConfig.File);
+			license.Text = File.ReadAllText (license_file);
+		}
+	}
+
+	// Creates a model for a .jar/.aar artifact payload
+	static void ConvertPayload (BindingConfig config, BindingProjectModel projectModel, MavenArtifactConfig mavenArtifact, Project mavenProject)
+	{
+		var artifactDir = Path.Combine (config.BasePath!, config.ExternalsDir, mavenArtifact.GroupId!);
+		var artifactFile = Path.Combine (artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
+		var md5File = artifactFile + ".md5";
+		var sha256File = artifactFile + ".sha256";
+		var md5 = File.Exists (md5File) ? File.ReadAllText (md5File) : string.Empty;
+		var sha256 = File.Exists (sha256File) ? File.ReadAllText (sha256File) : string.Empty;
+		var artifactExtractDir = Path.Combine (artifactDir, mavenArtifact.ArtifactId!);
+
+		var proguardFile = Path.Combine (artifactExtractDir, "proguard.txt");
+
+		var artifact = new MavenArtifactModel {
+			MavenGroupId = mavenArtifact.GroupId,
+			MavenArtifactId = mavenArtifact.ArtifactId,
+			MavenArtifactPackaging = mavenProject.Packaging,
+			MavenArtifactVersion = mavenArtifact.Version,
+			MavenArtifactMd5 = md5,
+			MavenArtifactSha256 = sha256,
+			ProguardFile = proguardFile,
+			MavenArtifactConfig = mavenArtifact,
+			DocumentationType = mavenArtifact.DocumentationType,
+		};
+
+		projectModel.MavenArtifacts.Add (artifact);
+	}
+
+	static void ConvertDependencies (BindingConfig config, BindingProjectModel model, MavenArtifactConfig mavenArtifact, Project mavenProject)
+	{
+		// Find all the POM specified dependencies that we need to consider
+		foreach (var mavenDep in mavenProject.Dependencies) {
+			FixDependency (config, mavenArtifact, mavenDep, mavenProject);
+
+			if (!ShouldIncludeDependency (config, mavenArtifact, mavenDep))
+				continue;
+
+			model.MavenDependencies.Add (mavenDep);
+		}
+
+		// Add any "extraDependencies"
+		model.MavenDependencies.AddRange (ParseExtraDependencies (mavenArtifact.ExtraDependencies));
+	}
+
+	static void FixDependency (BindingConfig config, MavenArtifactConfig mavenArtifact, Dependency dependency, Project project)
+	{
+		// Handle Parent POM
+		if ((string.IsNullOrEmpty (dependency.Version) || string.IsNullOrEmpty (dependency.Scope)) && project.Parent != null) {
+			var parent_pom = MavenFactory2.GetPomForArtifactParent (config, project.Parent.ToArtifact (), mavenArtifact);
+			var parent_dependency = parent_pom.FindParentDependency (dependency);
+
+			// Try to fish a version out of the parent POM
+			if (string.IsNullOrEmpty (dependency.Version))
+				dependency.Version = ReplaceVersionProperties (parent_pom, parent_dependency?.Version);
+
+			// Try to fish a scope out of the parent POM
+			if (string.IsNullOrEmpty (dependency.Scope))
+				dependency.Scope = parent_dependency?.Scope;
+		}
+
+		var version = dependency.Version;
+
+		if (string.IsNullOrWhiteSpace (version))
+			return;
+
+		version = ReplaceVersionProperties (project, version);
+
+		// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
+		// Fix them to be "1.0".
+		// https://github.com/NuGet/Home/issues/10342
+		if (!version.Contains ('.'))
+			version += ".0";
+
+		dependency.Version = version;
+	}
+
+	[return: NotNullIfNotNull (nameof (version))]
+	static string? ReplaceVersionProperties (Project project, string? version)
+	{
+		// Handle versions with Properties, like:
+		// <properties>
+		//   <java.version>1.8</java.version>
+		//   <gson.version>2.8.6</gson.version>
+		// </properties>
+		// <dependencies>
+		//   <dependency>
+		//     <groupId>com.google.code.gson</groupId>
+		//     <artifactId>gson</artifactId>
+		//     <version>${gson.version}</version>
+		//   </dependency>
+		// </dependencies>
+		if (string.IsNullOrWhiteSpace (version) || project?.Properties == null)
+			return version;
+
+		foreach (var prop in project.Properties.Any)
+			version = version!.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
+
+		return version;
+	}
+
+	static bool ShouldIncludeDependency (BindingConfig config, MavenArtifactConfig artifact, Dependency dependency)
+	{
+		// Check 'artifact' list
+		if (artifact.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
+			return false;
+
+		// Check 'global' list
+		if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
+			return false;
+
+		// We always care about 'compile' scoped dependencies
+		if (dependency.IsCompileDependency ())
+			return true;
+
+		// If we're not processing Runtime dependencies then ignore the rest
+		if (!config.StrictRuntimeDependencies)
+			return false;
+
+		// The only other thing we may care about is 'runtime', bail if this isn't 'runtime'
+		if (!dependency.IsRuntimeDependency ())
+			return false;
+
+		return true;
+	}
+
+	static IEnumerable<Dependency> ParseExtraDependencies (string? dependencies)
+	{
+		if (string.IsNullOrWhiteSpace (dependencies))
+			yield break;
+
+		// Format is: "groupid.artifactid:version"
+		// Version is optional
+		var deps = dependencies.Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+		foreach (var dep in deps) {
+			var id = dep;
+			var version = string.Empty;
+
+			if (dep.Contains (':')) {
+				id = dep.Substring (0, dep.IndexOf (':'));
+				version = dep.Substring (dep.IndexOf (':') + 1);
+			}
+
+			var result = new Dependency {
+				GroupId = id.Substring (0, id.LastIndexOf ('.')),
+				ArtifactId = id.Substring (id.LastIndexOf ('.') + 1),
+				Version = string.IsNullOrWhiteSpace (version) ? "0.0.0" : version
+			};
+
+			yield return result;
+		}
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectDependencyVerifier.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectDependencyVerifier.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Java.Interop.Tools.Maven.Models;
+
+namespace AndroidBinderator;
+
+static class BindingProjectDependencyVerifier
+{
+	public static void Verify (BindingConfig config, List<BindingProjectModel> artifacts)
+	{
+		var exceptions = new List<Exception> ();
+
+		foreach (var artifact in artifacts)
+			VerifyArtifact (config, artifact, exceptions);
+
+		if (exceptions.Count > 0)
+			throw new AggregateException (exceptions);
+	}
+
+	static void VerifyArtifact (BindingConfig config, BindingProjectModel projectModel, List<Exception> exceptions)
+	{
+		var artifact = projectModel.ToArtifact ();
+
+		// Ensure every artifact dependency is satisfied
+		foreach (var mavenDep in projectModel.MavenDependencies) {
+			mavenDep.GroupId = mavenDep.GroupId?.Replace ("${project.groupId}", artifact.GroupId);
+			mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", artifact.Version);
+
+			var depMapping = config.MavenArtifacts.FirstOrDefault (
+				ma => !string.IsNullOrEmpty (ma.Version)
+				&& ma.GroupId == mavenDep.GroupId
+				&& ma.ArtifactId == mavenDep.ArtifactId
+				&& mavenDep.Satisfies (ma.Version));
+
+			if (depMapping is null) {
+				AddDependencyException (exceptions, artifact, mavenDep.ToArtifact ());
+				continue;
+			}
+
+			projectModel.NuGetDependencies.Add (new NuGetDependencyModel {
+				IsProjectReference = !depMapping.DependencyOnly,
+				NuGetPackageId = depMapping.NugetPackageId,
+				NuGetVersionBase = depMapping.NugetVersion,
+				NuGetVersionSuffix = config.NugetVersionSuffix,
+				MavenArtifactConfig = depMapping,
+
+				MavenArtifact = new MavenArtifactModel {
+					MavenGroupId = mavenDep.GroupId,
+					MavenArtifactId = mavenDep.ArtifactId,
+					MavenArtifactVersion = mavenDep.Version,
+					MavenArtifactMd5 = projectModel.MavenArtifacts.First ().MavenArtifactMd5,
+					MavenArtifactSha256 = projectModel.MavenArtifacts.First ().MavenArtifactSha256
+				}
+			});
+		}
+	}
+
+	static void AddDependencyException (List<Exception> exceptions, Artifact artifact, Artifact dependency)
+	{
+		var sb = new StringBuilder ();
+
+		sb.AppendLine ($"");
+		sb.AppendLine ($"No matching artifact config found for: ");
+		sb.AppendLine ($"			{dependency.VersionedArtifactString}");
+		sb.AppendLine ($"to satisfy dependency of: ");
+		sb.AppendLine ($"			{artifact.VersionedArtifactString}");
+		sb.AppendLine ($"");
+		sb.AppendLine ($"	Please add following json snippet to config.json:");
+		sb.AppendLine ($"");
+		sb.AppendLine
+		($@"
+		   {{
+		     ""groupId"": ""{dependency.GroupId}"",
+		     ""artifactId"": ""{dependency.Id}"",
+		     ""version"": ""{dependency.Version}"",
+		     ""nugetVersion"": ""CHECK PREFIX {dependency.Version}"",
+		     ""nugetId"": ""CHECK NUGET ID"",
+		     ""dependencyOnly"": true/false
+		   }}
+		");
+		sb.AppendLine ($"");
+
+		exceptions.Add (new Exception (sb.ToString ()));
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -4,193 +4,187 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class BindingConfig
 {
-	public class BindingConfig
+	static HttpClient? client;
+
+	[JsonProperty ("basePath")]
+	public string? BasePath { get; set; }
+
+	[JsonProperty ("mavenRepositoryType")]
+	public MavenRepoType MavenRepositoryType { get; set; } = MavenRepoType.Google;
+
+	[JsonProperty ("mavenRepositoryLocation")]
+	public string? MavenRepositoryLocation { get; set; }
+
+	[JsonProperty ("slnFile")]
+	public string? SolutionFile { get; set; }
+
+	/// True to consider 'Runtime' dependencies from a POM file, False to ignore them.
+	[JsonProperty ("strictRuntimeDependencies")]
+	public bool StrictRuntimeDependencies { get; set; }
+
+	[JsonProperty ("defaultBindingsType")]
+	public BindingType DefaultBindingsType { get; set; } = BindingType.Targets;
+
+	[JsonProperty ("excludedRuntimeDependencies")]
+	public string? ExcludedRuntimeDependencies { get; set; }
+
+	[JsonProperty ("additionalProjects")]
+	public List<string> AdditionalProjects { get; set; } = new List<string> ();
+
+	[JsonProperty ("downloadExternalsWithFullName")]
+	public bool DownloadExternalsWithFullName { get; set; } = false;
+
+	[DefaultValue ("generated")]
+	[JsonProperty ("generatedDir")]
+	public string GeneratedDir { get; set; } = "generated";
+
+	[DefaultValue (true)]
+	[JsonProperty ("downloadExternals")]
+	public bool DownloadExternals { get; set; } = true;
+
+	[DefaultValue (true)]
+	[JsonProperty ("downloadJavaSourceJars")]
+	public bool DownloadJavaSourceJars { get; set; } = true;
+
+	[DefaultValue (true)]
+	[JsonProperty ("downloadJavaDocJars")]
+	public bool DownloadJavaDocJars { get; set; } = true;
+
+	[DefaultValue (true)]
+	[JsonProperty ("downloadMetadataFiles")]
+	public bool DownloadMetadataFiles { get; set; } = true;
+
+	[DefaultValue (true)]
+	[JsonProperty ("downloadPoms")]
+	public bool DownloadPoms { get; set; } = true;
+
+	[DefaultValue ("externals")]
+	[JsonProperty ("externalsDir")]
+	public string ExternalsDir { get; set; } = "externals";
+
+	[JsonProperty ("nugetVersionSuffix")]
+	public string? NugetVersionSuffix { get; set; }
+
+	public bool ShouldSerializeDebug () => false;
+
+	[JsonProperty ("debug")]
+	public BindingConfigDebug Debug { get; set; } = new BindingConfigDebug ();
+
+	[JsonProperty ("templates")]
+	public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig> ();
+
+	[JsonProperty ("artifacts")]
+	public List<MavenArtifactConfig> MavenArtifacts { get; set; } = new List<MavenArtifactConfig> ();
+
+	public bool ShouldSerializeMetadata () => Metadata.Count > 0;
+
+	[JsonProperty ("metadata")]
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
+
+	[JsonProperty ("licenses")]
+	public List<LicenseConfig> Licenses { get; set; } = new List<LicenseConfig> ();
+
+	[JsonProperty ("templateSets")]
+	public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel> ();
+
+	public TemplateSetModel GetTemplateSet (string? name)
 	{
-		static HttpClient? client;
+		// If an artifact doesn't specify a template set, first try using the original
+		// single template list if it exists.  If not, look for a template set called "default".
+		if (string.IsNullOrEmpty (name)) {
+			if (Templates.Any ())
+				return new TemplateSetModel { Templates = Templates };
 
-		[JsonProperty("basePath")]
-		public string? BasePath { get; set; }
-
-		[JsonProperty("mavenRepositoryType")]
-		public MavenRepoType MavenRepositoryType { get; set; } = MavenRepoType.Google;
-
-		[JsonProperty("mavenRepositoryLocation")]
-		public string? MavenRepositoryLocation { get; set; }
-
-		[JsonProperty("slnFile")]
-		public string? SolutionFile { get; set; }
-
-		/// True to consider 'Runtime' dependencies from a POM file, False to ignore them.
-		[JsonProperty ("strictRuntimeDependencies")]
-		public bool StrictRuntimeDependencies { get; set; }
-
-		[JsonProperty ("defaultBindingsType")]
-		public BindingType DefaultBindingsType { get; set; } = BindingType.Targets;
-
-		[JsonProperty ("excludedRuntimeDependencies")]
-		public string? ExcludedRuntimeDependencies { get; set; }
-
-		[JsonProperty ("additionalProjects")]
-		public List<string> AdditionalProjects { get; set; } = new List<string> ();
-
-		[JsonProperty ("downloadExternalsWithFullName")]
-		public bool DownloadExternalsWithFullName { get; set; } = false;
-
-		[DefaultValue ("generated")]
-		[JsonProperty ("generatedDir")]
-		public string GeneratedDir { get; set; } = "generated";
-
-		[DefaultValue (true)]
-		[JsonProperty ("downloadExternals")]
-		public bool DownloadExternals { get; set; } = true;
-
-		[DefaultValue (true)]
-		[JsonProperty ("downloadJavaSourceJars")]
-		public bool DownloadJavaSourceJars { get; set; } = true;
-
-		[DefaultValue (true)]
-		[JsonProperty ("downloadJavaDocJars")]
-		public bool DownloadJavaDocJars { get; set; } = true;
-
-		[DefaultValue (true)]
-		[JsonProperty ("downloadMetadataFiles")]
-		public bool DownloadMetadataFiles { get; set; } = true;
-
-		[DefaultValue(true)]
-		[JsonProperty("downloadPoms")]
-		public bool DownloadPoms { get; set; } = true;
-
-		[DefaultValue ("externals")]
-		[JsonProperty ("externalsDir")]
-		public string ExternalsDir { get; set; } = "externals";
-
-		[JsonProperty("nugetVersionSuffix")]
-		public string? NugetVersionSuffix { get; set; }
-
-		public bool ShouldSerializeDebug () => false;
-
-		[JsonProperty("debug")]
-		public BindingConfigDebug Debug { get; set; } = new BindingConfigDebug();
-
-		[JsonProperty("templates")]
-		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig>();
-
-		[JsonProperty("artifacts")]
-		public List<MavenArtifactConfig> MavenArtifacts { get; set; } = new List<MavenArtifactConfig>();
-
-		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
-
-		[JsonProperty ("metadata")]
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
-
-		[JsonProperty ("licenses")]
-		public List<LicenseConfig> Licenses { get; set; } = new List<LicenseConfig> ();
-
-		[JsonProperty("templateSets")]
-		public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel>();
-
-		public TemplateSetModel GetTemplateSet(string? name)
-		{
-			// If an artifact doesn't specify a template set, first try using the original
-			// single template list if it exists.  If not, look for a template set called "default".
-			if (string.IsNullOrEmpty(name)) {
-				if (Templates.Any())
-					return new TemplateSetModel { Templates = Templates };
-
-				name = "default";
-			}
-
-			var set = TemplateSets.FirstOrDefault(s => s.Name == name);
-
-			if (set == null)
-				throw new ArgumentException($"Could not find requested template set '{name}'");
-
-			return set;
+			name = "default";
 		}
 
-		/// <summary>
-		/// Load a config.json file from disk or a URL
-		/// </summary>
-		public static async Task<BindingConfig> Load (string path)
-		{
-			string? json;
+		var set = TemplateSets.FirstOrDefault (s => s.Name == name);
 
-			if (path.StartsWith ("http")) {
-				// Remote configuration file URL
-				client ??= new HttpClient();
-				json = await client.GetStringAsync (path);
-			} else {
-				json = File.ReadAllText (path);
-			}
+		if (set == null)
+			throw new ArgumentException ($"Could not find requested template set '{name}'");
 
-			var config_list = JsonConvert.DeserializeObject<List<BindingConfig>> (json) ?? throw new InvalidOperationException ("Could not deserialize config file");
-			var config = config_list.First ();
+		return set;
+	}
 
-			// Keep file sorted by:
-			// - Is dependency only
-			// - groupid
-			// - artifactid
-			config.MavenArtifacts.Sort ((MavenArtifactConfig a, MavenArtifactConfig b) => string.Compare ($"{a.DependencyOnly}-{a.GroupId} {a.ArtifactId}", $"{b.DependencyOnly}-{b.GroupId} {b.ArtifactId}"));
+	/// <summary>
+	/// Load a config.json file from disk or a URL
+	/// </summary>
+	public static async Task<BindingConfig> Load (string path)
+	{
+		string? json;
 
-			// Licenses are sorted by name
-			config.Licenses.Sort ((LicenseConfig a, LicenseConfig b) => string.Compare (a.Name, b.Name));
-
-			return config;
+		if (path.StartsWith ("http")) {
+			// Remote configuration file URL
+			client ??= new HttpClient ();
+			json = await client.GetStringAsync (path);
+		} else {
+			json = File.ReadAllText (path);
 		}
 
-		public void Save (string path)
-		{
-			var serializer_settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
-			serializer_settings.Converters.Add (new Newtonsoft.Json.Converters.StringEnumConverter ());
+		var config_list = JsonConvert.DeserializeObject<List<BindingConfig>> (json) ?? throw new InvalidOperationException ("Could not deserialize config file");
+		var config = config_list.First ();
 
-			// Write updated config.json back to disk
-			List<BindingConfig> config = [this];
-			var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
-			File.WriteAllText (path, output + Environment.NewLine);
-		}
+		// Keep file sorted by:
+		// - Is dependency only
+		// - groupid
+		// - artifactid
+		config.MavenArtifacts.Sort ((MavenArtifactConfig a, MavenArtifactConfig b) => string.Compare ($"{a.DependencyOnly}-{a.GroupId} {a.ArtifactId}", $"{b.DependencyOnly}-{b.GroupId} {b.ArtifactId}"));
+
+		// Licenses are sorted by name
+		config.Licenses.Sort ((LicenseConfig a, LicenseConfig b) => string.Compare (a.Name, b.Name));
+
+		return config;
 	}
 
-	public class BindingConfigDebug
+	public void Save (string path)
 	{
-		public bool DebugMode { get; set; } = false;
-		public bool DumpModels { get; set; } = false;
-	}
+		var serializer_settings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
+		serializer_settings.Converters.Add (new Newtonsoft.Json.Converters.StringEnumConverter ());
 
-	public enum MavenRepoType
-	{
-		Url,
-		Directory,
-		Google,
-		MavenCentral
+		List<BindingConfig> config = [this];
+		var output = JsonConvert.SerializeObject (config, Formatting.Indented, serializer_settings);
+		File.WriteAllText (path, output + Environment.NewLine);
 	}
+}
 
-	public enum BindingType
-	{
-		[EnumMember (Value = "targets")]
-		Targets,
-		[EnumMember (Value = "androidlibrary")]
-		AndroidLibrary,
-		[EnumMember (Value = "no-bindings")]
-		NoBindings,
-		[EnumMember (Value = "xbd")]
-		XamarinBuildDownload
-	}
+public class BindingConfigDebug
+{
+	public bool DebugMode { get; set; } = false;
+	public bool DumpModels { get; set; } = false;
+}
 
-	public enum DocumentationType
-	{
-		[EnumMember (Value = "none")]
-		None,
-		[EnumMember (Value = "javadoc")]
-		JavaDoc,
-		[EnumMember (Value = "javasource")]
-		JavaSource
-	}
+public enum MavenRepoType
+{
+	Url,
+	Directory,
+	Google,
+	MavenCentral
+}
+
+public enum BindingType
+{
+	[EnumMember (Value = "targets")]
+	Targets,
+	[EnumMember (Value = "androidlibrary")]
+	AndroidLibrary,
+	[EnumMember (Value = "no-bindings")]
+	NoBindings
+}
+
+public enum DocumentationType
+{
+	[EnumMember (Value = "none")]
+	None,
+	[EnumMember (Value = "javadoc")]
+	JavaDoc,
+	[EnumMember (Value = "javasource")]
+	JavaSource
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -176,7 +176,9 @@ public enum BindingType
 	[EnumMember (Value = "androidlibrary")]
 	AndroidLibrary,
 	[EnumMember (Value = "no-bindings")]
-	NoBindings
+	NoBindings,
+	[EnumMember (Value = "xbd")]
+	XamarinBuildDownload
 }
 
 public enum DocumentationType

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/LicenseConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/LicenseConfig.cs
@@ -17,7 +17,7 @@ public class LicenseConfig
 	public string Spdx { get; set; } = string.Empty;
 
 	[JsonProperty ("proprietary")]
-	public bool Proprietary { get; set; } 
+	public bool Proprietary { get; set; }
 
 	[DefaultValue ("")]
 	[JsonProperty ("comments")]

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -2,109 +2,108 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class MavenArtifactConfig
 {
-	public class MavenArtifactConfig
+	public MavenArtifactConfig ()
 	{
-		public MavenArtifactConfig()
-		{
-		}
-
-		public MavenArtifactConfig(string groupId, string artifactId, string version, string? nugetPackageId = null, string? nugetVersion = null)
-		{
-			GroupId = groupId;
-			ArtifactId = artifactId;
-			Version = version;
-			NugetVersion = nugetVersion;
-			NugetPackageId = nugetPackageId;
-		}
-
-		[JsonProperty("groupId")]
-		public string? GroupId { get; set; }
-
-		[JsonProperty("artifactId")]
-		public string? ArtifactId { get; set; }
-
-		[JsonProperty ("version")]
-		public string Version { get; set; } = string.Empty;
-
-		string? nugetVersion = null;
-
-		[JsonProperty("nugetVersion")]
-		public string? NugetVersion {
-			get { return nugetVersion ?? Version; }
-			set { nugetVersion = value; }
-		}
-
-		[JsonProperty("nugetId")]
-		public string? NugetPackageId { get; set; }
-
-		[DefaultValue ("")]
-		[JsonProperty ("dependencyOnly")]
-		public bool DependencyOnly { get; set; } = false;
-
-		[JsonProperty ("frozen")]
-		public bool Frozen { get; set; }
-
-		[JsonProperty ("allowPrereleaseDependencies")]
-		public bool AllowPrereleaseDependencies { get; set; }
-
-		[JsonProperty ("assemblyName")]
-		public string? AssemblyName { get; set; }
-
-		[JsonProperty("excludedRuntimeDependencies")]
-		public string? ExcludedRuntimeDependencies { get; set; }
-
-		[JsonProperty("extraDependencies")]
-		public string? ExtraDependencies { get; set; }
-
-		[JsonProperty ("type")]
-		public BindingType? BindingsType { get; set; }
-
-		[JsonProperty ("mavenRepositoryType")]
-		public MavenRepoType? MavenRepositoryType { get; set; } 
-
-		[JsonProperty ("mavenRepositoryLocation")]
-		public string? MavenRepositoryLocation { get; set; } = null;
-
-		[JsonProperty ("documentationType")]
-		[DefaultValue (DocumentationType.None)]
-		public DocumentationType DocumentationType { get; set; } = DocumentationType.None;
-
-		[JsonProperty("templateSet")]
-		public string? TemplateSet { get; set; }
-
-		[JsonProperty ("skipExtendedTests")]
-		public bool SkipExtendedTests { get; set; }
-
-		public bool ShouldSerializeOverrideLicenses () => OverrideLicenses.Count > 0;
-
-		[JsonProperty ("overrideLicenses")]
-		public List<string> OverrideLicenses { get; set; } = new List<string> ();
-
-		[JsonProperty ("comments")]
-		public string? Comments { get; set; }
-
-		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
-
-		[JsonProperty("metadata")]
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
-
-		// The latest version available in Maven
-		[JsonIgnore]
-		public string LatestVersion { get; set; } = string.Empty;
-
-		// NuGet version to match Maven LatestVersion
-		[JsonIgnore]
-		public string LatestNuGetVersion { get; set; } = string.Empty;
-
-		[JsonIgnore]
-		public string GroupAndArtifactId => $"{GroupId}.{ArtifactId}";
-
-		[JsonIgnore]
-		public bool NewVersionAvailable => LatestVersion != Version;
-
-		[JsonIgnore]
-		public bool NewNuGetVersionAvailable => LatestNuGetVersion != NugetVersion;
 	}
+
+	public MavenArtifactConfig (string groupId, string artifactId, string version, string? nugetPackageId = null, string? nugetVersion = null)
+	{
+		GroupId = groupId;
+		ArtifactId = artifactId;
+		Version = version;
+		NugetVersion = nugetVersion;
+		NugetPackageId = nugetPackageId;
+	}
+
+	[JsonProperty ("groupId")]
+	public string? GroupId { get; set; }
+
+	[JsonProperty ("artifactId")]
+	public string? ArtifactId { get; set; }
+
+	[JsonProperty ("version")]
+	public string Version { get; set; } = string.Empty;
+
+	string? nugetVersion = null;
+
+	[JsonProperty ("nugetVersion")]
+	public string? NugetVersion {
+		get { return nugetVersion ?? Version; }
+		set { nugetVersion = value; }
+	}
+
+	[JsonProperty ("nugetId")]
+	public string? NugetPackageId { get; set; }
+
+	[DefaultValue ("")]
+	[JsonProperty ("dependencyOnly")]
+	public bool DependencyOnly { get; set; } = false;
+
+	[JsonProperty ("frozen")]
+	public bool Frozen { get; set; }
+
+	[JsonProperty ("allowPrereleaseDependencies")]
+	public bool AllowPrereleaseDependencies { get; set; }
+
+	[JsonProperty ("assemblyName")]
+	public string? AssemblyName { get; set; }
+
+	[JsonProperty ("excludedRuntimeDependencies")]
+	public string? ExcludedRuntimeDependencies { get; set; }
+
+	[JsonProperty ("extraDependencies")]
+	public string? ExtraDependencies { get; set; }
+
+	[JsonProperty ("type")]
+	public BindingType? BindingsType { get; set; }
+
+	[JsonProperty ("mavenRepositoryType")]
+	public MavenRepoType? MavenRepositoryType { get; set; }
+
+	[JsonProperty ("mavenRepositoryLocation")]
+	public string? MavenRepositoryLocation { get; set; } = null;
+
+	[JsonProperty ("documentationType")]
+	[DefaultValue (DocumentationType.None)]
+	public DocumentationType DocumentationType { get; set; } = DocumentationType.None;
+
+	[JsonProperty ("templateSet")]
+	public string? TemplateSet { get; set; }
+
+	[JsonProperty ("skipExtendedTests")]
+	public bool SkipExtendedTests { get; set; }
+
+	public bool ShouldSerializeOverrideLicenses () => OverrideLicenses.Count > 0;
+
+	[JsonProperty ("overrideLicenses")]
+	public List<string> OverrideLicenses { get; set; } = new List<string> ();
+
+	[JsonProperty ("comments")]
+	public string? Comments { get; set; }
+
+	public bool ShouldSerializeMetadata () => Metadata.Count > 0;
+
+	[JsonProperty ("metadata")]
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
+
+	// The latest version available in Maven
+	[JsonIgnore]
+	public string LatestVersion { get; set; } = string.Empty;
+
+	// NuGet version to match Maven LatestVersion
+	[JsonIgnore]
+	public string LatestNuGetVersion { get; set; } = string.Empty;
+
+	[JsonIgnore]
+	public string GroupAndArtifactId => $"{GroupId}.{ArtifactId}";
+
+	[JsonIgnore]
+	public bool NewVersionAvailable => LatestVersion != Version;
+
+	[JsonIgnore]
+	public bool NewNuGetVersionAvailable => LatestNuGetVersion != NugetVersion;
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/TemplateConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/TemplateConfig.cs
@@ -3,41 +3,40 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class TemplateConfig
 {
-	public class TemplateConfig
+	public TemplateConfig ()
 	{
-		public TemplateConfig()
-		{
-		}
+	}
 
-		public TemplateConfig(string templateFile, string outputFileRule)
-		{
-			TemplateFile = templateFile ?? throw new ArgumentNullException(nameof(templateFile));
-			OutputFileRule = outputFileRule ?? throw new ArgumentNullException(nameof(outputFileRule));
-		}
+	public TemplateConfig (string templateFile, string outputFileRule)
+	{
+		TemplateFile = templateFile ?? throw new ArgumentNullException (nameof (templateFile));
+		OutputFileRule = outputFileRule ?? throw new ArgumentNullException (nameof (outputFileRule));
+	}
 
-		[JsonProperty("templateFile")]
-		public string TemplateFile { get; set; } = string.Empty;
+	[JsonProperty ("templateFile")]
+	public string TemplateFile { get; set; } = string.Empty;
 
-		[JsonProperty("outputFileRule")]
-		public string OutputFileRule { get; set; } = string.Empty;
+	[JsonProperty ("outputFileRule")]
+	public string OutputFileRule { get; set; } = string.Empty;
 
-		[JsonProperty("metadata")]
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+	[JsonProperty ("metadata")]
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
 
-		public bool ShouldSerializeMetadata () => Metadata.Count > 0;
+	public bool ShouldSerializeMetadata () => Metadata.Count > 0;
 
-		public string GetOutputFile(BindingConfig config, BindingProjectModel model)
-		{
-			var p = OutputFileRule
-					 .Replace("{generated}", config.GeneratedDir)
-					 .Replace("{groupid}", model.MavenGroupId)
-					 .Replace("{artifactid}", model.MavenArtifacts?.FirstOrDefault()?.MavenArtifactId ?? "")
-					 .Replace("{name}", model.Name)
-					 .Replace("{nugetid}", model.NuGetPackageId);
+	public string GetOutputFile (BindingConfig config, BindingProjectModel model)
+	{
+		var p = OutputFileRule
+				 .Replace ("{generated}", config.GeneratedDir)
+				 .Replace ("{groupid}", model.MavenGroupId)
+				 .Replace ("{artifactid}", model.MavenArtifacts?.FirstOrDefault ()?.MavenArtifactId ?? "")
+				 .Replace ("{name}", model.Name)
+				 .Replace ("{nugetid}", model.NuGetPackageId);
 
-			return System.IO.Path.Combine(config.BasePath!, p);
-		}
+		return System.IO.Path.Combine (config.BasePath!, p);
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -12,411 +12,404 @@ using MavenNet.Models;
 using RazorLight;
 using MavenGroup = MavenNet.Models.Group;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class Engine
 {
-	public class Engine
+	public static Task BinderateAsync (string configFile, string? basePath = null)
 	{
-		public static Task BinderateAsync(string configFile, string? basePath = null)
-		{
-			var config = Newtonsoft.Json.JsonConvert.DeserializeObject<BindingConfig>(File.ReadAllText(configFile))
-				?? throw new ArgumentException ("Could not deserialize config file");
+		var config = Newtonsoft.Json.JsonConvert.DeserializeObject<BindingConfig> (File.ReadAllText (configFile))
+			?? throw new ArgumentException ("Could not deserialize config file");
 
-			if (!string.IsNullOrEmpty(basePath))
-				config.BasePath = basePath;
+		if (!string.IsNullOrEmpty (basePath))
+			config.BasePath = basePath;
 
-			return BinderateAsync(config);
+		return BinderateAsync (config);
+	}
+
+	public static async Task BinderateAsync (BindingConfig config)
+	{
+		// Prime our Maven repositories
+		await MavenFactory.Initialize (config);
+
+		if (config.DownloadExternals) {
+			var artifactDir = Path.Combine (config.BasePath!, config.ExternalsDir);
+			if (!Directory.Exists (artifactDir))
+				Directory.CreateDirectory (artifactDir);
 		}
 
-		public static async Task BinderateAsync(BindingConfig config)
-		{
-			// Prime our Maven repositories
-			await MavenFactory.Initialize(config);
+		await ProcessConfig (config);
+	}
 
-			if (config.DownloadExternals)
-			{
-				var artifactDir = Path.Combine(config.BasePath!, config.ExternalsDir);
-				if (!Directory.Exists(artifactDir))
-					Directory.CreateDirectory(artifactDir);
+	static async Task ProcessConfig (BindingConfig config)
+	{
+		var mavenProjects = new Dictionary<string, Project> ();
+		var mavenGroups = new List<MavenGroup> ();
+
+		foreach (var artifact in config.MavenArtifacts) {
+			if (artifact.DependencyOnly)
+				continue;
+
+			var maven = MavenFactory.GetMavenRepository (config, artifact);
+
+			var mavenGroup = maven.Groups.FirstOrDefault (g => g.Id == artifact.GroupId);
+
+			Project? project = null;
+
+			project = await maven.GetProjectAsync (artifact.GroupId, artifact.ArtifactId, artifact.Version);
+
+			if (project != null)
+				mavenProjects.Add ($"{artifact.GroupId}/{artifact.ArtifactId}-{artifact.Version}", project);
+		}
+
+		if (config.DownloadExternals)
+			await DownloadArtifacts (config, mavenProjects);
+
+		// This isn't really correct, as it could be .aar, but it'll do until we hit that case and need to fix it
+		foreach (var artifact in mavenProjects.Values.Where (a => a.Packaging == "bundle"))
+			artifact.Packaging = "jar";
+
+		var slnProjModels = new Dictionary<string, BindingProjectModel> ();
+		var models = BuildProjectModels (config, mavenProjects);
+
+		var json = Newtonsoft.Json.JsonConvert.SerializeObject (models);
+
+		if (config.Debug.DumpModels)
+			File.WriteAllText (Path.Combine (config.BasePath!, "models.json"), json);
+
+		var engine = new RazorLightEngineBuilder ()
+			.UseMemoryCachingProvider ()
+			.Build ();
+
+		foreach (var model in models) {
+			var template_set = config.GetTemplateSet (model.MavenArtifacts.FirstOrDefault ()?.MavenArtifactConfig?.TemplateSet);
+
+			foreach (var template in template_set.Templates) {
+				var inputTemplateFile = Path.Combine (config.BasePath!, template.TemplateFile);
+				var templateSrc = File.ReadAllText (inputTemplateFile);
+
+				AssignMetadata (model, template);
+
+				var outputFile = new FileInfo (template.GetOutputFile (config, model))!;
+				if (!outputFile.Directory!.Exists)
+					outputFile.Directory.Create ();
+
+				string result = await engine.CompileRenderAsync (inputTemplateFile, templateSrc, model);
+
+				File.WriteAllText (outputFile.FullName, result);
+
+				// We want to collect all the models for the .csproj's so we can add them to a .sln file after
+				if (!slnProjModels.ContainsKey (outputFile.FullName) && template.OutputFileRule.EndsWith (".csproj"))
+					slnProjModels.Add (outputFile.FullName, model);
+			}
+		}
+
+		if (!string.IsNullOrEmpty (config.SolutionFile)) {
+			var slnPath = Path.Combine (config.BasePath ?? AppDomain.CurrentDomain.BaseDirectory, config.SolutionFile);
+			var sln = SolutionFileBuilder.Build (config, slnProjModels);
+			File.WriteAllText (slnPath, sln);
+		}
+	}
+
+	static async Task DownloadArtifacts (BindingConfig config, Dictionary<string, Project> mavenProjects)
+	{
+		var httpClient = new HttpClient ();
+
+		foreach (var mavenArtifact in config.MavenArtifacts) {
+			// Skip downloading dependencies
+			if (mavenArtifact.DependencyOnly)
+				continue;
+
+			var maven = MavenFactory.GetMavenRepository (config, mavenArtifact);
+			var version = mavenArtifact.Version;
+
+			if (!mavenProjects.TryGetValue ($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
+				continue;
+
+			var artifactDir = Path.Combine (
+				config.BasePath!,
+				config.ExternalsDir,
+				mavenArtifact.GroupId!);
+
+			var artifactExtractDir = Path.Combine (artifactDir, mavenArtifact.ArtifactId!);
+
+			Directory.CreateDirectory (artifactDir);
+			Directory.CreateDirectory (artifactExtractDir);
+
+			var mvnArt = maven.Groups.FirstOrDefault (g => g.Id == mavenArtifact.GroupId)?.Artifacts?.FirstOrDefault (a => a.Id == mavenArtifact.ArtifactId);
+
+			if (mvnArt is null)
+				throw new InvalidOperationException ($"Could not find artifact {mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}");
+
+			// Download artifact
+			var artifactFile = await DownloadPayload (mvnArt, mavenArtifact, mavenProject, artifactDir, config);
+
+			// Determine MD5
+			var md5File = artifactFile + ".md5";
+			var md5_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging + ".md5"));
+
+			if (!(await TryDownloadFile (md5_func, md5File, ErrorLevel.Info))) {
+				// Then hash the downloaded artifact
+				using (var file = File.OpenRead (artifactFile))
+					File.WriteAllText (md5File, Util.HashMd5 (file));
 			}
 
-			await ProcessConfig(config);
+			// Determine Sha256
+			var sha256File = artifactFile + ".sha256";
+			var sha_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging + ".sha256"));
+
+			// First try download, this almost certainly won't work
+			// but in case Maven ever starts supporting sha256 it should start
+			// they currently support .sha1 so there's no reason to believe the naming
+			// convention should be any different, and one day .sha256 may exist
+			if (!(await TryDownloadFile (sha_func, sha256File, ErrorLevel.Ignore))) {
+				// Create Sha256 hash if we couldn't download
+				using (var file = File.OpenRead (artifactFile))
+					File.WriteAllText (sha256File, Util.HashSha256 (file));
+			}
+
+			var base_file_name = Path.Combine (artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}" : $"{mavenArtifact.ArtifactId}");
+
+			if (config.DownloadJavaSourceJars) {
+				var source_file = base_file_name + "-sources.jar";
+				var source_func = new Func<Task<Stream>> (() => maven.OpenArtifactSourcesFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
+				await TryDownloadFile (source_func, source_file, ErrorLevel.Info);
+			}
+
+			if (config.DownloadPoms) {
+				var pom_file = base_file_name + ".pom";
+				var pom_func = new Func<Task<Stream>> (() => maven.OpenArtifactPomFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
+				await TryDownloadFile (pom_func, pom_file, ErrorLevel.Info);
+			}
+
+			if (config.DownloadJavaDocJars) {
+				var javadoc_file = base_file_name + "-javadoc.jar";
+				var javadoc_func = new Func<Task<Stream>> (() => maven.OpenArtifactDocsFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
+				await TryDownloadFile (javadoc_func, javadoc_file, ErrorLevel.Info);
+			}
+
+			if (config.DownloadMetadataFiles) {
+				var metadata_file = base_file_name + "-metadata.xml";
+				var metadata_func = new Func<Task<Stream>> (() => maven.OpenMavenMetadataFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId));
+				await TryDownloadFile (metadata_func, metadata_file, ErrorLevel.Info);
+			}
+
+			if (Directory.Exists (artifactExtractDir))
+				Directory.Delete (artifactExtractDir, true);
+
+			// Unzip artifact into externals
+			if (mavenProject.Packaging.ToLowerInvariant () == "aar")
+				ZipFile.ExtractToDirectory (artifactFile, artifactExtractDir);
+		}
+	}
+
+	// Returns artifact output path
+	static async Task<string> DownloadPayload (Artifact mvnArt, MavenArtifactConfig mavenArtifact, Project mavenProject, string artifactDir, BindingConfig config)
+	{
+		var package_prefix = config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}." : string.Empty;
+		package_prefix += $"{mavenArtifact.ArtifactId}.";
+
+		var base_path = Path.Combine (artifactDir, package_prefix);
+
+		if (mavenProject.Packaging == "jar" || mavenProject.Packaging == "aar") {
+			var func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging));
+			await TryDownloadFile (func, base_path + mavenProject.Packaging, ErrorLevel.Error);
+
+			return base_path + mavenProject.Packaging;
 		}
 
-		static async Task ProcessConfig(BindingConfig config)
-		{
-			var mavenProjects = new Dictionary<string, Project>();
-			var mavenGroups = new List<MavenGroup>();
+		// Sometimes the "Packaging" isn't useful, like "bundle" for Guava or "pom" for KotlinX Coroutines.
+		// In this case we're going to try "jar" and "aar" to try to find the real payload
 
-			foreach (var artifact in config.MavenArtifacts)
-			{
-				if (artifact.DependencyOnly)
+		// Try jar
+		var jar_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, "jar"));
+		var jar_result = await TryDownloadFile (jar_func, base_path + "jar", ErrorLevel.Ignore);
+
+		if (jar_result) {
+			mavenProject.Packaging = "jar";
+			return base_path + "jar";
+		}
+
+		// Try aar
+		var aar_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, "aar"));
+		var aar_result = await TryDownloadFile (aar_func, base_path + "aar", ErrorLevel.Ignore);
+
+		if (aar_result) {
+			mavenProject.Packaging = "aar";
+			return base_path + "aar";
+		}
+
+		throw new Exception ($"Could not find artifact payload {base_path + "jar"}. [Packaging was {mavenProject.Packaging}.]");
+	}
+
+	// Return value indicates download success
+	static async Task<bool> TryDownloadFile (Func<Task<Stream>> func, string outputFile, ErrorLevel level = ErrorLevel.Info)
+	{
+		try {
+			using (var astrm = await func.Invoke ())
+			using (var sw = File.Create (outputFile))
+				await astrm.CopyToAsync (sw);
+
+			return true;
+		} catch (Exception ex) {
+			if (level == ErrorLevel.Error)
+				throw;
+
+			if (level == ErrorLevel.Info)
+				Trace.WriteLine ($"Failed to download {Path.GetFileName (outputFile)}: {ex.Message}");
+
+			return false;
+		}
+	}
+
+	enum ErrorLevel
+	{
+		Ignore,
+		Info,
+		Error
+	}
+
+	static List<BindingProjectModel> BuildProjectModels (BindingConfig config, Dictionary<string, Project> mavenProjects)
+	{
+		var projectModels = new List<BindingProjectModel> ();
+		var exceptions = new List<Exception> ();
+
+		foreach (var mavenArtifact in config.MavenArtifacts) {
+			if (mavenArtifact.DependencyOnly)
+				continue;
+
+			if (!mavenProjects.TryGetValue ($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
+				continue;
+
+			var projectModel = new BindingProjectModel {
+				Name = mavenArtifact.ArtifactId,
+				NuGetPackageId = mavenArtifact.NugetPackageId,
+				NuGetVersionBase = mavenArtifact.NugetVersion,
+				NuGetVersionSuffix = config.NugetVersionSuffix,
+				MavenGroupId = mavenArtifact.GroupId,
+				AssemblyName = mavenArtifact.AssemblyName,
+				Config = config,
+				MavenDescription = mavenProject.Description,
+				MavenUrl = mavenProject.Url,
+				JavaSourceRepository = mavenProject.Scm?.Url,
+				Type = mavenArtifact.BindingsType ?? config.DefaultBindingsType,
+				AllowPrereleaseDependencies = mavenArtifact.AllowPrereleaseDependencies,
+			};
+
+			var licenses = mavenProject.Licenses;
+
+			// Override licenses ignore any licenses in the POM
+			if (mavenArtifact.OverrideLicenses.Count > 0) {
+				licenses = new List<License> ();
+
+				foreach (var l in mavenArtifact.OverrideLicenses) {
+					var parts = l.Split ('|');
+					licenses.Add (new License {
+						Name = parts [0],
+						Url = parts.Length > 1 ? parts [1] : string.Empty
+					});
+				}
+			}
+
+			// Verify that we have known licenses
+			foreach (var license in licenses) {
+				var license_config = config.Licenses.FirstOrDefault (l => string.Compare (l.Name, license.Name, true) == 0);
+
+				if (license_config is null) {
+					exceptions.Add (new Exception ($"Unknown license '{license.Name}' for artifact '{mavenArtifact.GroupAndArtifactId}'. This license must be added to 'config.json'."));
+					continue;
+				}
+
+				projectModel.Licenses.Add (new MavenArtifactLicense (license.Name, license.Url, license_config));
+			}
+
+			if (projectModel.Licenses.Count == 0)
+				exceptions.Add (new Exception ($"No license(s) could be found for artifact '{mavenArtifact.GroupAndArtifactId}'. Use 'overrideLicenses' in 'config.json' to specify with format 'name|url' ('url' is optional)."));
+
+			// Load license text
+			foreach (var license in projectModel.Licenses) {
+				var license_file = Path.Combine (config.BasePath!, license.LicenseConfig.File);
+				license.Text = File.ReadAllText (license_file);
+			}
+
+			foreach (var developer in mavenProject.Developers)
+				projectModel.Developers.Add (new MavenArtifactDeveloper (developer.Name));
+
+			projectModels.Add (projectModel);
+
+			var artifactDir = Path.Combine (config.BasePath!, config.ExternalsDir, mavenArtifact.GroupId!);
+			var artifactFile = Path.Combine (artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
+			var md5File = artifactFile + ".md5";
+			var sha256File = artifactFile + ".sha256";
+			var md5 = File.Exists (md5File) ? File.ReadAllText (md5File) : string.Empty;
+			var sha256 = File.Exists (sha256File) ? File.ReadAllText (sha256File) : string.Empty;
+			var artifactExtractDir = Path.Combine (artifactDir, mavenArtifact.ArtifactId!);
+
+			var proguardFile = Path.Combine (artifactExtractDir, "proguard.txt");
+
+			projectModel.MavenArtifacts.Add (new MavenArtifactModel {
+				MavenGroupId = mavenArtifact.GroupId,
+				MavenArtifactId = mavenArtifact.ArtifactId,
+				MavenArtifactPackaging = mavenProject.Packaging,
+				MavenArtifactVersion = mavenArtifact.Version,
+				MavenArtifactMd5 = md5,
+				MavenArtifactSha256 = sha256,
+				ProguardFile = File.Exists (proguardFile) ? GetRelativePath (proguardFile, config.BasePath ?? "").Replace ("/", "\\") : null,
+				MavenArtifactConfig = mavenArtifact,
+				DocumentationType = mavenArtifact.DocumentationType,
+			});
+
+			List<Dependency> dependencies = new List<Dependency> ();
+
+			// Find all the POM specified dependencies that we need to consider
+			foreach (var mavenDep in mavenProject.Dependencies) {
+				FixDependency (config, mavenArtifact, mavenDep, mavenProject);
+
+				if (!ShouldIncludeDependency (config, mavenArtifact, mavenDep, exceptions))
 					continue;
 
-				var maven = MavenFactory.GetMavenRepository (config, artifact);
-
-				var mavenGroup = maven.Groups.FirstOrDefault(g => g.Id == artifact.GroupId);
-
-				Project? project = null;
-
-				project = await maven.GetProjectAsync(artifact.GroupId, artifact.ArtifactId, artifact.Version);
-
-				if (project != null)
-					mavenProjects.Add($"{artifact.GroupId}/{artifact.ArtifactId}-{artifact.Version}", project);
+				dependencies.Add (mavenDep);
 			}
 
-			if (config.DownloadExternals)
-				await DownloadArtifacts(config, mavenProjects);
+			// Add any "extraDependencies"
+			dependencies.AddRange (ParseExtraDependencies (mavenArtifact.ExtraDependencies));
 
-			// This isn't really correct, as it could be .aar, but it'll do until we hit that case and need to fix it
-			foreach (var artifact in mavenProjects.Values.Where (a => a.Packaging == "bundle"))
-				artifact.Packaging = "jar";
+			// Try and map out nuget dependencies
+			foreach (var mavenDep in dependencies) {
+				mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
+				mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
 
-			var slnProjModels = new Dictionary<string, BindingProjectModel>();
-			var models = BuildProjectModels(config, mavenProjects);
+				var depMapping = config.MavenArtifacts.FirstOrDefault (
+					ma => !string.IsNullOrEmpty (ma.Version)
+					&& ma.GroupId == mavenDep.GroupId
+					&& ma.ArtifactId == mavenDep.ArtifactId
+					&& mavenDep.Satisfies (ma.Version));
 
-			var json = Newtonsoft.Json.JsonConvert.SerializeObject(models);
+				if (depMapping is null && mavenDep.IsRuntimeDependency ()) {
+					StringBuilder sb = new StringBuilder ();
+					sb.AppendLine ($"");
+					sb.AppendLine ($"Artifact");
+					sb.AppendLine ($"	{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
+					sb.AppendLine ($"has unknown 'Runtime' dependency ");
+					sb.AppendLine ($"	{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
+					sb.AppendLine ($"Either fulfill or exclude this dependency.");
 
-			if (config.Debug.DumpModels)
-				File.WriteAllText(Path.Combine(config.BasePath!, "models.json"), json);
-
-			var engine = new RazorLightEngineBuilder()
-				.UseFileSystemProject (config.BasePath)
-				.UseMemoryCachingProvider()
-				.Build();
-
-			foreach (var model in models) {
-				var template_set = config.GetTemplateSet(model.MavenArtifacts.FirstOrDefault()?.MavenArtifactConfig?.TemplateSet);
-
-				foreach (var template in template_set.Templates) {
-					AssignMetadata(model, template);
-
-					var outputFile = new FileInfo (template.GetOutputFile (config, model))!;
-					if (!outputFile.Directory!.Exists)
-						outputFile.Directory.Create();
-
-					string result = await engine.CompileRenderAsync(template.TemplateFile, model);
-
-					File.WriteAllText(outputFile.FullName, result);
-
-					// We want to collect all the models for the .csproj's so we can add them to a .sln file after
-					if (!slnProjModels.ContainsKey(outputFile.FullName) && template.OutputFileRule.EndsWith(".csproj"))
-						slnProjModels.Add(outputFile.FullName, model);
-				}
-			}
-
-			if (!string.IsNullOrEmpty(config.SolutionFile))
-			{
-				var slnPath = Path.Combine(config.BasePath ?? AppDomain.CurrentDomain.BaseDirectory, config.SolutionFile);
-				var sln = SolutionFileBuilder.Build(config, slnProjModels);
-				File.WriteAllText(slnPath, sln);
-			}
-		}
-
-		static async Task DownloadArtifacts(BindingConfig config, Dictionary<string, Project> mavenProjects)
-		{
-			var httpClient = new HttpClient();
-
-			foreach (var mavenArtifact in config.MavenArtifacts)
-			{
-                // Skip downloading dependencies
-                if (mavenArtifact.DependencyOnly)
-                    continue;
-
-				var maven = MavenFactory.GetMavenRepository(config, mavenArtifact);
-				var version = mavenArtifact.Version;
-
-				if (!mavenProjects.TryGetValue($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
+					exceptions.Add (new Exception (sb.ToString ()));
 					continue;
-
-				var artifactDir = Path.Combine(
-					config.BasePath!,
-					config.ExternalsDir,
-					mavenArtifact.GroupId!);
-
-				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId!);
-
-				Directory.CreateDirectory(artifactDir);
-				Directory.CreateDirectory(artifactExtractDir);
-
-				var mvnArt = maven.Groups.FirstOrDefault(g => g.Id == mavenArtifact.GroupId)?.Artifacts?.FirstOrDefault(a => a.Id == mavenArtifact.ArtifactId);
-
-				if (mvnArt is null)
-					throw new InvalidOperationException ($"Could not find artifact {mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}");
-
-				// Download artifact
-				var artifactFile = await DownloadPayload(mvnArt, mavenArtifact, mavenProject, artifactDir, config);
-
-				// Determine MD5
-				var md5File = artifactFile + ".md5";
-				var md5_func = new Func<Task<Stream>>(() => mvnArt.OpenLibraryFile(mavenArtifact.Version, mavenProject.Packaging + ".md5"));
-
-				if (!(await TryDownloadFile(md5_func, md5File, ErrorLevel.Info))) {
-					// Then hash the downloaded artifact
-					using (var file = File.OpenRead(artifactFile))
-						File.WriteAllText (md5File, Util.HashMd5(file));
 				}
 
-				// Determine Sha256
-				var sha256File = artifactFile + ".sha256";
-				var sha_func = new Func<Task<Stream>>(() => mvnArt.OpenLibraryFile(mavenArtifact.Version, mavenProject.Packaging + ".sha256"));
-
-				// First try download, this almost certainly won't work
-				// but in case Maven ever starts supporting sha256 it should start
-				// they currently support .sha1 so there's no reason to believe the naming
-				// convention should be any different, and one day .sha256 may exist
-				if (!(await TryDownloadFile(sha_func, sha256File, ErrorLevel.Ignore))) {
-					// Create Sha256 hash if we couldn't download
-					using (var file = File.OpenRead(artifactFile))
-						File.WriteAllText(sha256File, Util.HashSha256(file));
-				}
-
-				var base_file_name = Path.Combine (artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}" : $"{mavenArtifact.ArtifactId}");
-
-				if (config.DownloadJavaSourceJars) {
-					var source_file = base_file_name + "-sources.jar";
-					var source_func = new Func<Task<Stream>>(() => maven.OpenArtifactSourcesFile(mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-					await TryDownloadFile(source_func, source_file, ErrorLevel.Info);
-				}
-
-				if (config.DownloadPoms) {
-					var pom_file = base_file_name + ".pom";
-					var pom_func = new Func<Task<Stream>>(() => maven.OpenArtifactPomFile(mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-					await TryDownloadFile(pom_func, pom_file, ErrorLevel.Info);
-				}
-
-				if (config.DownloadJavaDocJars) {
-					var javadoc_file = base_file_name + "-javadoc.jar";
-					var javadoc_func = new Func<Task<Stream>> (() => maven.OpenArtifactDocsFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-					await TryDownloadFile (javadoc_func, javadoc_file, ErrorLevel.Info);
-				}
-
-				if (config.DownloadMetadataFiles) {
-					var metadata_file = base_file_name + "-metadata.xml";
-					var metadata_func = new Func<Task<Stream>>(() => maven.OpenMavenMetadataFile(mavenArtifact.GroupId, mavenArtifact.ArtifactId));
-					await TryDownloadFile(metadata_func, metadata_file, ErrorLevel.Info);
-				}
-
-				if (Directory.Exists(artifactExtractDir))
-					Directory.Delete(artifactExtractDir, true);
-
-				// Unzip artifact into externals
-				if (mavenProject.Packaging.ToLowerInvariant() == "aar")
-					ZipFile.ExtractToDirectory(artifactFile, artifactExtractDir);
-			}
-		}
-
-		// Returns artifact output path
-		static async Task<string> DownloadPayload(Artifact mvnArt, MavenArtifactConfig mavenArtifact, Project mavenProject, string artifactDir, BindingConfig config)
-		{
-			var package_prefix = config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}." : string.Empty;
-			package_prefix += $"{mavenArtifact.ArtifactId}.";
-
-			var base_path = Path.Combine(artifactDir, package_prefix);
-
-			if (mavenProject.Packaging == "jar" || mavenProject.Packaging == "aar") {
-				var func = new Func<Task<Stream>>(() => mvnArt.OpenLibraryFile(mavenArtifact.Version, mavenProject.Packaging));
-				await TryDownloadFile(func, base_path + mavenProject.Packaging, ErrorLevel.Error);
-
-				return base_path + mavenProject.Packaging;
-			}
-
-			// Sometimes the "Packaging" isn't useful, like "bundle" for Guava or "pom" for KotlinX Coroutines.
-			// In this case we're going to try "jar" and "aar" to try to find the real payload
-
-			// Try jar
-			var jar_func = new Func<Task<Stream>>(() => mvnArt.OpenLibraryFile(mavenArtifact.Version, "jar"));
-			var jar_result = await TryDownloadFile(jar_func, base_path + "jar", ErrorLevel.Ignore);
-
-			if (jar_result) {
-				mavenProject.Packaging = "jar";
-				return base_path + "jar";
-			}
-
-			// Try aar
-			var aar_func = new Func<Task<Stream>>(() => mvnArt.OpenLibraryFile(mavenArtifact.Version, "aar"));
-			var aar_result = await TryDownloadFile(aar_func, base_path + "aar", ErrorLevel.Ignore);
-
-			if (aar_result) {
-				mavenProject.Packaging = "aar";
-				return base_path + "aar";
-			}
-
-			throw new Exception($"Could not find artifact payload {base_path + "jar"}. [Packaging was {mavenProject.Packaging}.]");
-		}
-
-		// Return value indicates download success
-		static async Task<bool> TryDownloadFile(Func<Task<Stream>> func, string outputFile, ErrorLevel level = ErrorLevel.Info)
-		{
-			try {
-				using (var astrm = await func.Invoke())
-				using (var sw = File.Create(outputFile))
-					await astrm.CopyToAsync(sw);
-
-				return true;
-			} catch (Exception ex) {
-				if (level == ErrorLevel.Error)
-					throw;
-
-				if (level == ErrorLevel.Info)
-					Trace.WriteLine($"Failed to download {Path.GetFileName (outputFile)}: {ex.Message}");
-
-				return false;
-			}
-		}
-
-		enum ErrorLevel
-		{
-			Ignore,
-			Info,
-			Error
-		}
-
-		static List<BindingProjectModel> BuildProjectModels(BindingConfig config, Dictionary<string, Project> mavenProjects)
-		{
-			var projectModels = new List<BindingProjectModel>();
-			var exceptions = new List<Exception>();
-
-			foreach (var mavenArtifact in config.MavenArtifacts)
-			{
-				if (mavenArtifact.DependencyOnly)
-					continue;
-
-				if (!mavenProjects.TryGetValue($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
-					continue;
-
-				var projectModel = new BindingProjectModel
-				{
-					Name = mavenArtifact.ArtifactId,
-					NuGetPackageId = mavenArtifact.NugetPackageId,
-					NuGetVersionBase = mavenArtifact.NugetVersion,
-					NuGetVersionSuffix = config.NugetVersionSuffix,
-					MavenGroupId = mavenArtifact.GroupId,
-					AssemblyName = mavenArtifact.AssemblyName,
-					Config = config,
-					MavenDescription = mavenProject.Description,
-					MavenUrl = mavenProject.Url,
-					JavaSourceRepository = mavenProject.Scm?.Url,
-					Type = mavenArtifact.BindingsType ?? config.DefaultBindingsType,
-					AllowPrereleaseDependencies = mavenArtifact.AllowPrereleaseDependencies,
-				};
-
-				var licenses = mavenProject.Licenses;
-
-				// Override licenses ignore any licenses in the POM
-				if (mavenArtifact.OverrideLicenses.Count > 0) {
-					licenses = new List<License> ();
-
-					foreach (var l in mavenArtifact.OverrideLicenses) {
-						var parts = l.Split ('|');
-						licenses.Add (new License {
-							Name = parts [0],
-							Url = parts.Length > 1 ? parts [1] : string.Empty
-						});
-					}
-				}
-
-				// Verify that we have known licenses
-				foreach (var license in licenses) {
-					var license_config = config.Licenses.FirstOrDefault (l => string.Compare (l.Name, license.Name, true) == 0);
-
-					if (license_config is null) {
-						exceptions.Add (new Exception ($"Unknown license '{license.Name}' for artifact '{mavenArtifact.GroupAndArtifactId}'. This license must be added to 'config.json'."));
-						continue;
-					}
-
-					projectModel.Licenses.Add (new MavenArtifactLicense (license.Name, license.Url, license_config));
-				}
-
-				if (projectModel.Licenses.Count == 0)
-					exceptions.Add (new Exception ($"No license(s) could be found for artifact '{mavenArtifact.GroupAndArtifactId}'. Use 'overrideLicenses' in 'config.json' to specify with format 'name|url' ('url' is optional)."));
-
-				// Load license text
-				foreach (var license in projectModel.Licenses) {
-					var license_file = Path.Combine (config.BasePath!, license.LicenseConfig.File);
-					license.Text = File.ReadAllText (license_file);
-				}
-
-				foreach (var developer in mavenProject.Developers)
-					projectModel.Developers.Add (new MavenArtifactDeveloper (developer.Name));
-
-				projectModels.Add (projectModel);
-
-				var artifactDir = Path.Combine(config.BasePath!, config.ExternalsDir, mavenArtifact.GroupId!);
-				var artifactFile = Path.Combine(artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
-				var md5File = artifactFile + ".md5";
-				var sha256File = artifactFile + ".sha256";
-				var md5 = File.Exists(md5File) ? File.ReadAllText(md5File) : string.Empty;
-				var sha256 = File.Exists(sha256File) ? File.ReadAllText(sha256File) : string.Empty;
-				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId!);
-
-				var proguardFile = Path.Combine(artifactExtractDir, "proguard.txt");
-
-				projectModel.MavenArtifacts.Add(new MavenArtifactModel
-				{
-					MavenGroupId = mavenArtifact.GroupId,
-					MavenArtifactId = mavenArtifact.ArtifactId,
-					MavenArtifactPackaging = mavenProject.Packaging,
-					MavenArtifactVersion = mavenArtifact.Version,
-					MavenArtifactMd5 = md5,
-					MavenArtifactSha256 = sha256,
-					ProguardFile = File.Exists(proguardFile) ? GetRelativePath(proguardFile, config.BasePath ?? "").Replace("/", "\\") : null,
-					MavenArtifactConfig = mavenArtifact,
-					DocumentationType = mavenArtifact.DocumentationType,
-				});
-
-				List<Dependency> dependencies = new List<Dependency>();
-
-				// Find all the POM specified dependencies that we need to consider
-				foreach (var mavenDep in mavenProject.Dependencies) {
-					FixDependency(config, mavenArtifact, mavenDep, mavenProject);
-
-					if (!ShouldIncludeDependency(config, mavenArtifact, mavenDep, exceptions))
-						continue;
-
-					dependencies.Add(mavenDep);
-				}
-
-				// Add any "extraDependencies"
-				dependencies.AddRange(ParseExtraDependencies(mavenArtifact.ExtraDependencies));
-
-				// Try and map out nuget dependencies
-				foreach (var mavenDep in dependencies)
-				{
-					mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
-					mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
-
-					var depMapping = config.MavenArtifacts.FirstOrDefault(
-						ma => !string.IsNullOrEmpty(ma.Version)
-						&& ma.GroupId == mavenDep.GroupId
-						&& ma.ArtifactId == mavenDep.ArtifactId
-						&& mavenDep.Satisfies(ma.Version));
-
-					if (depMapping is null && mavenDep.IsRuntimeDependency()) {
-						StringBuilder sb = new StringBuilder ();
-						sb.AppendLine ($"");
-						sb.AppendLine ($"Artifact");
-						sb.AppendLine ($"	{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
-						sb.AppendLine ($"has unknown 'Runtime' dependency ");
-						sb.AppendLine ($"	{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
-						sb.AppendLine ($"Either fulfill or exclude this dependency.");
-
-						exceptions.Add(new Exception(sb.ToString()));
-						continue;
-					}
-
-					if (depMapping == null)
-					{
-						StringBuilder sb = new StringBuilder();
-						sb.AppendLine($"");
-						sb.AppendLine($"No matching artifact config found for: ");
-						sb.AppendLine($"			{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
-						sb.AppendLine($"to satisfy dependency of: ");
-						sb.AppendLine($"			{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
-						sb.AppendLine($"");
-						sb.AppendLine($"	Please add following json snippet to config.json:");
-						sb.AppendLine($"");
-						sb.AppendLine
-						($@"
+				if (depMapping == null) {
+					StringBuilder sb = new StringBuilder ();
+					sb.AppendLine ($"");
+					sb.AppendLine ($"No matching artifact config found for: ");
+					sb.AppendLine ($"			{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
+					sb.AppendLine ($"to satisfy dependency of: ");
+					sb.AppendLine ($"			{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
+					sb.AppendLine ($"");
+					sb.AppendLine ($"	Please add following json snippet to config.json:");
+					sb.AppendLine ($"");
+					sb.AppendLine
+					($@"
       {{
         ""groupId"": ""{mavenDep.GroupId}"",
         ""artifactId"": ""{mavenDep.ArtifactId}"",
@@ -426,221 +419,216 @@ namespace AndroidBinderator
         ""dependencyOnly"": true/false
       }}
 						");
-						sb.AppendLine($"");
-						exceptions.Add(new Exception(sb.ToString()));
-						continue;
+					sb.AppendLine ($"");
+					exceptions.Add (new Exception (sb.ToString ()));
+					continue;
+				}
+
+				projectModel.NuGetDependencies.Add (new NuGetDependencyModel {
+					IsProjectReference = !depMapping.DependencyOnly,
+					NuGetPackageId = depMapping.NugetPackageId,
+					NuGetVersionBase = depMapping.NugetVersion,
+					NuGetVersionSuffix = config.NugetVersionSuffix,
+					MavenArtifactConfig = depMapping,
+
+					MavenArtifact = new MavenArtifactModel {
+						MavenGroupId = mavenDep.GroupId,
+						MavenArtifactId = mavenDep.ArtifactId,
+						MavenArtifactVersion = mavenDep.Version,
+						MavenArtifactMd5 = md5,
+						MavenArtifactSha256 = sha256,
+						DownloadedArtifact = artifactFile,
 					}
-
-					projectModel.NuGetDependencies.Add(new NuGetDependencyModel
-					{
-						IsProjectReference = !depMapping.DependencyOnly,
-						NuGetPackageId = depMapping.NugetPackageId,
-						NuGetVersionBase = depMapping.NugetVersion,
-						NuGetVersionSuffix = config.NugetVersionSuffix,
-						MavenArtifactConfig = depMapping,
-
-						MavenArtifact = new MavenArtifactModel
-						{
-							MavenGroupId = mavenDep.GroupId,
-							MavenArtifactId = mavenDep.ArtifactId,
-							MavenArtifactVersion = mavenDep.Version,
-							MavenArtifactMd5 = md5,
-							MavenArtifactSha256 = sha256,
-							DownloadedArtifact = artifactFile,
-						}
-					});
-				}
-
+				});
 			}
 
-			if (exceptions.Any())
-				throw new AggregateException(exceptions.ToArray());
-
-
-			return projectModels;
 		}
 
-		static void AssignMetadata (BindingProjectModel project, TemplateConfig template)
-		{
-			// Calculate metadata from the config file and template file
-			var baseMetadata = new Dictionary<string, string>();
+		if (exceptions.Any ())
+			throw new AggregateException (exceptions.ToArray ());
 
-			MergeValues(baseMetadata, project.Config?.Metadata);
-			MergeValues(baseMetadata, template.Metadata);
 
-			// Add metadata for artifact
-			var artifactMetadata = new Dictionary<string, string>();
-			MergeValues(artifactMetadata, baseMetadata);
+		return projectModels;
+	}
 
-			if (project.MavenArtifacts.FirstOrDefault() is MavenArtifactModel artifact)
-				MergeValues(artifactMetadata, artifact.MavenArtifactConfig?.Metadata);
+	static void AssignMetadata (BindingProjectModel project, TemplateConfig template)
+	{
+		// Calculate metadata from the config file and template file
+		var baseMetadata = new Dictionary<string, string> ();
 
-			project.Metadata = artifactMetadata;
+		MergeValues (baseMetadata, project.Config?.Metadata);
+		MergeValues (baseMetadata, template.Metadata);
 
-			foreach (var art in project.MavenArtifacts)
-				art.Metadata = artifactMetadata;
+		// Add metadata for artifact
+		var artifactMetadata = new Dictionary<string, string> ();
+		MergeValues (artifactMetadata, baseMetadata);
 
-			// Add metadata for dependency
-			var dependencyMetadata = new Dictionary<string, string>();
-			MergeValues(dependencyMetadata, baseMetadata);
+		if (project.MavenArtifacts.FirstOrDefault () is MavenArtifactModel artifact)
+			MergeValues (artifactMetadata, artifact.MavenArtifactConfig?.Metadata);
 
-			if (project.NuGetDependencies.FirstOrDefault() is NuGetDependencyModel depMapping)
-				MergeValues(dependencyMetadata, depMapping.MavenArtifactConfig?.Metadata);
+		project.Metadata = artifactMetadata;
 
-			foreach (var dep in project.NuGetDependencies) {
-				dep.Metadata = dependencyMetadata;
-				dep.MavenArtifact!.Metadata = dependencyMetadata;
-			}
+		foreach (var art in project.MavenArtifacts)
+			art.Metadata = artifactMetadata;
+
+		// Add metadata for dependency
+		var dependencyMetadata = new Dictionary<string, string> ();
+		MergeValues (dependencyMetadata, baseMetadata);
+
+		if (project.NuGetDependencies.FirstOrDefault () is NuGetDependencyModel depMapping)
+			MergeValues (dependencyMetadata, depMapping.MavenArtifactConfig?.Metadata);
+
+		foreach (var dep in project.NuGetDependencies) {
+			dep.Metadata = dependencyMetadata;
+			dep.MavenArtifact!.Metadata = dependencyMetadata;
 		}
+	}
 
-		static bool ShouldIncludeDependency(BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
-		{
-			// Check 'artifact' list
-			if (artifact.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
-				return false;
+	static bool ShouldIncludeDependency (BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
+	{
+		// Check 'artifact' list
+		if (artifact.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
+			return false;
 
-			// Check 'global' list
-			if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
-				return false;
+		// Check 'global' list
+		if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
+			return false;
 
-			// We always care about 'compile' scoped dependencies
-			if (dependency.IsCompileDependency ())
-				return true;
-
-			// If we're not processing Runtime dependencies then ignore the rest
-			if (!config.StrictRuntimeDependencies)
-				return false;
-
-			// The only other thing we may care about is 'runtime', bail if this isn't 'runtime'
-			if (!dependency.IsRuntimeDependency ())
-				return false;
-
+		// We always care about 'compile' scoped dependencies
+		if (dependency.IsCompileDependency ())
 			return true;
-		}
 
-		static string GetRelativePath(string filespec, string folder)
-		{
-			Uri pathUri = new Uri(filespec);
-			// Folders must end in a slash
-			if (!folder.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase))
-				folder += Path.DirectorySeparatorChar;
-			Uri folderUri = new Uri(folder);
-			return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', Path.DirectorySeparatorChar));
-		}
+		// If we're not processing Runtime dependencies then ignore the rest
+		if (!config.StrictRuntimeDependencies)
+			return false;
 
-		static Dictionary<string, string> MergeValues(Dictionary<string, string>? dest, Dictionary<string, string>? src)
-		{
-			dest = dest ?? new Dictionary<string, string>();
-			if (src != null)
-			{
-				foreach (var kvp in src)
-				{
-					dest[kvp.Key] = kvp.Value;
-				}
+		// The only other thing we may care about is 'runtime', bail if this isn't 'runtime'
+		if (!dependency.IsRuntimeDependency ())
+			return false;
+
+		return true;
+	}
+
+	static string GetRelativePath (string filespec, string folder)
+	{
+		Uri pathUri = new Uri (filespec);
+		// Folders must end in a slash
+		if (!folder.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase))
+			folder += Path.DirectorySeparatorChar;
+		Uri folderUri = new Uri (folder);
+		return Uri.UnescapeDataString (folderUri.MakeRelativeUri (pathUri).ToString ().Replace ('/', Path.DirectorySeparatorChar));
+	}
+
+	static Dictionary<string, string> MergeValues (Dictionary<string, string>? dest, Dictionary<string, string>? src)
+	{
+		dest = dest ?? new Dictionary<string, string> ();
+		if (src != null) {
+			foreach (var kvp in src) {
+				dest [kvp.Key] = kvp.Value;
 			}
-			return dest;
+		}
+		return dest;
+	}
+
+	static void FixDependency (BindingConfig config, MavenArtifactConfig mavenArtifact, Dependency dependency, Project project)
+	{
+		// Handle Parent POM
+		if ((string.IsNullOrEmpty (dependency.Version) || string.IsNullOrEmpty (dependency.Scope)) && project.Parent != null) {
+			var parent_pom = GetParentPom (config, mavenArtifact, project.Parent);
+			var parent_dependency = parent_pom.FindParentDependency (dependency);
+
+			// Try to fish a version out of the parent POM
+			if (string.IsNullOrEmpty (dependency.Version))
+				dependency.Version = ReplaceVersionProperties (parent_pom, parent_dependency?.Version);
+
+			// Try to fish a scope out of the parent POM
+			if (string.IsNullOrEmpty (dependency.Scope))
+				dependency.Scope = parent_dependency?.Scope;
 		}
 
-		static void FixDependency(BindingConfig config, MavenArtifactConfig mavenArtifact, Dependency dependency, Project project)
-		{
-			// Handle Parent POM
-			if ((string.IsNullOrEmpty(dependency.Version) || string.IsNullOrEmpty(dependency.Scope)) && project.Parent != null) {
-				var parent_pom = GetParentPom(config, mavenArtifact, project.Parent);
-				var parent_dependency = parent_pom.FindParentDependency(dependency);
+		var version = dependency.Version;
 
-				// Try to fish a version out of the parent POM
-				if (string.IsNullOrEmpty(dependency.Version))
-					dependency.Version = ReplaceVersionProperties(parent_pom, parent_dependency?.Version);
+		if (string.IsNullOrWhiteSpace (version))
+			return;
 
-				// Try to fish a scope out of the parent POM
-				if (string.IsNullOrEmpty(dependency.Scope))
-					dependency.Scope = parent_dependency?.Scope;
-			}
+		version = ReplaceVersionProperties (project, version);
 
-			var version = dependency.Version;
+		// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
+		// Fix them to be "1.0".
+		// https://github.com/NuGet/Home/issues/10342
+		if (!version.Contains ("."))
+			version += ".0";
 
-			if (string.IsNullOrWhiteSpace(version))
-				return;
+		dependency.Version = version;
+	}
 
-			version = ReplaceVersionProperties(project, version);
-
-			// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
-			// Fix them to be "1.0".
-			// https://github.com/NuGet/Home/issues/10342
-			if (!version.Contains("."))
-				version += ".0";
-
-			dependency.Version = version;
-		}
-
-		[return:NotNullIfNotNull (nameof (version))]
-		static string? ReplaceVersionProperties(Project project, string? version)
-		{
-			// Handle versions with Properties, like:
-			// <properties>
-			//   <java.version>1.8</java.version>
-			//   <gson.version>2.8.6</gson.version>
-			// </properties>
-			// <dependencies>
-			//   <dependency>
-			//     <groupId>com.google.code.gson</groupId>
-			//     <artifactId>gson</artifactId>
-			//     <version>${gson.version}</version>
-			//   </dependency>
-			// </dependencies>
-			if (string.IsNullOrWhiteSpace(version) || project?.Properties == null)
-				return version;
-
-			foreach (var prop in project.Properties.Any)
-				version = version!.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
-
+	[return: NotNullIfNotNull (nameof (version))]
+	static string? ReplaceVersionProperties (Project project, string? version)
+	{
+		// Handle versions with Properties, like:
+		// <properties>
+		//   <java.version>1.8</java.version>
+		//   <gson.version>2.8.6</gson.version>
+		// </properties>
+		// <dependencies>
+		//   <dependency>
+		//     <groupId>com.google.code.gson</groupId>
+		//     <artifactId>gson</artifactId>
+		//     <version>${gson.version}</version>
+		//   </dependency>
+		// </dependencies>
+		if (string.IsNullOrWhiteSpace (version) || project?.Properties == null)
 			return version;
-		}
 
-		static Dictionary<string, Project> parent_poms = new Dictionary<string, Project>();
+		foreach (var prop in project.Properties.Any)
+			version = version!.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
 
-		static Project GetParentPom(BindingConfig config, MavenArtifactConfig mavenArtifact, Parent parent)
-		{
-			var key = $"{parent.GroupId}.{parent.ArtifactId}-{parent.Version}";
+		return version;
+	}
 
-			if (parent_poms.TryGetValue(key, out var cached_pom))
-				return cached_pom;
+	static Dictionary<string, Project> parent_poms = new Dictionary<string, Project> ();
 
-			var maven = MavenFactory.GetMavenRepository(config, mavenArtifact);
-			maven.Populate(parent.GroupId, parent.ArtifactId).Wait();
-			var pom = maven.GetProjectAsync(parent.GroupId, parent.ArtifactId, parent.Version).Result;
+	static Project GetParentPom (BindingConfig config, MavenArtifactConfig mavenArtifact, Parent parent)
+	{
+		var key = $"{parent.GroupId}.{parent.ArtifactId}-{parent.Version}";
 
-			parent_poms.Add(key, pom);
+		if (parent_poms.TryGetValue (key, out var cached_pom))
+			return cached_pom;
 
-			return pom;
-		}
+		var maven = MavenFactory.GetMavenRepository (config, mavenArtifact);
+		maven.Populate (parent.GroupId, parent.ArtifactId).Wait ();
+		var pom = maven.GetProjectAsync (parent.GroupId, parent.ArtifactId, parent.Version).Result;
 
-		static IEnumerable<Dependency> ParseExtraDependencies(string? dependencies)
-		{
-			if (string.IsNullOrWhiteSpace(dependencies))
-				yield break;
+		parent_poms.Add (key, pom);
 
-			// Format is: "groupid.artifactid:version"
-			// Version is optional
-			var deps = dependencies.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+		return pom;
+	}
 
-			foreach (var dep in deps) {
-				var id = dep;
-				var version = string.Empty;
+	static IEnumerable<Dependency> ParseExtraDependencies (string? dependencies)
+	{
+		if (string.IsNullOrWhiteSpace (dependencies))
+			yield break;
 
-				if (dep.Contains(':')) {
-					id = dep.Substring(0, dep.IndexOf(':'));
-					version = dep.Substring(dep.IndexOf(':') + 1);
-				}
+		// Format is: "groupid.artifactid:version"
+		// Version is optional
+		var deps = dependencies.Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
-				var result = new Dependency {
-					GroupId = id.Substring(0, id.LastIndexOf(".")),
-					ArtifactId = id.Substring(id.LastIndexOf(".") + 1),
-					Version = string.IsNullOrWhiteSpace (version) ? "0.0.0" : version
-				};
+		foreach (var dep in deps) {
+			var id = dep;
+			var version = string.Empty;
 
-				yield return result;
+			if (dep.Contains (':')) {
+				id = dep.Substring (0, dep.IndexOf (':'));
+				version = dep.Substring (dep.IndexOf (':') + 1);
 			}
+
+			var result = new Dependency {
+				GroupId = id.Substring (0, id.LastIndexOf (".")),
+				ArtifactId = id.Substring (id.LastIndexOf (".") + 1),
+				Version = string.IsNullOrWhiteSpace (version) ? "0.0.0" : version
+			};
+
+			yield return result;
 		}
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -1,16 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
-using MavenNet.Models;
 using RazorLight;
-using MavenGroup = MavenNet.Models.Group;
 
 namespace AndroidBinderator;
 
@@ -29,9 +22,6 @@ public class Engine
 
 	public static async Task BinderateAsync (BindingConfig config)
 	{
-		// Prime our Maven repositories
-		await MavenFactory.Initialize (config);
-
 		if (config.DownloadExternals) {
 			var artifactDir = Path.Combine (config.BasePath!, config.ExternalsDir);
 			if (!Directory.Exists (artifactDir))
@@ -43,58 +33,53 @@ public class Engine
 
 	static async Task ProcessConfig (BindingConfig config)
 	{
-		var mavenProjects = new Dictionary<string, Project> ();
-		var mavenGroups = new List<MavenGroup> ();
+		var slnProjModels = new Dictionary<string, BindingProjectModel> ();
 
-		foreach (var artifact in config.MavenArtifacts) {
-			if (artifact.DependencyOnly)
-				continue;
+		var models = BindingProjectConverter.Convert (config);
 
-			var maven = MavenFactory.GetMavenRepository (config, artifact);
-
-			var mavenGroup = maven.Groups.FirstOrDefault (g => g.Id == artifact.GroupId);
-
-			Project? project = null;
-
-			project = await maven.GetProjectAsync (artifact.GroupId, artifact.ArtifactId, artifact.Version);
-
-			if (project != null)
-				mavenProjects.Add ($"{artifact.GroupId}/{artifact.ArtifactId}-{artifact.Version}", project);
-		}
+		BindingProjectDependencyVerifier.Verify (config, models);
 
 		if (config.DownloadExternals)
-			await DownloadArtifacts (config, mavenProjects);
+			MavenArtifactDownloader.Download (config, models);
 
 		// This isn't really correct, as it could be .aar, but it'll do until we hit that case and need to fix it
-		foreach (var artifact in mavenProjects.Values.Where (a => a.Packaging == "bundle"))
-			artifact.Packaging = "jar";
+		foreach (var artifact in models.Where (a => a.MavenArtifacts.First ().MavenArtifactPackaging == "bundle"))
+			artifact.MavenArtifacts.First ().MavenArtifactPackaging = "jar";
 
-		var slnProjModels = new Dictionary<string, BindingProjectModel> ();
-		var models = BuildProjectModels (config, mavenProjects);
+		// Look for Proguard files extracted from AARs
+		foreach (var model in models) {
+			var ma = model.MavenArtifacts.First ();
 
-		var json = Newtonsoft.Json.JsonConvert.SerializeObject (models);
+			if (!ma.ProguardFile.HasValue ())
+				continue;
 
-		if (config.Debug.DumpModels)
+			if (File.Exists (ma.ProguardFile))
+				ma.ProguardFile = Extensions.GetRelativePath (ma.ProguardFile, config.BasePath ?? "").Replace ("/", "\\");
+			else
+				ma.ProguardFile = null;
+		}
+
+		if (config.Debug.DumpModels) {
+			var json = Newtonsoft.Json.JsonConvert.SerializeObject (models);
 			File.WriteAllText (Path.Combine (config.BasePath!, "models.json"), json);
+		}
 
 		var engine = new RazorLightEngineBuilder ()
 			.UseMemoryCachingProvider ()
+			.UseFileSystemProject (config.BasePath)
 			.Build ();
 
 		foreach (var model in models) {
 			var template_set = config.GetTemplateSet (model.MavenArtifacts.FirstOrDefault ()?.MavenArtifactConfig?.TemplateSet);
 
 			foreach (var template in template_set.Templates) {
-				var inputTemplateFile = Path.Combine (config.BasePath!, template.TemplateFile);
-				var templateSrc = File.ReadAllText (inputTemplateFile);
-
 				AssignMetadata (model, template);
 
 				var outputFile = new FileInfo (template.GetOutputFile (config, model))!;
 				if (!outputFile.Directory!.Exists)
 					outputFile.Directory.Create ();
 
-				string result = await engine.CompileRenderAsync (inputTemplateFile, templateSrc, model);
+				var result = await engine.CompileRenderAsync (template.TemplateFile, model);
 
 				File.WriteAllText (outputFile.FullName, result);
 
@@ -109,346 +94,6 @@ public class Engine
 			var sln = SolutionFileBuilder.Build (config, slnProjModels);
 			File.WriteAllText (slnPath, sln);
 		}
-	}
-
-	static async Task DownloadArtifacts (BindingConfig config, Dictionary<string, Project> mavenProjects)
-	{
-		var httpClient = new HttpClient ();
-
-		foreach (var mavenArtifact in config.MavenArtifacts) {
-			// Skip downloading dependencies
-			if (mavenArtifact.DependencyOnly)
-				continue;
-
-			var maven = MavenFactory.GetMavenRepository (config, mavenArtifact);
-			var version = mavenArtifact.Version;
-
-			if (!mavenProjects.TryGetValue ($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
-				continue;
-
-			var artifactDir = Path.Combine (
-				config.BasePath!,
-				config.ExternalsDir,
-				mavenArtifact.GroupId!);
-
-			var artifactExtractDir = Path.Combine (artifactDir, mavenArtifact.ArtifactId!);
-
-			Directory.CreateDirectory (artifactDir);
-			Directory.CreateDirectory (artifactExtractDir);
-
-			var mvnArt = maven.Groups.FirstOrDefault (g => g.Id == mavenArtifact.GroupId)?.Artifacts?.FirstOrDefault (a => a.Id == mavenArtifact.ArtifactId);
-
-			if (mvnArt is null)
-				throw new InvalidOperationException ($"Could not find artifact {mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}");
-
-			// Download artifact
-			var artifactFile = await DownloadPayload (mvnArt, mavenArtifact, mavenProject, artifactDir, config);
-
-			// Determine MD5
-			var md5File = artifactFile + ".md5";
-			var md5_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging + ".md5"));
-
-			if (!(await TryDownloadFile (md5_func, md5File, ErrorLevel.Info))) {
-				// Then hash the downloaded artifact
-				using (var file = File.OpenRead (artifactFile))
-					File.WriteAllText (md5File, Util.HashMd5 (file));
-			}
-
-			// Determine Sha256
-			var sha256File = artifactFile + ".sha256";
-			var sha_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging + ".sha256"));
-
-			// First try download, this almost certainly won't work
-			// but in case Maven ever starts supporting sha256 it should start
-			// they currently support .sha1 so there's no reason to believe the naming
-			// convention should be any different, and one day .sha256 may exist
-			if (!(await TryDownloadFile (sha_func, sha256File, ErrorLevel.Ignore))) {
-				// Create Sha256 hash if we couldn't download
-				using (var file = File.OpenRead (artifactFile))
-					File.WriteAllText (sha256File, Util.HashSha256 (file));
-			}
-
-			var base_file_name = Path.Combine (artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}" : $"{mavenArtifact.ArtifactId}");
-
-			if (config.DownloadJavaSourceJars) {
-				var source_file = base_file_name + "-sources.jar";
-				var source_func = new Func<Task<Stream>> (() => maven.OpenArtifactSourcesFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-				await TryDownloadFile (source_func, source_file, ErrorLevel.Info);
-			}
-
-			if (config.DownloadPoms) {
-				var pom_file = base_file_name + ".pom";
-				var pom_func = new Func<Task<Stream>> (() => maven.OpenArtifactPomFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-				await TryDownloadFile (pom_func, pom_file, ErrorLevel.Info);
-			}
-
-			if (config.DownloadJavaDocJars) {
-				var javadoc_file = base_file_name + "-javadoc.jar";
-				var javadoc_func = new Func<Task<Stream>> (() => maven.OpenArtifactDocsFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId, version));
-				await TryDownloadFile (javadoc_func, javadoc_file, ErrorLevel.Info);
-			}
-
-			if (config.DownloadMetadataFiles) {
-				var metadata_file = base_file_name + "-metadata.xml";
-				var metadata_func = new Func<Task<Stream>> (() => maven.OpenMavenMetadataFile (mavenArtifact.GroupId, mavenArtifact.ArtifactId));
-				await TryDownloadFile (metadata_func, metadata_file, ErrorLevel.Info);
-			}
-
-			if (Directory.Exists (artifactExtractDir))
-				Directory.Delete (artifactExtractDir, true);
-
-			// Unzip artifact into externals
-			if (mavenProject.Packaging.ToLowerInvariant () == "aar")
-				ZipFile.ExtractToDirectory (artifactFile, artifactExtractDir);
-		}
-	}
-
-	// Returns artifact output path
-	static async Task<string> DownloadPayload (Artifact mvnArt, MavenArtifactConfig mavenArtifact, Project mavenProject, string artifactDir, BindingConfig config)
-	{
-		var package_prefix = config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}." : string.Empty;
-		package_prefix += $"{mavenArtifact.ArtifactId}.";
-
-		var base_path = Path.Combine (artifactDir, package_prefix);
-
-		if (mavenProject.Packaging == "jar" || mavenProject.Packaging == "aar") {
-			var func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, mavenProject.Packaging));
-			await TryDownloadFile (func, base_path + mavenProject.Packaging, ErrorLevel.Error);
-
-			return base_path + mavenProject.Packaging;
-		}
-
-		// Sometimes the "Packaging" isn't useful, like "bundle" for Guava or "pom" for KotlinX Coroutines.
-		// In this case we're going to try "jar" and "aar" to try to find the real payload
-
-		// Try jar
-		var jar_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, "jar"));
-		var jar_result = await TryDownloadFile (jar_func, base_path + "jar", ErrorLevel.Ignore);
-
-		if (jar_result) {
-			mavenProject.Packaging = "jar";
-			return base_path + "jar";
-		}
-
-		// Try aar
-		var aar_func = new Func<Task<Stream>> (() => mvnArt.OpenLibraryFile (mavenArtifact.Version, "aar"));
-		var aar_result = await TryDownloadFile (aar_func, base_path + "aar", ErrorLevel.Ignore);
-
-		if (aar_result) {
-			mavenProject.Packaging = "aar";
-			return base_path + "aar";
-		}
-
-		throw new Exception ($"Could not find artifact payload {base_path + "jar"}. [Packaging was {mavenProject.Packaging}.]");
-	}
-
-	// Return value indicates download success
-	static async Task<bool> TryDownloadFile (Func<Task<Stream>> func, string outputFile, ErrorLevel level = ErrorLevel.Info)
-	{
-		try {
-			using (var astrm = await func.Invoke ())
-			using (var sw = File.Create (outputFile))
-				await astrm.CopyToAsync (sw);
-
-			return true;
-		} catch (Exception ex) {
-			if (level == ErrorLevel.Error)
-				throw;
-
-			if (level == ErrorLevel.Info)
-				Trace.WriteLine ($"Failed to download {Path.GetFileName (outputFile)}: {ex.Message}");
-
-			return false;
-		}
-	}
-
-	enum ErrorLevel
-	{
-		Ignore,
-		Info,
-		Error
-	}
-
-	static List<BindingProjectModel> BuildProjectModels (BindingConfig config, Dictionary<string, Project> mavenProjects)
-	{
-		var projectModels = new List<BindingProjectModel> ();
-		var exceptions = new List<Exception> ();
-
-		foreach (var mavenArtifact in config.MavenArtifacts) {
-			if (mavenArtifact.DependencyOnly)
-				continue;
-
-			if (!mavenProjects.TryGetValue ($"{mavenArtifact.GroupId}/{mavenArtifact.ArtifactId}-{mavenArtifact.Version}", out var mavenProject))
-				continue;
-
-			var projectModel = new BindingProjectModel {
-				Name = mavenArtifact.ArtifactId,
-				NuGetPackageId = mavenArtifact.NugetPackageId,
-				NuGetVersionBase = mavenArtifact.NugetVersion,
-				NuGetVersionSuffix = config.NugetVersionSuffix,
-				MavenGroupId = mavenArtifact.GroupId,
-				AssemblyName = mavenArtifact.AssemblyName,
-				Config = config,
-				MavenDescription = mavenProject.Description,
-				MavenUrl = mavenProject.Url,
-				JavaSourceRepository = mavenProject.Scm?.Url,
-				Type = mavenArtifact.BindingsType ?? config.DefaultBindingsType,
-				AllowPrereleaseDependencies = mavenArtifact.AllowPrereleaseDependencies,
-			};
-
-			var licenses = mavenProject.Licenses;
-
-			// Override licenses ignore any licenses in the POM
-			if (mavenArtifact.OverrideLicenses.Count > 0) {
-				licenses = new List<License> ();
-
-				foreach (var l in mavenArtifact.OverrideLicenses) {
-					var parts = l.Split ('|');
-					licenses.Add (new License {
-						Name = parts [0],
-						Url = parts.Length > 1 ? parts [1] : string.Empty
-					});
-				}
-			}
-
-			// Verify that we have known licenses
-			foreach (var license in licenses) {
-				var license_config = config.Licenses.FirstOrDefault (l => string.Compare (l.Name, license.Name, true) == 0);
-
-				if (license_config is null) {
-					exceptions.Add (new Exception ($"Unknown license '{license.Name}' for artifact '{mavenArtifact.GroupAndArtifactId}'. This license must be added to 'config.json'."));
-					continue;
-				}
-
-				projectModel.Licenses.Add (new MavenArtifactLicense (license.Name, license.Url, license_config));
-			}
-
-			if (projectModel.Licenses.Count == 0)
-				exceptions.Add (new Exception ($"No license(s) could be found for artifact '{mavenArtifact.GroupAndArtifactId}'. Use 'overrideLicenses' in 'config.json' to specify with format 'name|url' ('url' is optional)."));
-
-			// Load license text
-			foreach (var license in projectModel.Licenses) {
-				var license_file = Path.Combine (config.BasePath!, license.LicenseConfig.File);
-				license.Text = File.ReadAllText (license_file);
-			}
-
-			foreach (var developer in mavenProject.Developers)
-				projectModel.Developers.Add (new MavenArtifactDeveloper (developer.Name));
-
-			projectModels.Add (projectModel);
-
-			var artifactDir = Path.Combine (config.BasePath!, config.ExternalsDir, mavenArtifact.GroupId!);
-			var artifactFile = Path.Combine (artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
-			var md5File = artifactFile + ".md5";
-			var sha256File = artifactFile + ".sha256";
-			var md5 = File.Exists (md5File) ? File.ReadAllText (md5File) : string.Empty;
-			var sha256 = File.Exists (sha256File) ? File.ReadAllText (sha256File) : string.Empty;
-			var artifactExtractDir = Path.Combine (artifactDir, mavenArtifact.ArtifactId!);
-
-			var proguardFile = Path.Combine (artifactExtractDir, "proguard.txt");
-
-			projectModel.MavenArtifacts.Add (new MavenArtifactModel {
-				MavenGroupId = mavenArtifact.GroupId,
-				MavenArtifactId = mavenArtifact.ArtifactId,
-				MavenArtifactPackaging = mavenProject.Packaging,
-				MavenArtifactVersion = mavenArtifact.Version,
-				MavenArtifactMd5 = md5,
-				MavenArtifactSha256 = sha256,
-				ProguardFile = File.Exists (proguardFile) ? GetRelativePath (proguardFile, config.BasePath ?? "").Replace ("/", "\\") : null,
-				MavenArtifactConfig = mavenArtifact,
-				DocumentationType = mavenArtifact.DocumentationType,
-			});
-
-			List<Dependency> dependencies = new List<Dependency> ();
-
-			// Find all the POM specified dependencies that we need to consider
-			foreach (var mavenDep in mavenProject.Dependencies) {
-				FixDependency (config, mavenArtifact, mavenDep, mavenProject);
-
-				if (!ShouldIncludeDependency (config, mavenArtifact, mavenDep, exceptions))
-					continue;
-
-				dependencies.Add (mavenDep);
-			}
-
-			// Add any "extraDependencies"
-			dependencies.AddRange (ParseExtraDependencies (mavenArtifact.ExtraDependencies));
-
-			// Try and map out nuget dependencies
-			foreach (var mavenDep in dependencies) {
-				mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
-				mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
-
-				var depMapping = config.MavenArtifacts.FirstOrDefault (
-					ma => !string.IsNullOrEmpty (ma.Version)
-					&& ma.GroupId == mavenDep.GroupId
-					&& ma.ArtifactId == mavenDep.ArtifactId
-					&& mavenDep.Satisfies (ma.Version));
-
-				if (depMapping is null && mavenDep.IsRuntimeDependency ()) {
-					StringBuilder sb = new StringBuilder ();
-					sb.AppendLine ($"");
-					sb.AppendLine ($"Artifact");
-					sb.AppendLine ($"	{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
-					sb.AppendLine ($"has unknown 'Runtime' dependency ");
-					sb.AppendLine ($"	{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
-					sb.AppendLine ($"Either fulfill or exclude this dependency.");
-
-					exceptions.Add (new Exception (sb.ToString ()));
-					continue;
-				}
-
-				if (depMapping == null) {
-					StringBuilder sb = new StringBuilder ();
-					sb.AppendLine ($"");
-					sb.AppendLine ($"No matching artifact config found for: ");
-					sb.AppendLine ($"			{mavenDep.GroupId}.{mavenDep.ArtifactId}:{mavenDep.Version}");
-					sb.AppendLine ($"to satisfy dependency of: ");
-					sb.AppendLine ($"			{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}:{mavenArtifact.Version}");
-					sb.AppendLine ($"");
-					sb.AppendLine ($"	Please add following json snippet to config.json:");
-					sb.AppendLine ($"");
-					sb.AppendLine
-					($@"
-      {{
-        ""groupId"": ""{mavenDep.GroupId}"",
-        ""artifactId"": ""{mavenDep.ArtifactId}"",
-        ""version"": ""{mavenDep.Version}"",
-        ""nugetVersion"": ""CHECK PREFIX {mavenDep.Version}"",
-        ""nugetId"": ""CHECK NUGET ID"",
-        ""dependencyOnly"": true/false
-      }}
-						");
-					sb.AppendLine ($"");
-					exceptions.Add (new Exception (sb.ToString ()));
-					continue;
-				}
-
-				projectModel.NuGetDependencies.Add (new NuGetDependencyModel {
-					IsProjectReference = !depMapping.DependencyOnly,
-					NuGetPackageId = depMapping.NugetPackageId,
-					NuGetVersionBase = depMapping.NugetVersion,
-					NuGetVersionSuffix = config.NugetVersionSuffix,
-					MavenArtifactConfig = depMapping,
-
-					MavenArtifact = new MavenArtifactModel {
-						MavenGroupId = mavenDep.GroupId,
-						MavenArtifactId = mavenDep.ArtifactId,
-						MavenArtifactVersion = mavenDep.Version,
-						MavenArtifactMd5 = md5,
-						MavenArtifactSha256 = sha256,
-						DownloadedArtifact = artifactFile,
-					}
-				});
-			}
-
-		}
-
-		if (exceptions.Any ())
-			throw new AggregateException (exceptions.ToArray ());
-
-
-		return projectModels;
 	}
 
 	static void AssignMetadata (BindingProjectModel project, TemplateConfig template)
@@ -484,41 +129,6 @@ public class Engine
 		}
 	}
 
-	static bool ShouldIncludeDependency (BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
-	{
-		// Check 'artifact' list
-		if (artifact.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
-			return false;
-
-		// Check 'global' list
-		if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
-			return false;
-
-		// We always care about 'compile' scoped dependencies
-		if (dependency.IsCompileDependency ())
-			return true;
-
-		// If we're not processing Runtime dependencies then ignore the rest
-		if (!config.StrictRuntimeDependencies)
-			return false;
-
-		// The only other thing we may care about is 'runtime', bail if this isn't 'runtime'
-		if (!dependency.IsRuntimeDependency ())
-			return false;
-
-		return true;
-	}
-
-	static string GetRelativePath (string filespec, string folder)
-	{
-		Uri pathUri = new Uri (filespec);
-		// Folders must end in a slash
-		if (!folder.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase))
-			folder += Path.DirectorySeparatorChar;
-		Uri folderUri = new Uri (folder);
-		return Uri.UnescapeDataString (folderUri.MakeRelativeUri (pathUri).ToString ().Replace ('/', Path.DirectorySeparatorChar));
-	}
-
 	static Dictionary<string, string> MergeValues (Dictionary<string, string>? dest, Dictionary<string, string>? src)
 	{
 		dest = dest ?? new Dictionary<string, string> ();
@@ -528,107 +138,5 @@ public class Engine
 			}
 		}
 		return dest;
-	}
-
-	static void FixDependency (BindingConfig config, MavenArtifactConfig mavenArtifact, Dependency dependency, Project project)
-	{
-		// Handle Parent POM
-		if ((string.IsNullOrEmpty (dependency.Version) || string.IsNullOrEmpty (dependency.Scope)) && project.Parent != null) {
-			var parent_pom = GetParentPom (config, mavenArtifact, project.Parent);
-			var parent_dependency = parent_pom.FindParentDependency (dependency);
-
-			// Try to fish a version out of the parent POM
-			if (string.IsNullOrEmpty (dependency.Version))
-				dependency.Version = ReplaceVersionProperties (parent_pom, parent_dependency?.Version);
-
-			// Try to fish a scope out of the parent POM
-			if (string.IsNullOrEmpty (dependency.Scope))
-				dependency.Scope = parent_dependency?.Scope;
-		}
-
-		var version = dependency.Version;
-
-		if (string.IsNullOrWhiteSpace (version))
-			return;
-
-		version = ReplaceVersionProperties (project, version);
-
-		// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
-		// Fix them to be "1.0".
-		// https://github.com/NuGet/Home/issues/10342
-		if (!version.Contains ("."))
-			version += ".0";
-
-		dependency.Version = version;
-	}
-
-	[return: NotNullIfNotNull (nameof (version))]
-	static string? ReplaceVersionProperties (Project project, string? version)
-	{
-		// Handle versions with Properties, like:
-		// <properties>
-		//   <java.version>1.8</java.version>
-		//   <gson.version>2.8.6</gson.version>
-		// </properties>
-		// <dependencies>
-		//   <dependency>
-		//     <groupId>com.google.code.gson</groupId>
-		//     <artifactId>gson</artifactId>
-		//     <version>${gson.version}</version>
-		//   </dependency>
-		// </dependencies>
-		if (string.IsNullOrWhiteSpace (version) || project?.Properties == null)
-			return version;
-
-		foreach (var prop in project.Properties.Any)
-			version = version!.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
-
-		return version;
-	}
-
-	static Dictionary<string, Project> parent_poms = new Dictionary<string, Project> ();
-
-	static Project GetParentPom (BindingConfig config, MavenArtifactConfig mavenArtifact, Parent parent)
-	{
-		var key = $"{parent.GroupId}.{parent.ArtifactId}-{parent.Version}";
-
-		if (parent_poms.TryGetValue (key, out var cached_pom))
-			return cached_pom;
-
-		var maven = MavenFactory.GetMavenRepository (config, mavenArtifact);
-		maven.Populate (parent.GroupId, parent.ArtifactId).Wait ();
-		var pom = maven.GetProjectAsync (parent.GroupId, parent.ArtifactId, parent.Version).Result;
-
-		parent_poms.Add (key, pom);
-
-		return pom;
-	}
-
-	static IEnumerable<Dependency> ParseExtraDependencies (string? dependencies)
-	{
-		if (string.IsNullOrWhiteSpace (dependencies))
-			yield break;
-
-		// Format is: "groupid.artifactid:version"
-		// Version is optional
-		var deps = dependencies.Split (new [] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
-		foreach (var dep in deps) {
-			var id = dep;
-			var version = string.Empty;
-
-			if (dep.Contains (':')) {
-				id = dep.Substring (0, dep.IndexOf (':'));
-				version = dep.Substring (dep.IndexOf (':') + 1);
-			}
-
-			var result = new Dependency {
-				GroupId = id.Substring (0, id.LastIndexOf (".")),
-				ArtifactId = id.Substring (id.LastIndexOf (".") + 1),
-				Version = string.IsNullOrWhiteSpace (version) ? "0.0.0" : version
-			};
-
-			yield return result;
-		}
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
@@ -1,28 +1,25 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using MavenNet.Models;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public static class Extensions
 {
-	public static class Extensions
+	public static bool HasValue ([NotNullWhen (true)] this string? str) => !string.IsNullOrWhiteSpace (str);
+
+	public static string OrEmpty (this string? value) => value ?? string.Empty;
+
+	public static string GroupAndArtifactId (this Dependency dependency) => $"{dependency.GroupId}.{dependency.ArtifactId}";
+
+	public static bool IsCompileDependency (this Dependency dependency) => string.IsNullOrWhiteSpace (dependency.Scope) || dependency.Scope.ToLowerInvariant ().Equals ("compile");
+
+	public static bool IsRuntimeDependency (this Dependency dependency) => dependency?.Scope != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
+
+	public static Dependency? FindParentDependency (this Project project, Dependency dependency)
 	{
-		public static bool HasValue ([NotNullWhen (true)] this string? str) => !string.IsNullOrWhiteSpace (str);
-
-		public static string OrEmpty (this string? value) => value ?? string.Empty;
-
-		public static string GroupAndArtifactId (this Dependency dependency) => $"{dependency.GroupId}.{dependency.ArtifactId}";
-
-		public static bool IsCompileDependency (this Dependency dependency) => string.IsNullOrWhiteSpace (dependency.Scope) || dependency.Scope.ToLowerInvariant ().Equals ("compile");
-
-		public static bool IsRuntimeDependency (this Dependency dependency) => dependency?.Scope != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
-
-		public static Dependency? FindParentDependency (this Project project, Dependency dependency)
-		{
-			return project.DependencyManagement?.Dependencies?.FirstOrDefault (
-				d => d.GroupAndArtifactId () == dependency.GroupAndArtifactId () && d.Classifier != "sources");
-		}
+		return project.DependencyManagement?.Dependencies?.FirstOrDefault (
+			d => d.GroupAndArtifactId () == dependency.GroupAndArtifactId () && d.Classifier != "sources");
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
-using MavenNet.Models;
+using System.Threading.Tasks;
+using Java.Interop.Tools.Maven;
+using Java.Interop.Tools.Maven.Models;
+using Java.Interop.Tools.Maven.Repositories;
 
 namespace AndroidBinderator;
 
@@ -17,9 +22,73 @@ public static class Extensions
 
 	public static bool IsRuntimeDependency (this Dependency dependency) => dependency?.Scope != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
 
+	public static Artifact ToArtifact (this MavenArtifactConfig config) => new Artifact (config.GroupId!, config.ArtifactId!, config.Version);
+
+	public static Artifact ToArtifact (this Parent parent) => new Artifact (parent.GroupId!, parent.ArtifactId!, parent.Version!);
+
+	public static Artifact ToArtifact (this BindingProjectModel parent) => new Artifact (parent.MavenGroupId!, parent.MavenArtifacts.First ().MavenArtifactId!, parent.MavenArtifacts.First ().MavenArtifactVersion!);
+
 	public static Dependency? FindParentDependency (this Project project, Dependency dependency)
 	{
 		return project.DependencyManagement?.Dependencies?.FirstOrDefault (
 			d => d.GroupAndArtifactId () == dependency.GroupAndArtifactId () && d.Classifier != "sources");
+	}
+
+	public async static Task<Project> GetProjectAsync (this MavenRepository repository, string groupId, string artifactId, string version)
+	{
+		var project = await repository.GetProjectAsync (groupId, artifactId, version);
+
+		if (project is null)
+			throw new InvalidOperationException ($"Could not find project {groupId}:{artifactId}:{version}");
+		return project;
+	}
+
+	public static string GetRelativePath (string filespec, string folder)
+	{
+		Uri pathUri = new Uri (filespec);
+		// Folders must end in a slash
+		if (!folder.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase))
+			folder += Path.DirectorySeparatorChar;
+		Uri folderUri = new Uri (folder);
+		return Uri.UnescapeDataString (folderUri.MakeRelativeUri (pathUri).ToString ().Replace ('/', Path.DirectorySeparatorChar));
+	}
+
+	public static bool Satisfies (this Dependency dependency, string value)
+	{
+		if (!dependency.Version.HasValue ())
+			throw new Exception ("no value");
+
+		var version = MavenVersion.Parse (value);
+		var range = MavenVersionRange.Parse (dependency.Version);
+
+		return range.Any (r => r.ContainsVersion (version));
+	}
+}
+
+public class ProjectResolver : IProjectResolver
+{
+	readonly CachedMavenRepository repository;
+
+	public Dictionary<string, string> ResolvedPoms { get; } = new Dictionary<string, string> ();
+
+	public ProjectResolver (CachedMavenRepository repository)
+	{
+		this.repository = repository;
+	}
+
+	public Project Resolve (Artifact artifact)
+	{
+		if (repository.TryGetFilePath (artifact, $"{artifact.Id}-{artifact.Version}.pom", out var path)) {
+			using (var stream = File.OpenRead (path)) {
+				var pom = Project.Load (stream) ?? throw new InvalidOperationException ($"Could not deserialize POM for {artifact}");
+
+				// Use index instead of Add to handle duplicates
+				ResolvedPoms [artifact.VersionedArtifactString] = path;
+
+				return pom;
+			}
+		}
+
+		throw new InvalidOperationException ($"No POM found for {artifact}");
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenArtifactDownloader.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenArtifactDownloader.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Java.Interop.Tools.Maven.Models;
+using Java.Interop.Tools.Maven.Repositories;
+
+namespace AndroidBinderator;
+
+static class MavenArtifactDownloader
+{
+	public static void Download (BindingConfig config, List<BindingProjectModel> artifacts)
+	{
+		var externals_dir = Path.Combine (config.BasePath!, config.ExternalsDir);
+		Directory.CreateDirectory (externals_dir);
+
+		foreach (var artifact in artifacts) {
+			var maven_artifact = artifact.MavenArtifacts.First ();
+			var config_artifact = maven_artifact.MavenArtifactConfig;
+
+			if (config_artifact is null)
+				throw new InvalidOperationException ($"No MavenArtifactConfig found for {artifact}");
+
+			if (config_artifact.DependencyOnly)
+				continue;
+
+			// Find and download the artifact payload
+			maven_artifact.DownloadedArtifact = DownloadPayload (config, artifact);
+
+			// Download additional files
+			DownloadAdditionalFiles (config, artifact);
+		}
+
+		// Copy files to externals directory and extract .aar files
+		Parallel.ForEach (artifacts, artifact => {
+
+			var maven_artifact = artifact.MavenArtifacts.First ();
+			var config_artifact = maven_artifact.MavenArtifactConfig!;
+			var artifact_file = maven_artifact.DownloadedArtifact!;
+
+			// Copy to externals directory
+			var output_dir = Path.Combine (externals_dir, artifact.MavenGroupId!);
+			Directory.CreateDirectory (output_dir);
+
+			var output_file = Path.Combine (output_dir, $"{config_artifact.ArtifactId}{Path.GetExtension (artifact_file)}");
+			File.Copy (artifact_file, output_file, overwrite: true);
+
+			// Extract .aar files
+			if (Path.GetExtension (artifact_file) == ".aar") {
+				var extract_dir = Path.Combine (output_dir, config_artifact.ArtifactId!);
+
+				if (Directory.Exists (extract_dir))
+					Directory.Delete (extract_dir, true);
+
+				Directory.CreateDirectory (extract_dir);
+				ZipFile.ExtractToDirectory (artifact_file, extract_dir);
+			}
+		});
+	}
+
+	static string DownloadPayload (BindingConfig config, BindingProjectModel artifact)
+	{
+		var artifact_dir = Path.Combine (config.BasePath!, config.ExternalsDir, artifact.MavenGroupId!);
+		Directory.CreateDirectory (artifact_dir);
+
+		var artifact_model = artifact.MavenArtifacts.First ();
+		var repository = MavenFactory2.GetMavenRepository (config, artifact_model.MavenArtifactConfig!);
+		var a = artifact.ToArtifact ();
+
+		if (artifact_model.MavenArtifactPackaging == "jar" || artifact_model.MavenArtifactPackaging == "aar") {
+			if (repository.TryGetFilePath (a, FormatPayloadFileName (a, artifact_model.MavenArtifactPackaging), out var payload_path))
+				return payload_path;
+
+			throw new InvalidOperationException ($"Failed to download {a} from {repository.Name}");
+		}
+
+		// Sometimes the "MavenArtifactPackaging" isn't useful, like "bundle" for Guava or "pom" for KotlinX Coroutines.
+		// In this case we're going to try "jar" and "aar" to try to find the real payload
+		if (repository.TryGetFilePath (a, FormatPayloadFileName (a, "jar"), out var jar_path)) {
+			artifact_model.MavenArtifactPackaging = "jar";
+			return jar_path;
+		}
+
+		if (repository.TryGetFilePath (a, FormatPayloadFileName (a, "aar"), out var aar_path)) {
+			artifact_model.MavenArtifactPackaging = "aar";
+			return aar_path;
+		}
+
+		throw new Exception ($"Could not find artifact payload {a.VersionedArtifactString}. [Packaging was {artifact_model.MavenArtifactPackaging}.]");
+	}
+
+	static void DownloadAdditionalFiles (BindingConfig config, BindingProjectModel artifact)
+	{
+		var art = artifact.ToArtifact ();
+		var artifact_model = artifact.MavenArtifacts.First ();
+		var artifact_dir = Path.Combine (config.BasePath!, config.ExternalsDir, art.GroupId!);
+		var base_output_file_name = config.DownloadExternalsWithFullName ? $"{art.GroupId}.{art.Id}" : $"{art.Id}";
+		var repository = MavenFactory2.GetMavenRepository (config, artifact_model.MavenArtifactConfig!);
+
+		if (config.DownloadJavaSourceJars) {
+			var source_file = FormatMavenFileName (art) + "-sources.jar";
+			var dest_file = base_output_file_name + "-sources.jar";
+			TryDownloadFile (repository, art, source_file, Path.Combine (artifact_dir, dest_file));
+		}
+
+		if (config.DownloadPoms) {
+			var pom_file = FormatMavenFileName (art) + ".pom";
+			var dest_file = base_output_file_name + ".pom";
+			TryDownloadFile (repository, art, pom_file, Path.Combine (artifact_dir, dest_file));
+		}
+
+		if (config.DownloadJavaDocJars) {
+			var javadoc_file = FormatMavenFileName (art) + "-javadoc.jar";
+			var dest_file = base_output_file_name + "-javadoc.jar";
+			TryDownloadFile (repository, art, javadoc_file, Path.Combine (artifact_dir, dest_file));
+		}
+	}
+
+	static bool TryDownloadFile (CachedMavenRepository repository, Artifact artifact, string filename, string outputFile)
+	{
+		try {
+			if (repository.TryGetFilePath (artifact, filename, out var path)) {
+				File.Copy (path, outputFile, overwrite: true);
+				return true;
+			}
+		} catch (Exception) {
+			// None of these files are required, so we can ignore any exceptions
+			return false;
+		}
+
+		return false;
+	}
+
+	static string FormatPayloadFileName (Artifact artifact, string packaging)
+		=> FormatMavenFileName (artifact) + "." + packaging.ToLowerInvariant ().TrimStart ('.');
+
+	static string FormatMavenFileName (Artifact artifact)
+		=> artifact.Id + "-" + artifact.Version;
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
@@ -1,83 +1,81 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using MavenNet;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public static class MavenFactory
 {
-	public static class MavenFactory
+	static readonly Dictionary<string, MavenRepository> repositories = new Dictionary<string, MavenRepository> ();
+
+	public static async Task Initialize (BindingConfig config)
 	{
-		static readonly Dictionary<string, MavenRepository> repositories = new Dictionary<string, MavenRepository>();
+		var artifact_mavens = new List<(MavenRepository, MavenArtifactConfig)> ();
 
-		public static async Task Initialize(BindingConfig config)
-		{
-			var artifact_mavens = new List<(MavenRepository, MavenArtifactConfig)>();
+		foreach (var artifact in config.MavenArtifacts.Where (ma => !ma.DependencyOnly)) {
+			var (type, location) = GetMavenInfoForArtifact (config, artifact);
+			var repo = GetOrCreateRepository (type, location);
 
-			foreach (var artifact in config.MavenArtifacts.Where(ma => !ma.DependencyOnly)) {
-				var (type, location) = GetMavenInfoForArtifact(config, artifact);
-				var repo = GetOrCreateRepository(type, location);
+			artifact_mavens.Add ((repo, artifact));
+		}
 
-				artifact_mavens.Add((repo, artifact));
-			}
+		foreach (var maven_group in artifact_mavens.GroupBy (a => a.Item1)) {
+			var maven = maven_group.Key;
+			var artifacts = maven_group.Select (a => a.Item2);
 
-			foreach (var maven_group in artifact_mavens.GroupBy(a => a.Item1)) {
-				var maven = maven_group.Key;
-				var artifacts = maven_group.Select(a => a.Item2);
+			foreach (var artifact_group in artifacts.GroupBy (a => a.GroupId)) {
+				var gid = artifact_group.Key;
+				var artifact_ids = artifact_group.Select (a => a.ArtifactId).ToArray ();
 
-				foreach (var artifact_group in artifacts.GroupBy(a => a.GroupId)) {
-					var gid = artifact_group.Key;
-					var artifact_ids = artifact_group.Select(a => a.ArtifactId).ToArray();
-
-					await maven.Populate(gid, artifact_ids);
-				}
+				await maven.Populate (gid, artifact_ids);
 			}
 		}
+	}
 
-		public static MavenRepository GetMavenRepository(BindingConfig config, MavenArtifactConfig artifact)
-		{
-			var (type, location) = GetMavenInfoForArtifact(config, artifact);
-			var repo = GetOrCreateRepository(type, location);
+	public static MavenRepository GetMavenRepository (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		var (type, location) = GetMavenInfoForArtifact (config, artifact);
+		var repo = GetOrCreateRepository (type, location);
 
-			return repo;
-		}
+		return repo;
+	}
 
-		static (MavenRepoType type, string location) GetMavenInfoForArtifact(BindingConfig config, MavenArtifactConfig artifact)
-		{
-			// Precendence: Artifact > TemplateSet > Config
-			if (artifact.MavenRepositoryType.HasValue)
-				return (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
+	static (MavenRepoType type, string location) GetMavenInfoForArtifact (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		// Precendence: Artifact > TemplateSet > Config
+		if (artifact.MavenRepositoryType.HasValue)
+			return (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
 
-			var template = config.GetTemplateSet(artifact.TemplateSet);
+		var template = config.GetTemplateSet (artifact.TemplateSet);
 
-			if (template.MavenRepositoryType.HasValue)
-				return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
+		if (template.MavenRepositoryType.HasValue)
+			return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
 
-			return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
-		}
+		return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
+	}
 
-		static MavenRepository GetOrCreateRepository(MavenRepoType type, string location)
-		{
-			var key = $"{type}|{location}";
+	static MavenRepository GetOrCreateRepository (MavenRepoType type, string location)
+	{
+		var key = $"{type}|{location}";
 
-			if (repositories.TryGetValue(key, out MavenRepository? repository))
-				return repository;
+		if (repositories.TryGetValue (key, out MavenRepository? repository))
+			return repository;
 
-			MavenRepository maven;
+		MavenRepository maven;
 
-			if (type == MavenRepoType.Directory)
-				maven = MavenRepository.FromDirectory(location);
-			else if (type == MavenRepoType.Url)
-				maven = MavenRepository.FromUrl(location);
-			else if (type == MavenRepoType.MavenCentral)
-				maven = MavenRepository.FromMavenCentral();
-			else
-				maven = MavenRepository.FromGoogle();
+		if (type == MavenRepoType.Directory)
+			maven = MavenRepository.FromDirectory (location);
+		else if (type == MavenRepoType.Url)
+			maven = MavenRepository.FromUrl (location);
+		else if (type == MavenRepoType.MavenCentral)
+			maven = MavenRepository.FromMavenCentral ();
+		else
+			maven = MavenRepository.FromGoogle ();
 
-			repositories.Add(key, maven);
+		repositories.Add (key, maven);
 
-			return maven;
-		}
+		return maven;
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Java.Interop.Tools.Maven.Models;
+using Java.Interop.Tools.Maven.Repositories;
+
+namespace AndroidBinderator;
+
+public static class MavenFactory2
+{
+	static string cache_location = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "maven-cache");
+	static readonly Dictionary<string, CachedMavenRepository> repositories = new Dictionary<string, CachedMavenRepository> ();
+	static readonly Dictionary<string, ProjectResolver> project_resolvers = new Dictionary<string, ProjectResolver> ();
+
+	public static CachedMavenRepository GetMavenRepository (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		var (type, location) = GetMavenInfoForArtifact (config, artifact);
+		var repo = GetOrCreateRepository (type, location);
+
+		return repo;
+	}
+
+	public static ProjectResolver GetProjectResolver (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		var (type, location) = GetMavenInfoForArtifact (config, artifact);
+		var resolver = GetOrCreateProjectResolver (type, location);
+
+		return resolver;
+	}
+
+	public static Project GetPomForArtifact (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		var resolver = GetProjectResolver (config, artifact);
+		var project = resolver.Resolve (artifact.ToArtifact ());
+
+		return project;
+	}
+
+	public static Project GetPomForArtifactParent (BindingConfig config, Artifact parentArtifact, MavenArtifactConfig originalArtifact)
+	{
+		// We assume the parent artifact is in the same repository as the original artifact
+		var resolver = GetProjectResolver (config, originalArtifact);
+		var project = resolver.Resolve (parentArtifact);
+
+		return project;
+	}
+
+	static (MavenRepoType type, string location) GetMavenInfoForArtifact (BindingConfig config, MavenArtifactConfig artifact)
+	{
+		// Precendence: Artifact > TemplateSet > Config
+		if (artifact.MavenRepositoryType.HasValue)
+			return (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
+
+		var template = config.GetTemplateSet (artifact.TemplateSet);
+
+		if (template.MavenRepositoryType.HasValue)
+			return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
+
+		return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
+	}
+
+	static CachedMavenRepository GetOrCreateRepository (MavenRepoType type, string location)
+	{
+		var key = $"{type}|{location}";
+
+		if (repositories.TryGetValue (key, out var repository))
+			return repository;
+
+		MavenRepository maven;
+
+		if (type == MavenRepoType.Directory)
+			throw new ArgumentException ("Directory repository type not supported");
+		else if (type == MavenRepoType.Url)
+			maven = new MavenRepository (location, location);
+		else if (type == MavenRepoType.MavenCentral)
+			maven = MavenRepository.Central;
+		else
+			maven = MavenRepository.Google;
+
+		var cached_maven = new CachedMavenRepository (cache_location, maven);
+
+		repositories.Add (key, cached_maven);
+
+		return cached_maven;
+	}
+
+	static ProjectResolver GetOrCreateProjectResolver (MavenRepoType type, string location)
+	{
+		var key = $"{type}|{location}";
+
+		if (project_resolvers.TryGetValue (key, out ProjectResolver? pr))
+			return pr;
+
+		var resolver = new ProjectResolver (GetOrCreateRepository (type, location));
+
+		project_resolvers.Add (key, resolver);
+
+		return resolver;
+	}
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
@@ -1,111 +1,109 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class BindingProjectModel
 {
-	public class BindingProjectModel
+	public string Id { get; private set; } = Guid.NewGuid ().ToString ().ToUpperInvariant ();
+
+	public string? Name { get; set; }
+
+	public string? MavenGroupId { get; set; }
+
+	public BindingType Type { get; set; }
+
+	public List<MavenArtifactModel> MavenArtifacts { get; set; } = new List<MavenArtifactModel> ();
+
+	public string? NuGetPackageId { get; set; }
+	public string? NuGetVersionBase { get; set; }
+	public string? NuGetVersionSuffix { get; set; }
+
+	public string? NuGetVersion =>
+		string.IsNullOrWhiteSpace (NuGetVersionSuffix)
+			? NuGetVersionBase
+			: NuGetVersionBase + NuGetVersionSuffix;
+
+	public string? AssemblyName { get; set; }
+
+	public List<NuGetDependencyModel> NuGetDependencies { get; set; } = new List<NuGetDependencyModel> ();
+
+	public List<string> ProjectReferences { get; set; } = new List<string> ();
+
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
+
+	public BindingConfig? Config { get; set; }
+
+	public string? MavenDescription { get; set; }
+	public string? MavenUrl { get; set; }
+	public string? JavaSourceRepository { get; set; }
+	public bool AllowPrereleaseDependencies { get; set; }
+
+	public List<MavenArtifactLicense> Licenses { get; } = new List<MavenArtifactLicense> ();
+
+	public List<MavenArtifactDeveloper> Developers { get; } = new List<MavenArtifactDeveloper> ();
+
+	public string GetAssemblyName () => AssemblyName.HasValue () ? AssemblyName : NuGetPackageId ?? string.Empty;
+
+	public string GetArtifactVersion () => MavenArtifacts.FirstOrDefault ()?.MavenArtifactVersion ?? string.Empty;
+
+	public string GetRootNamespace ()
 	{
-		public string Id { get; private set; } = Guid.NewGuid().ToString().ToUpperInvariant();
+		if (Metadata.TryGetValue ("rootNamespace", out var rootNamespace))
+			return rootNamespace;
 
-		public string? Name { get; set; }
-
-		public string? MavenGroupId { get; set; }
-
-		public BindingType Type { get; set; }
-
-		public List<MavenArtifactModel> MavenArtifacts { get; set; } = new List<MavenArtifactModel>();
-
-		public string? NuGetPackageId { get; set; }
-		public string? NuGetVersionBase { get; set; }
-		public string? NuGetVersionSuffix { get; set; }
-
-		public string? NuGetVersion =>
-			string.IsNullOrWhiteSpace(NuGetVersionSuffix)
-				? NuGetVersionBase
-				: NuGetVersionBase + NuGetVersionSuffix;
-
-		public string? AssemblyName { get; set; }
-
-		public List<NuGetDependencyModel> NuGetDependencies { get; set; } = new List<NuGetDependencyModel>();
-
-		public List<string> ProjectReferences { get; set; } = new List<string>();
-
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
-
-		public BindingConfig? Config { get; set; }
-
-		public string? MavenDescription { get; set; }
-		public string? MavenUrl { get; set; }
-		public string? JavaSourceRepository { get; set; }
-		public bool AllowPrereleaseDependencies { get; set; }
-
-		public List<MavenArtifactLicense> Licenses { get; } = new List<MavenArtifactLicense> ();
-
-		public List<MavenArtifactDeveloper> Developers { get; } = new List<MavenArtifactDeveloper> ();
-
-		public string GetAssemblyName () => AssemblyName.HasValue () ? AssemblyName : NuGetPackageId ?? string.Empty;
-
-		public string GetArtifactVersion () => MavenArtifacts.FirstOrDefault ()?.MavenArtifactVersion ?? string.Empty;
-
-		public string GetRootNamespace ()
-		{
-			if (Metadata.TryGetValue ("rootNamespace", out var rootNamespace))
-				return rootNamespace;
-
-			return NuGetPackageId!.Replace ("Xamarin.", "");
-		}
-
-		// TODO: Move this to config.json
-		// Whether to bind the Java .jar/.aar
-		public bool ShouldBindArtifact => NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm" && NuGetPackageId != "Xamarin.Android.Glide.Annotations";
-
-		// TODO: Move this to config.json
-		// Whether to include the Java .jar/.aar in the NuGet package
-		public bool ShouldIncludeArtifact => NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm";
-
-		// Proprietary licenses aren't supported by SPDX
-		public bool CanUseSpdx => !Licenses.Any (s => string.IsNullOrWhiteSpace (s.Spdx));
-
-		public string GetSpdxExpression ()
-		{
-			if (!CanUseSpdx)
-				throw new InvalidOperationException ("One or more licenses do not have an SPDX expression");
-
-			// Our SPDX expression is MIT for Microsoft code, plus any
-			// other licenses that govern the artifact.
-			var licenses = new string [] { "MIT" }.Concat (Licenses.Select (s => s.Spdx)).Distinct ().ToList ();
-
-			return string.Join (" AND ", licenses);
-		}
+		return NuGetPackageId!.Replace ("Xamarin.", "");
 	}
 
-	public class MavenArtifactLicense
+	// TODO: Move this to config.json
+	// Whether to bind the Java .jar/.aar
+	public bool ShouldBindArtifact => NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm" && NuGetPackageId != "Xamarin.Android.Glide.Annotations";
+
+	// TODO: Move this to config.json
+	// Whether to include the Java .jar/.aar in the NuGet package
+	public bool ShouldIncludeArtifact => NuGetPackageId != "Xamarin.AndroidX.DataStore.Core.Jvm";
+
+	// Proprietary licenses aren't supported by SPDX
+	public bool CanUseSpdx => !Licenses.Any (s => string.IsNullOrWhiteSpace (s.Spdx));
+
+	public string GetSpdxExpression ()
 	{
-		public string Name { get; set; }
-		public string Url { get; set; }
-		public string Spdx { get; set; }
-		public string? Text { get; set; }
+		if (!CanUseSpdx)
+			throw new InvalidOperationException ("One or more licenses do not have an SPDX expression");
 
-		public LicenseConfig LicenseConfig { get; set; }
+		// Our SPDX expression is MIT for Microsoft code, plus any
+		// other licenses that govern the artifact.
+		var licenses = new string [] { "MIT" }.Concat (Licenses.Select (s => s.Spdx)).Distinct ().ToList ();
 
-		public MavenArtifactLicense (string name, string url, LicenseConfig licenseConfig)
-		{
-			Name = name;
-			Url = url;
-			LicenseConfig = licenseConfig;
-			Spdx = licenseConfig.Spdx;
-		}
+		return string.Join (" AND ", licenses);
 	}
+}
 
-	public class MavenArtifactDeveloper
+public class MavenArtifactLicense
+{
+	public string Name { get; set; }
+	public string Url { get; set; }
+	public string Spdx { get; set; }
+	public string? Text { get; set; }
+
+	public LicenseConfig LicenseConfig { get; set; }
+
+	public MavenArtifactLicense (string name, string url, LicenseConfig licenseConfig)
 	{
-		public string Name { get; set; }
+		Name = name;
+		Url = url;
+		LicenseConfig = licenseConfig;
+		Spdx = licenseConfig.Spdx;
+	}
+}
 
-		public MavenArtifactDeveloper (string name)
-		{
-			Name = name;
-		}
+public class MavenArtifactDeveloper
+{
+	public string Name { get; set; }
+
+	public MavenArtifactDeveloper (string name)
+	{
+		Name = name;
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/BindingProjectModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Java.Interop.Tools.Maven.Models;
 
 namespace AndroidBinderator;
 
@@ -15,6 +16,7 @@ public class BindingProjectModel
 	public BindingType Type { get; set; }
 
 	public List<MavenArtifactModel> MavenArtifacts { get; set; } = new List<MavenArtifactModel> ();
+	public List<Dependency> MavenDependencies { get; set; } = new List<Dependency> ();
 
 	public string? NuGetPackageId { get; set; }
 	public string? NuGetVersionBase { get; set; }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
@@ -1,21 +1,20 @@
 using System.Collections.Generic;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class MavenArtifactModel
 {
-	public class MavenArtifactModel
-	{
-		public string? MavenGroupId { get; set; }
-		public string? MavenArtifactId { get; set; }
-		public string? MavenArtifactVersion { get; set; }
-		public string? MavenArtifactPackaging { get; set; }
-		public string? MavenArtifactMd5 { get; set; }
-		public string? MavenArtifactSha256 { get; set; }
-		public MavenArtifactConfig? MavenArtifactConfig { get; set; }
+	public string? MavenGroupId { get; set; }
+	public string? MavenArtifactId { get; set; }
+	public string? MavenArtifactVersion { get; set; }
+	public string? MavenArtifactPackaging { get; set; }
+	public string? MavenArtifactMd5 { get; set; }
+	public string? MavenArtifactSha256 { get; set; }
+	public MavenArtifactConfig? MavenArtifactConfig { get; set; }
 
-		public string? DownloadedArtifact { get; set; }
-		public string? ProguardFile { get; set; }
-		public DocumentationType DocumentationType { get; set; }
+	public string? DownloadedArtifact { get; set; }
+	public string? ProguardFile { get; set; }
+	public DocumentationType DocumentationType { get; set; }
 
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
-	}
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
@@ -1,77 +1,76 @@
 using System.Collections.Generic;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class NuGetDependencyModel
 {
-	public class NuGetDependencyModel
+	public bool IsProjectReference { get; set; }
+
+	public string? NuGetPackageId { get; set; }
+	public string? NuGetVersionBase { get; set; }
+	public string? NuGetVersionSuffix { get; set; }
+	public MavenArtifactConfig? MavenArtifactConfig { get; set; }
+
+	public string? NuGetVersion =>
+		!IsProjectReference || string.IsNullOrWhiteSpace (NuGetVersionSuffix)
+			? NuGetVersionBase
+			: NuGetVersionBase + NuGetVersionSuffix;
+
+	public MavenArtifactModel? MavenArtifact { get; set; }
+
+	public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
+
+	// Gets the version string needed for a NuGet package dependency, which we adjust to allow floating revisions
+	public string GetPackageVersionString ()
 	{
-		public bool IsProjectReference { get; set; }
+		var mavenVersion = MavenArtifact!.MavenArtifactVersion!;
+		var nugetVersion = NuGetVersion!;
 
-		public string? NuGetPackageId { get; set; }
-		public string? NuGetVersionBase { get; set; }
-		public string? NuGetVersionSuffix { get; set; }
-		public MavenArtifactConfig? MavenArtifactConfig { get; set; }
+		// If this isn't an exact version we don't use this code
+		if (!mavenVersion.StartsWith ('[') || !mavenVersion.EndsWith (']') || mavenVersion.Contains (','))
+			return nugetVersion;
 
-		public string? NuGetVersion =>
-			!IsProjectReference || string.IsNullOrWhiteSpace(NuGetVersionSuffix)
-				? NuGetVersionBase
-				: NuGetVersionBase + NuGetVersionSuffix;
+		// An exact version is requested like "1.2.0", however we want to let the revision (4th NuGet number) float,
+		// so that our updates that don't change the Java artifact can still be used.
+		// That is, if the POM specifies "1.2.0" and the dependency NuGet is already "1.2.0.4", we want to allow:
+		// 1.2.0.4 >= x < 1.2.1
+		// NuGet expresses that as "[1.2.0.4, 1.2.1)", so that's what we need to create.
+		var lower_bound = nugetVersion;
 
-		public MavenArtifactModel? MavenArtifact { get; set; }
+		var nuget_first = 0;
+		var nuget_second = 0;
+		var nuget_third = 0;
 
-		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+		var nuget_parts = nugetVersion.Split ('.');
 
-		// Gets the version string needed for a NuGet package dependency, which we adjust to allow floating revisions
-		public string GetPackageVersionString ()
-		{
-			var mavenVersion = MavenArtifact!.MavenArtifactVersion!;
-			var nugetVersion = NuGetVersion!;
+		if (nuget_parts.Length > 0 && int.TryParse (nuget_parts [0], out var p1))
+			nuget_first = p1;
 
-			// If this isn't an exact version we don't use this code
-			if (!mavenVersion.StartsWith ('[') || !mavenVersion.EndsWith (']') || mavenVersion.Contains (','))
-				return nugetVersion;
+		if (nuget_parts.Length > 1 && int.TryParse (nuget_parts [1], out var p2))
+			nuget_second = p2;
 
-			// An exact version is requested like "1.2.0", however we want to let the revision (4th NuGet number) float,
-			// so that our updates that don't change the Java artifact can still be used.
-			// That is, if the POM specifies "1.2.0" and the dependency NuGet is already "1.2.0.4", we want to allow:
-			// 1.2.0.4 >= x < 1.2.1
-			// NuGet expresses that as "[1.2.0.4, 1.2.1)", so that's what we need to create.
-			var lower_bound = nugetVersion;
+		if (nuget_parts.Length > 2 && int.TryParse (nuget_parts [2], out var p3))
+			nuget_third = p3;
 
-			var nuget_first = 0;
-			var nuget_second = 0;
-			var nuget_third = 0;
+		// Bump the third number
+		nuget_third++;
 
-			var nuget_parts = nugetVersion.Split ('.');
+		var upper_bound = $"{nuget_first}.{nuget_second}.{nuget_third}";
 
-			if (nuget_parts.Length > 0 && int.TryParse (nuget_parts [0], out var p1))
-				nuget_first = p1;
+		// Put it all together
+		return $"[{lower_bound}, {upper_bound})";
+	}
 
-			if (nuget_parts.Length > 1 && int.TryParse (nuget_parts [1], out var p2))
-				nuget_second = p2;
+	// Gets the version string needed for a project dependency, which we adjust to allow floating revisions
+	public string? GetProjectVersionString ()
+	{
+		var nugetVersion = NuGetVersion!;
+		var adjusted_string = GetPackageVersionString ();
 
-			if (nuget_parts.Length > 2 && int.TryParse (nuget_parts [2], out var p3))
-				nuget_third = p3;
+		// If nothing changed, return empty string
+		if (adjusted_string == nugetVersion)
+			return null;
 
-			// Bump the third number
-			nuget_third++;
-
-			var upper_bound = $"{nuget_first}.{nuget_second}.{nuget_third}";
-
-			// Put it all together
-			return $"[{lower_bound}, {upper_bound})";
-		}
-
-		// Gets the version string needed for a project dependency, which we adjust to allow floating revisions
-		public string? GetProjectVersionString ()
-		{
-			var nugetVersion = NuGetVersion!;
-			var adjusted_string = GetPackageVersionString ();
-
-			// If nothing changed, return empty string
-			if (adjusted_string == nugetVersion)
-				return null;
-
-			return adjusted_string;
-		}
+		return adjusted_string;
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
@@ -1,22 +1,20 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public class TemplateSetModel
 {
-	public class TemplateSetModel
-	{
-		[JsonProperty("name")]
-		public string? Name { get; set; }
+	[JsonProperty ("name")]
+	public string? Name { get; set; }
 
-		[JsonProperty("mavenRepositoryType")]
-		public MavenRepoType? MavenRepositoryType { get; set; }
+	[JsonProperty ("mavenRepositoryType")]
+	public MavenRepoType? MavenRepositoryType { get; set; }
 
-		[JsonProperty("mavenRepositoryLocation")]
-		public string? MavenRepositoryLocation { get; set; } = null;
+	[JsonProperty ("mavenRepositoryLocation")]
+	public string? MavenRepositoryLocation { get; set; } = null;
 
-		[JsonProperty("templates")]
-		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig> ();
-	}
+	[JsonProperty ("templates")]
+	public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig> ();
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/SolutionFileBuilder.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/SolutionFileBuilder.cs
@@ -1,99 +1,94 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+public static class SolutionFileBuilder
 {
-    public static class SolutionFileBuilder
-    {
-        public static string Build (BindingConfig config, Dictionary<string, BindingProjectModel> projects)
-        {
-			var csprojNamespaces = new XmlNamespaceManager(new NameTable());
-			csprojNamespaces.AddNamespace("ns", "http://schemas.microsoft.com/developer/msbuild/2003");
+	public static string Build (BindingConfig config, Dictionary<string, BindingProjectModel> projects)
+	{
+		var csprojNamespaces = new XmlNamespaceManager (new NameTable ());
+		csprojNamespaces.AddNamespace ("ns", "http://schemas.microsoft.com/developer/msbuild/2003");
 
-			var slnFileInfo = new FileInfo(config.SolutionFile!);
+		var slnFileInfo = new FileInfo (config.SolutionFile!);
 
-			// Collect all the projects to be added to the .sln
-			var allProjects = new List<(string guid, string name, string key)>();
+		// Collect all the projects to be added to the .sln
+		var allProjects = new List<(string guid, string name, string key)> ();
 
-			// First go through additional projects specified in the config
-			foreach (var ap in config.AdditionalProjects)
-			{
-				var prjPath = Path.Combine(config.BasePath!, ap);
-				var prjPathFileInfo = new FileInfo(prjPath);
+		// First go through additional projects specified in the config
+		foreach (var ap in config.AdditionalProjects) {
+			var prjPath = Path.Combine (config.BasePath!, ap);
+			var prjPathFileInfo = new FileInfo (prjPath);
 
-				if (!File.Exists(prjPath))
-					throw new FileNotFoundException(prjPath);
+			if (!File.Exists (prjPath))
+				throw new FileNotFoundException (prjPath);
 
-				var prjName = Path.GetFileNameWithoutExtension(prjPathFileInfo.Name);
+			var prjName = Path.GetFileNameWithoutExtension (prjPathFileInfo.Name);
 
-				// Try and find an existing project guid in the .csproj
-				// which might not exist if it's an SDK style project
-				var xml = XDocument.Load(prjPath);
-				var xelem = xml.XPathSelectElement("/ns:Project/ns:PropertyGroup/ns:ProjectGuid", csprojNamespaces);
+			// Try and find an existing project guid in the .csproj
+			// which might not exist if it's an SDK style project
+			var xml = XDocument.Load (prjPath);
+			var xelem = xml.XPathSelectElement ("/ns:Project/ns:PropertyGroup/ns:ProjectGuid", csprojNamespaces);
 
-				var prjGuid = xelem?.Value ?? Guid.NewGuid().ToString("B");
-				var prjKey = GetRelativePath(slnFileInfo.FullName, prjPathFileInfo.FullName).Replace("/", "\\");
+			var prjGuid = xelem?.Value ?? Guid.NewGuid ().ToString ("B");
+			var prjKey = GetRelativePath (slnFileInfo.FullName, prjPathFileInfo.FullName).Replace ("/", "\\");
 
-				allProjects.Add((prjGuid, prjName, prjKey));
-			}
-
-			// Add all of the generated projects
-			foreach (var p in projects)
-			{
-				var groupId = p.Value.MavenGroupId;
-				var prjName = groupId + "." + p.Value.Name;
-				var prjKey = GetRelativePath(slnFileInfo.FullName, p.Key).Replace("/", "\\");
-				var prjGuid = "{" + p.Value.Id + "}";
-
-				allProjects.Add((prjGuid, prjName, prjKey));
-			}
-
-			var s = new StringBuilder();
-
-            s.AppendLine();
-            s.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
-            s.AppendLine("# Visual Studio 2012");
-
-            //Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "@(project.Name)", "@(project.Name)\@(project.Name).csproj", "@(project.Id)"
-            foreach (var project in allProjects)
-            {
-                s.AppendLine("Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"" + project.name + "\", \"" + project.key + "\", \"" + project.guid + "\"");
-                s.AppendLine("EndProject");
-            }
-            
-            s.AppendLine("Global");
-
-            s.AppendLine("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
-            s.AppendLine("\t\tDebug|Any CPU = Debug|Any CPU");
-            s.AppendLine("\t\tRelease|Any CPU = Release|Any CPU");
-            s.AppendLine("\tEndGlobalSection");
-
-            s.AppendLine("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
-            foreach (var project in allProjects) {
-                s.AppendLine("\t\t" + project.guid + ".Debug|Any CPU.ActiveCfg = Debug|Any CPU");
-                s.AppendLine("\t\t" + project.guid + ".Debug|Any CPU.Build.0 = Debug|Any CPU");
-                s.AppendLine("\t\t" + project.guid + ".Release|Any CPU.ActiveCfg = Release|Any CPU");
-                s.AppendLine("\t\t" + project.guid + ".Release|Any CPU.Build.0 = Release|Any CPU");
-            }
-            s.AppendLine("\tEndGlobalSection");
-
-            s.AppendLine("EndGlobal");
-
-            return s.ToString();
-        }
-
-		static string GetRelativePath(string basePath, string filePath)
-		{
-			var path1 = new Uri(basePath);
-			var path2 = new Uri(filePath);
-			Uri diff = path1.MakeRelativeUri(path2);
-			return diff.OriginalString;
+			allProjects.Add ((prjGuid, prjName, prjKey));
 		}
+
+		// Add all of the generated projects
+		foreach (var p in projects) {
+			var groupId = p.Value.MavenGroupId;
+			var prjName = groupId + "." + p.Value.Name;
+			var prjKey = GetRelativePath (slnFileInfo.FullName, p.Key).Replace ("/", "\\");
+			var prjGuid = "{" + p.Value.Id + "}";
+
+			allProjects.Add ((prjGuid, prjName, prjKey));
+		}
+
+		var s = new StringBuilder ();
+
+		s.AppendLine ();
+		s.AppendLine ("Microsoft Visual Studio Solution File, Format Version 12.00");
+		s.AppendLine ("# Visual Studio 2012");
+
+		//Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "@(project.Name)", "@(project.Name)\@(project.Name).csproj", "@(project.Id)"
+		foreach (var project in allProjects) {
+			s.AppendLine ("Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"" + project.name + "\", \"" + project.key + "\", \"" + project.guid + "\"");
+			s.AppendLine ("EndProject");
+		}
+
+		s.AppendLine ("Global");
+
+		s.AppendLine ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
+		s.AppendLine ("\t\tDebug|Any CPU = Debug|Any CPU");
+		s.AppendLine ("\t\tRelease|Any CPU = Release|Any CPU");
+		s.AppendLine ("\tEndGlobalSection");
+
+		s.AppendLine ("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
+		foreach (var project in allProjects) {
+			s.AppendLine ("\t\t" + project.guid + ".Debug|Any CPU.ActiveCfg = Debug|Any CPU");
+			s.AppendLine ("\t\t" + project.guid + ".Debug|Any CPU.Build.0 = Debug|Any CPU");
+			s.AppendLine ("\t\t" + project.guid + ".Release|Any CPU.ActiveCfg = Release|Any CPU");
+			s.AppendLine ("\t\t" + project.guid + ".Release|Any CPU.Build.0 = Release|Any CPU");
+		}
+		s.AppendLine ("\tEndGlobalSection");
+
+		s.AppendLine ("EndGlobal");
+
+		return s.ToString ();
+	}
+
+	static string GetRelativePath (string basePath, string filePath)
+	{
+		var path1 = new Uri (basePath);
+		var path2 = new Uri (filePath);
+		Uri diff = path1.MakeRelativeUri (path2);
+		return diff.OriginalString;
 	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Util.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Util.cs
@@ -1,57 +1,50 @@
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Security.Cryptography;
+using System.Text;
 
-namespace AndroidBinderator
+namespace AndroidBinderator;
+
+internal static class Util
 {
-    internal static class Util
-    {
-        internal static string HashMd5(Stream value)
-        {
+	internal static string HashMd5 (Stream value)
+	{
 #pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms - This is not used for cryptographic purposes
-	    using (var md5 = MD5.Create())
-	        return BitConverter.ToString(md5.ComputeHash(value)).Replace("-", "").ToLowerInvariant();
+		using (var md5 = MD5.Create ())
+			return BitConverter.ToString (md5.ComputeHash (value)).Replace ("-", "").ToLowerInvariant ();
 #pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
 	}
 
-        internal static string HashSha256(string value)
-        {
-            return HashSha256(Encoding.UTF8.GetBytes(value));
-        }
+	internal static string HashSha256 (string value)
+	{
+		return HashSha256 (Encoding.UTF8.GetBytes (value));
+	}
 
-        internal static string HashSha256(byte[] value)
-        {
+	internal static string HashSha256 (byte [] value)
+	{
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
-            using (var sha256 = new SHA256Managed())
-            {
-                var hash = new StringBuilder();
-                var hashData = sha256.ComputeHash(value);
-                foreach (var b in hashData)
-                    hash.Append(b.ToString("x2"));
+		using (var sha256 = new SHA256Managed ()) {
+			var hash = new StringBuilder ();
+			var hashData = sha256.ComputeHash (value);
+			foreach (var b in hashData)
+				hash.Append (b.ToString ("x2"));
 
-                return hash.ToString();
-            }
-#pragma warning restore SYSLIB0021 // Type or member is obsolete
+			return hash.ToString ();
 		}
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+	}
 
-        internal static string HashSha256(Stream value)
-        {
+	internal static string HashSha256 (Stream value)
+	{
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
-            using (var sha256 = new SHA256Managed())
-            {
-                var hash = new StringBuilder();
-                var hashData = sha256.ComputeHash(value);
-                foreach (var b in hashData)
-                    hash.Append(b.ToString("x2"));
+		using (var sha256 = new SHA256Managed ()) {
+			var hash = new StringBuilder ();
+			var hashData = sha256.ComputeHash (value);
+			foreach (var b in hashData)
+				hash.Append (b.ToString ("x2"));
 
-                return hash.ToString();
-            }
-#pragma warning restore SYSLIB0021 // Type or member is obsolete
+			return hash.ToString ();
 		}
-    }
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+	}
 }

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -32,4 +32,11 @@
       <None Include="..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Reference Include="Java.Interop.Tools.Maven">
+        <HintPath>..\..\..\tools\Microsoft.Android.Sdk.Windows.35.0.0-rc.1.80\tools\Java.Interop.Tools.Maven.dll</HintPath>
+        <Private>True</Private>
+      </Reference>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Rebase `binderator` on top of `Java.Interop.Tools.Maven` instead of `MavenNet`.  This has 2 benefits:

- Built-in Maven caching so local builds don't have to download the same artifacts every run.
- Better implementations of `MavenVersion` and `MavenVersionRange` that should work for more cases.

This PR also runs `dotnet-format` on `Xamarin.AndroidBinderator` to standardize to our `.editorconfig` settings.