### PR TITLE
[GitHub] Update our new issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-use-package.yml
+++ b/.github/ISSUE_TEMPLATE/01-use-package.yml
@@ -9,13 +9,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
-      - Not applicable
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.0.1, VSMac 8.10, .NET 6.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea
@@ -40,7 +40,7 @@ body:
       label: Steps to Reproduce
       description: Describe all the steps we need to take to show the behavior that you have observed. If you have a repro project, you can drag and drop the .zip/etc. onto the issue editor to attach it, or post a link to a sample project.
       placeholder: | 
-        1. Create a File > New Android App (Xamarin)
+        1. File > New Project > New Android Application
         2. Add the following code: ...
         3. Run the app and observe the bug 🐞
     validations:

--- a/.github/ISSUE_TEMPLATE/02-new-package.yml
+++ b/.github/ISSUE_TEMPLATE/02-new-package.yml
@@ -1,5 +1,5 @@
-name: 🆕 New AndroidX package binding request
-description: Request for a new Google AndroidX package to be bound.
+name: 🆕 New package binding request
+description: Request a new Google package to be bound.
 title: 'Bind "example.package"'
 labels: ["new-package-request"]
 body:

--- a/.github/ISSUE_TEMPLATE/03-updated-package.yml
+++ b/.github/ISSUE_TEMPLATE/03-updated-package.yml
@@ -1,13 +1,13 @@
-name: 📦 Update AndroidX package binding request
-description: Request for a newer version of a package in this repository to be bound.
+name: 📦 Update package binding request
+description: Request a newer version of a package in this repository to be bound.
 title: 'Update "example.package" to "1.1.0"'
 labels: 'update-package-request'
 body:
   - type: markdown
     attributes:
       value: |
-        Note that this template rarely needs to be used. We have an automated process that runs periodically
-        that files a PR to update the packages to the latest *stable* releases from Google.
+        Note that this template rarely needs to be used. We have an script we regularly run
+        that updates the packages to the latest *stable* releases from Google.
 
         It may take a few weeks to get new versions committed and released.
 

--- a/.github/ISSUE_TEMPLATE/04-other.yml
+++ b/.github/ISSUE_TEMPLATE/04-other.yml
@@ -8,13 +8,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid12.0, etc.)
-      - Android for .NET (net6.0-android, etc.)
-      - Not applicable
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.0.1, VSMac 8.10, .NET 6.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-### Support Libraries Version (eg: 23.3.0):
-
-
-### Does this change any of the generated binding API's?
-
-
-### Describe your contribution


### PR DESCRIPTION
We no longer need to ask if this is Classic Xamarin.Android or Android for .NET in the issue template.

Additionally, remove the PR template.  It's outdated (support libraries) and doesn't seem to provide any value, and none of our other repositories have one.