### PR TITLE
[ILLink] Fix trimmer warnings.

### DIFF
--- a/source/com.google.android.gms/play-services-base/Additions/ResultCallbackImpl.cs
+++ b/source/com.google.android.gms/play-services-base/Additions/ResultCallbackImpl.cs
@@ -4,17 +4,18 @@ using Java.Util.Concurrent;
 using Android.OS;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Android.Gms.Common.Apis
 {
     public static class IPendingResultExtensions
     {
-        public static void SetResultCallback<TResult> (this PendingResult pr, Action<TResult> callback) where TResult : class, IResult
+        public static void SetResultCallback<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> (this PendingResult pr, Action<TResult> callback) where TResult : class, IResult
         {
             pr.SetResultCallback (new ResultCallback<TResult> (callback));
         }
 
-        public static Task<TResult> AsAsync<TResult> (this PendingResult pr) where TResult : class, IResult
+        public static Task<TResult> AsAsync<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> (this PendingResult pr) where TResult : class, IResult
         {
             var rc = new AwaitableResultCallback<TResult> ();
 
@@ -32,7 +33,7 @@ namespace Android.Gms.Common.Apis
         //   await rc.AwaitAsync ();
         //}
 
-        public static TaskAwaiter<TResult> GetAwaiter<TResult> (this PendingResult pr) where TResult : class, IResult
+        public static TaskAwaiter<TResult> GetAwaiter<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> (this PendingResult pr) where TResult : class, IResult
         {
             var rc = new AwaitableResultCallback<TResult> ();
 

--- a/source/com.google.android.gms/play-services-basement/Additions/ResultCallbackImpl.cs
+++ b/source/com.google.android.gms/play-services-basement/Additions/ResultCallbackImpl.cs
@@ -4,10 +4,11 @@ using Java.Util.Concurrent;
 using Android.OS;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Android.Gms.Common.Apis
 {
-    public class ResultCallback<TResult> : Java.Lang.Object, IResultCallback where TResult : class, IResult
+    public class ResultCallback<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> : Java.Lang.Object, IResultCallback where TResult : class, IResult
     {
         public ResultCallback (Action<TResult> handler)
         {
@@ -24,7 +25,7 @@ namespace Android.Gms.Common.Apis
         }
     }
 
-    public class AwaitableResultCallback<TResult> : Java.Lang.Object, IResultCallback where TResult : class, IResult
+    public class AwaitableResultCallback<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> : Java.Lang.Object, IResultCallback where TResult : class, IResult
     {
         public AwaitableResultCallback ()
         {

--- a/source/com.google.android.gms/play-services-tasks/Additions/Task.cs
+++ b/source/com.google.android.gms/play-services-tasks/Additions/Task.cs
@@ -3,13 +3,14 @@ using Android.Runtime;
 using Android.Gms.Tasks;
 using System.Runtime.CompilerServices;
 using Android.Gms.Extensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Android.Gms.Extensions
 {
     public static class TasksExtensions
     {
         
-        public static System.Threading.Tasks.Task<TResult> AsAsync<TResult> (this Task task) where TResult : class, IJavaObject
+        public static System.Threading.Tasks.Task<TResult> AsAsync<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> (this Task task) where TResult : class, IJavaObject
         {
             var c = new AwaitableTaskCompleteListener<TResult> ();
 
@@ -29,7 +30,7 @@ namespace Android.Gms.Extensions
             return c.AwaitAsync ();
         }
 
-        public static TaskAwaiter<TResult> GetAwaiter<TResult> (this Task task) where TResult : class, IJavaObject
+        public static TaskAwaiter<TResult> GetAwaiter<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> (this Task task) where TResult : class, IJavaObject
         {
             var c = new AwaitableTaskCompleteListener<TResult> ();
 
@@ -49,7 +50,7 @@ namespace Android.Gms.Extensions
     }
 
     [Android.Runtime.Preserve]
-    class AwaitableTaskCompleteListener<TResult> : Java.Lang.Object, IOnCompleteListener where TResult : class, IJavaObject
+    class AwaitableTaskCompleteListener<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TResult> : Java.Lang.Object, IOnCompleteListener where TResult : class, IJavaObject
     {
         System.Threading.Tasks.TaskCompletionSource<TResult> taskCompletionSource;
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/AndroidX/issues/1018

Fixes instances of:

```
C:\code\AndroidX\source\com.google.android.gms\play-services-tasks\Additions\Task.cs(66,62): warning IL2091: 'TResult' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.Runtime.Extensions.JavaCast<TResult>(IJavaObject)'. The generic parameter 'TResult' of 'Android.Gms.Extensions.AwaitableTaskCompleteListener<TResult>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
C:\code\AndroidX\source\com.google.android.gms\play-services-basement\Additions\ResultCallbackImpl.cs(23,19): warning IL2091: 'TResult' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.Runtime.Extensions.JavaCast<TResult>(IJavaObject)'. The generic parameter 'TResult' of 'Android.Gms.Common.Apis.ResultCallback<TResult>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
C:\code\AndroidX\source\com.google.android.gms\play-services-basement\Additions\ResultCallbackImpl.cs(38,21): warning IL2091: 'TResult' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in 'Android.Runtime.Extensions.JavaCast<TResult>(IJavaObject)'. The generic parameter 'TResult' of 'Android.Gms.Common.Apis.AwaitableResultCallback<TResult>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

When consumed in a `net9.0-android` project, these packages produce user warnings like:

```
C:\Users\me\.nuget\packages\xamarin.googleplayservices.tasks\118.2.0.2\lib\net8.0-android34.0\Xamarin.GooglePlayServices.Tasks.dll : warning IL2104: Assembly 'Xamarin.GooglePlayServices.Tasks' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries 
```