### PR TITLE
[binderator] Add check to ensure we use Xamarin.Build.Download for proprietary licensed artifacts.

### DIFF
--- a/config.json
+++ b/config.json
@@ -2360,9 +2360,7 @@
         "nugetVersion": "1.1.2.6",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "dependencyOnly": false,
-        "frozen": true,
-        "type": "androidlibrary",
-        "comments": "Changed from Apache to Android SDK License"
+        "type": "xbd"
       },
       {
         "groupId": "com.android.volley",
@@ -3559,7 +3557,7 @@
         "nugetVersion": "3.0.0.1",
         "nugetId": "Xamarin.Google.UserMessagingPlatform",
         "dependencyOnly": false,
-        "type": "androidlibrary"
+        "type": "xbd"
       },
       {
         "groupId": "com.google.assistant.appactions",
@@ -3575,7 +3573,8 @@
         "version": "0.0.1",
         "nugetVersion": "0.0.1.16",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
-        "dependencyOnly": false
+        "dependencyOnly": false,
+        "type": "xbd"
       },
       {
         "groupId": "com.google.auto.value",

--- a/source/_PackageLevelCustomizations.cshtml
+++ b/source/_PackageLevelCustomizations.cshtml
@@ -55,3 +55,14 @@
     <EmbeddedJar Include="..\..\externals\com.xamarin.google.android.play.feature.delivery.extensions\extensions.jar" />
   </ItemGroup>
 }
+
+@if (Model.Type == AndroidBinderator.BindingType.XamarinBuildDownload
+     && Model.NuGetPackageId != "Xamarin.Google.Android.InstallReferrer"
+     && Model.NuGetPackageId != "Xamarin.Google.UserMessagingPlatform"
+     && Model.NuGetPackageId != "Xamarin.Google.Assistant.AppActions.Widgets"
+     ) {
+  <ItemGroup>
+    <!-- GPS doesn't currently use <AndroidNamespaceReplacement> -->
+    <AndroidNamespaceReplacement Remove="@@(AndroidNamespaceReplacement)" />
+  </ItemGroup>
+}

--- a/source/_XBDProjectType.cshtml
+++ b/source/_XBDProjectType.cshtml
@@ -7,11 +7,7 @@
   var targets_path = "@" + @"(AndroidXNuGetTargetFolders->'%(Identity)\" + Model.NuGetPackageId + ".targets')";
 }
 
-  @* Long-term, GPS != XBD, but for now this is ok. (Long-term we also migrate to namespace replacements.) *@
   <ItemGroup>
-    <!-- GPS doesn't currently use <AndroidNamespaceReplacement> -->
-    <AndroidNamespaceReplacement Remove="@@(AndroidNamespaceReplacement)" />
-    
     <_AndroidDocumentationPath Include="..\..\externals\paramnames.txt" Condition="Exists('..\..\externals\paramnames.txt')" />
   </ItemGroup>
 

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectConverter.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/BindingProjectConverter.cs
@@ -82,6 +82,11 @@ static class BindingProjectConverter
 			license.Text = File.ReadAllText (license_file);
 		}
 
+		// Ensure we use Xamarin.Build.Download for any proprietary licenses
+		if (projectModel.Type != BindingType.XamarinBuildDownload)
+			foreach (var l in projectModel.Licenses)
+				if (l.LicenseConfig.Proprietary)
+					exceptions.Add (new Exception ($"Artifact '{mavenArtifact.GroupAndArtifactId}' has proprietary license '{l.Name}' and must use the `xbd` artifact type."));
 	}
 
 	static Collection<License> FindLicenses (BindingConfig config, MavenArtifactConfig mavenArtifact, Project mavenProject)


### PR DESCRIPTION
Update `binderator` to enforce that Java libraries with proprietary licenses are packaged using the `Xamarin.Build.Download` method.

Unfreeze `Xamarin.Google.Android.InstallReferrer` and bind newer versions that are no longer Apache licensed using `"type": "xbd"`.

Additionally, this check found 2 other libraries that are proprietary licensed and should be bound using the `Xamarin.Build.Download` method.  They are updated as well.