### PR TITLE
[ci] Create CI option to test running repository on next version of .NET.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,10 @@ parameters:
   displayName: Run Extended Tests?
   type: boolean
   default: false
+- name: RunDotnetNextTest
+  displayName: Run on .NET next preview?
+  type: boolean
+  default: false
   
 variables:
   # Variables used by both AndroidX/GPS go in the template
@@ -61,6 +65,7 @@ extends:
             image: $(windowsImage)
             os: windows
           runAPIScan: true
+          runDotnetNextTest: ${{ parameters.RunDotnetNextTest }}
 
     - stage: build_mac
       displayName: Build - Mac
@@ -74,6 +79,7 @@ extends:
             name: $(macosAgentPoolName)
             vmImage: $(macosImage)
             os: macOS
+          runDotnetNextTest: ${{ parameters.RunDotnetNextTest }}
 
     - template: build/ci/stage-standard-tests.yml@self
       parameters:

--- a/build.cake
+++ b/build.cake
@@ -18,6 +18,7 @@
 #load "build/cake/update-config.cake"
 #load "build/cake/tests.cake"
 #load "build/cake/gps-parameters.cake"
+#load "build/cake/dotnet-next.cake"
 
 using System.Text.RegularExpressions;
 using System.Xml;

--- a/build/cake/dotnet-next.cake
+++ b/build/cake/dotnet-next.cake
@@ -1,0 +1,34 @@
+// Updates repository to be tested on preview versions of .NET
+
+Task ("dotnet-next")
+    .Does (() =>
+{
+  var next_net_framework_version = Argument<string> ("framework-version");
+  var next_api_level_version = Argument<string> ("api-level-version");
+  var next_net_sdk_version = Argument<string> ("dotnet-version");
+  
+  Information ("");
+  Information ("Script Arguments:");
+  Information ("  dotnet Version: {0}", next_net_framework_version);
+  Information ("  dotnet TF Version: {0}", next_net_sdk_version);
+  Information ("  Android SDK API Level: {0}", next_api_level_version);
+  Information ("");
+
+  // Update global.json
+  var global_json = File ("global.json");
+  var json = JToken.Parse (FileReadText (global_json));
+  json["sdk"]["version"] = next_net_sdk_version;
+  
+  FileWriteText (global_json, json.ToString ());
+  
+  // Update Directory.Build.props
+  var directory_build = File ("Directory.Build.props");
+  
+  XmlPoke (directory_build, "/Project/PropertyGroup/_DefaultNetTargetFrameworks", $"net{next_net_framework_version}.0");
+  XmlPoke (directory_build, "/Project/PropertyGroup/_DefaultTargetFrameworks", $"net{next_net_framework_version}.0-android");
+
+  XmlPoke (directory_build, "/Project/ItemGroup/AndroidXNuGetTargetFolders[starts-with (@Include, 'build\\')]/@Include", $@"build\net{next_net_framework_version}.0-android{next_api_level_version}.0");
+  XmlPoke (directory_build, "/Project/ItemGroup/AndroidXNuGetTargetFolders[starts-with (@Include, 'buildTransitive\\')]/@Include", $@"buildTransitive\net{next_net_framework_version}.0-android{next_api_level_version}.0");
+
+  XmlPoke (directory_build, "/Project/ItemGroup/AndroidXNuGetLibFolders/@Include", $@"lib\net{next_net_framework_version}.0-android{next_api_level_version}.0");
+});    

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -6,6 +6,7 @@ parameters:
   # Build Parameters
   timeoutInMinutes: 300                                             # Max job runtime in minutes
   runAPIScan: false                                                 # Run APIScan analysis
+  runDotnetNextTest: false
   
   tools:                                                            # Additional .NET global tools to install
   - 'xamarin.androidbinderator.tool': '0.5.7'
@@ -38,6 +39,7 @@ jobs:
     - template: setup-environment.yml
       parameters:
         dotnetTools: ${{ parameters.tools }}
+        runDotnetNextTest: ${{ parameters.runDotnetNextTest }}
 
     - template: build-and-test.yml
       parameters:

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -1,5 +1,6 @@
 parameters:
   dotnetTools: []
