### PR TITLE
Add support for specifying skipping extended tests in config.json.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,13 @@ trigger:
 pr:
   - main
   
+schedules:
+- cron: '0 0 * * *'
+  displayName: Nightly Extended Tests
+  branches:
+    include:
+    - main
+    
 parameters:
 - name: RunExtendedTests
   displayName: Run Extended Tests?
@@ -77,7 +84,7 @@ extends:
 
     - template: build/ci/stage-extended-tests.yml@self
       parameters:
-        stageCondition: and(succeeded(), ne('$(skipUnitTests)', 'true'), eq('${{ parameters.RunExtendedTests }}', 'true'))
+        stageCondition: and(succeeded(), ne('$(skipUnitTests)', 'true'), or(eq('${{ parameters.RunExtendedTests }}', 'true'), eq(variables['Build.CronSchedule.DisplayName'], 'Nightly Extended Tests')))
         buildPool:
           name: $(windowsAgentPoolName)
           image: $(windowsImage)

--- a/config.json
+++ b/config.json
@@ -1022,7 +1022,9 @@
         "version": "1.5.0",
         "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.Emoji2.EmojiPicker",
-        "dependencyOnly": false
+        "dependencyOnly": false,
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to explicit dependency version request causes conflicts"
       },
       {
         "groupId": "androidx.emoji2",
@@ -3995,7 +3997,9 @@
         "nugetId": "Xamarin.Firebase.Firestore",
         "dependencyOnly": false,
         "extraDependencies": "com.google.guava.guava",
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4004,7 +4008,9 @@
         "nugetVersion": "125.1.0",
         "nugetId": "Xamarin.Firebase.Firestore.Ktx",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4049,7 +4055,9 @@
         "nugetVersion": "121.0.0.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4058,7 +4066,9 @@
         "nugetVersion": "121.0.0.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4067,7 +4077,9 @@
         "nugetVersion": "121.0.0.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display.Ktx",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4076,7 +4088,9 @@
         "nugetVersion": "121.0.0.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Ktx",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4292,7 +4306,9 @@
         "nugetVersion": "121.0.1.2",
         "nugetId": "Xamarin.Firebase.Perf",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4301,7 +4317,9 @@
         "nugetVersion": "121.0.1.2",
         "nugetId": "Xamarin.Firebase.Perf.Ktx",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.firebase",
@@ -4346,7 +4364,9 @@
         "nugetVersion": "118.0.0.18",
         "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
         "dependencyOnly": false,
-        "type": "xbd"
+        "type": "xbd",
+        "skipExtendedTests": true,
+        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
       },
       {
         "groupId": "com.google.flatbuffers",

--- a/tests/extended/BinderatorConfigFileParser.cs
+++ b/tests/extended/BinderatorConfigFileParser.cs
@@ -99,6 +99,9 @@ public class BinderatorConfigFileParser
 		[JsonProperty ("templateSet")]
 		public string TemplateSet { get; set; }
 
+		[JsonProperty ("skipExtendedTests")]
+		public bool SkipExtendedTests { get; set; }
+
 		[JsonProperty ("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string> ();
 

--- a/tests/extended/TestAllIndividualPackages.cs
+++ b/tests/extended/TestAllIndividualPackages.cs
@@ -70,12 +70,14 @@ public class TestAllIndividualPackages
 		var config_file = Path.Combine (base_dir, "config.json");
 		var config = BinderatorConfigFileParser.ParseConfigurationFile (config_file).Result;
 
-		return config.FirstOrDefault ()?.Artifacts?.Where (a => !a.DependencyOnly).Select (a => new object [] { a.NugetId, a.NugetVersion }).ToArray () ?? Array.Empty<object> ();
+		return config.FirstOrDefault ()?.Artifacts?.Where (a => !a.DependencyOnly && !a.SkipExtendedTests).Select (a => new object [] { a.NugetId, a.NugetVersion }).ToArray () ?? Array.Empty<object> ();
 	}
 
 	async Task TestPackage (string id, string version, string template)
 	{
-		var case_dir = Path.Combine (base_dir, test_dir, template, $"{id}Test");
+		// Need to rename "Default" because it becomes a Java keyword
+		var sanitized_id = id.Replace (".Default.", ".Default2.");
+		var case_dir = Path.Combine (base_dir, test_dir, template, $"{sanitized_id}Test");
 
 		// Test the package
 		if (Directory.Exists (case_dir))

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -74,6 +74,9 @@ namespace AndroidBinderator
 		[JsonProperty("templateSet")]
 		public string? TemplateSet { get; set; }
 
+		[JsonProperty ("skipExtendedTests")]
+		public bool SkipExtendedTests { get; set; }
+
 		public bool ShouldSerializeOverrideLicenses () => OverrideLicenses.Count > 0;
 
 		[JsonProperty ("overrideLicenses")]


### PR DESCRIPTION
- Add `"skipExtendedTests"` to `config.json`.  When set to `true`, the "extended" tests are not run for this package.  This allows us to get our test job green with the packages that currently work.  This way we can go ahead and have it running for currently working packages to ensure they do not regress.
- Set up a "nightly" job that will run the "extended" test suite every night.  Note that this will only run if there have been changes to `main` since the previous run, so it generally won't actually run every night.

Green CI run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10351430