### PR TITLE
Don't make a NuGet package for binderator.

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,9 +6,7 @@
     "additionalProjects": [
       "source/androidx.appcompat/typeforwarders/androidx.appcompat.appcompat-resources-typeforwarders.csproj",
       "source/com.google.android.gms/play-services-basement/buildtasks/Basement-BuildTasks.csproj",
-      "util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj",
-      "util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj",
-      "util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj"
+      "util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj"
     ],
     "templates": [
       {

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ToolCommandName>xamarin-android-binderator</ToolCommandName>
     <AssemblyName>Xamarin.AndroidBinderator.Tool</AssemblyName>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Nullable>enable</Nullable>
     <RollForward>Major</RollForward>


### PR DESCRIPTION
We no longer use `binderator` outside of this repository.  Stop building a NuGet package and running package diffs on it to help remove some noise in the diff reports.