+  runDotnetNextTest: false
   
 steps:
   # before the build starts, make sure the tooling is as expected
@@ -11,14 +12,46 @@ steps:
       includePreviewVersions: true
     condition: ne('$(dotnetVersion)', '')
 
-  - pwsh: |
-      dotnet workload install maui --verbosity diag --from-rollback-file $(dotnetWorkloadRollbackFile) --source $(dotnetWorkloadSource) --source $(dotnetNuGetOrgSource)
-      if ($LASTEXITCODE -ne 0) {
-          Write-Host "##vso[task.logissue type=error]Failed to install workloads."
-          Write-Host "##vso[task.complete result=Failed;]"
-          exit 0
-      }
-    displayName: Install .NET Workloads
+  - ${{ if eq(parameters.runDotnetNextTest, true) }}:
+    - task: UseDotNet@2
+      displayName: 'Use dotnet $(dotnetNextVersion)'
+      inputs:
+        version: $(dotnetNextVersion)
+        performMultiLevelLookup: true
+        includePreviewVersions: true
+      
+  - ${{ each tool in parameters.dotnetTools }}:
+    - ${{ each pair in tool }}:
+      - pwsh: dotnet tool update -g ${{ pair.key }} --version ${{ pair.value }}
+        displayName: 'Install tool: ${{ pair.key }}'
+
+  - ${{ if eq(parameters.runDotnetNextTest, true) }}:
+    - pwsh: |
+        dotnet cake -t=dotnet-next `
+          --dotnet-version="$(dotnetNextVersion)" `
+          --framework-version="$(dotnetNextFrameworkVersion)" `
+          --api-level-version="$(dotnetNextApiLevel)"
+      displayName: Set up dotnet-next test changes
+
+  - ${{ if eq(parameters.runDotnetNextTest, false) }}:
+    - pwsh: |
+        dotnet workload install maui --verbosity diag --from-rollback-file $(dotnetWorkloadRollbackFile) --source $(dotnetWorkloadSource) --source $(dotnetNuGetOrgSource)
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+            Write-Host "##vso[task.complete result=Failed;]"
+            exit 0
+        }
+      displayName: Install .NET Workloads
+
+  - ${{ if eq(parameters.runDotnetNextTest, true) }}:
+    - pwsh: |
+        dotnet workload install maui --verbosity diag
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+            Write-Host "##vso[task.complete result=Failed;]"
+            exit 0
+        }
+      displayName: Install Preview .NET Workloads
 
   - task: JavaToolInstaller@0
     displayName: Use Java 11 SDK
@@ -26,8 +59,3 @@ steps:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
-      
-  - ${{ each tool in parameters.dotnetTools }}:
-    - ${{ each pair in tool }}:
-      - pwsh: dotnet tool update -g ${{ pair.key }} --version ${{ pair.value }}
-        displayName: 'Install tool: ${{ pair.key }}'

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -33,3 +33,7 @@ variables:
   extendedTestProject: tests/extended/ExtendedTests.csproj                              # Extended tests project file
   extendedTestAssembly: tests/extended/bin/$(configuration)/net8.0/ExtendedTests.dll    # Extended tests compiled binary
 
+  # dotnet-next test variables
+  dotnetNextVersion: 9.0.100-rc.2.24474.11                                              # .NET preview version to install
+  dotnetNextFrameworkVersion: 9                                                         # The number to use for TF (eg: net9.0-android)
+  dotnetNextApiLevel: 35                                                                # The Android SDK API Level to use (eg: -android35.0)


### PR DESCRIPTION
We waited too late to ensure that this repository builds successfully on .NET 9, causing last-minute fixes in `generator`.  This is something we need to be doing throughout the entire preview cycle, even though we do not ship packages targeting the preview framework.

This PR creates a CI option that can be requested which will run the repository on the preview version of .NET N+1.

Once this test succeeds (hopefully with .NET 9 RTM!) we can enable it as a nightly test to ensure we are continuously testing our .NET previews instead of waiting until the end of the preview cycle.

CI run with this (the failure is expected): https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10401538