### PR TITLE
[binderator] Add support for licenses specified in parent POMs.

### DIFF
--- a/config.json
+++ b/config.json
@@ -3587,11 +3587,7 @@
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.code.findbugs",
@@ -4406,11 +4402,7 @@
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.guava",
@@ -4421,11 +4413,7 @@
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.guava",
@@ -4435,11 +4423,7 @@
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.inject",
@@ -4449,11 +4433,7 @@
         "nugetId": "Xamarin.Google.Inject.Guice",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "The Apache Software License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.j2objc",
@@ -4774,11 +4754,7 @@
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "BSD-3-Clause|https://opensource.org/licenses/BSD-3-Clause"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.protobuf",
@@ -4789,11 +4765,7 @@
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "BSD-3-Clause|https://opensource.org/licenses/BSD-3-Clause"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.google.zxing",
@@ -4804,11 +4776,7 @@
         "dependencyOnly": false,
         "assemblyName": "Google.ZXing.Core",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.squareup",
@@ -4829,11 +4797,7 @@
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.squareup.okio.okio,com.google.android.android",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.squareup.okhttp3",
@@ -4924,11 +4888,7 @@
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp,com.google.code.gson.gson,com.google.android.android,io.reactivex.rxjava,com.google.appengine.appengine-api-1.0-sdk",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "com.squareup.retrofit2",
@@ -5200,11 +5160,7 @@
         "nugetId": "Xamarin.Brotli.Dec",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "MIT License|http://www.opensource.org/licenses/mit-license.php"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "org.checkerframework",
@@ -5268,11 +5224,7 @@
         "nugetId": "Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations",
         "dependencyOnly": false,
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "MIT license|https://spdx.org/licenses/MIT.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "org.jetbrains",
@@ -5545,11 +5497,7 @@
         "dependencyOnly": false,
         "assemblyName": "org.tensorflow.tensorflow-android",
         "type": "androidlibrary",
-        "mavenRepositoryType": "MavenCentral",
-        "overrideLicenses": [
-          "The Apache Software License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
-        ],
-        "comments": "License is specified in parent POM"
+        "mavenRepositoryType": "MavenCentral"
       },
       {
         "groupId": "org.tensorflow",
@@ -5834,6 +5782,11 @@
         "name": "ML Kit Terms of Service",
         "file": "templates/licenses/mlkit.txt",
         "proprietary": true
+      },
+      {
+        "name": "New BSD license",
+        "file": "templates/licenses/bsd.txt",
+        "spdx": "BSD-3-Clause"
       },
       {
         "name": "Play Core Software Development Kit Terms of Service",


### PR DESCRIPTION
Add support in `binderator` for finding licensing information that is specified in parent POM files.  This allows us to remove all of the hardcoded `overrideLicenses` info currently in `config.json`.