### PR TITLE
Suppress binding warnings.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,9 +22,6 @@
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 
-    <!-- Mark .NET6+ packages as supporting trimming -->
-    <IsTrimmable>true</IsTrimmable>
-
     <!-- Assemblies should be deterministic -->
     <Deterministic>true</Deterministic>
     
@@ -35,6 +32,38 @@
     <!-- NU5104: A stable release of a package should not have a prerelease dependency. -->
     <WarningsAsErrors>$(WarningsAsErrors);NU5104</WarningsAsErrors>
     
+    <!-- Ignore binding generator warnings by default -->
+    <_AndroidIgnoreGeneratorWarnings>true</_AndroidIgnoreGeneratorWarnings>
+    
+    <!-- 
+      BG8102: Class 'foo' has unknown base type 'foo'.
+      BG8103: Class 'foo' has invalid base type 'foo'.
+      BG8300: For constructor 'foo', could not find enclosing type 'foo'.
+      BG8400: Unexpected field type `foo` (foo).
+      BG8401: Skipping 'foo' due to a duplicate nested type name. (Java type: 'foo')
+      BG8402: Skipping 'foo' due to a duplicate field. (Java type: 'foo')
+      BG8403: Type 'foo' has a type name which matches the enclosing namespace name. See https://aka.ms/BG8403 for more information.
+      BG8501: No event name provided in 'foo'.
+      BG8502: Invalidating 'IFoo' and all its nested types because some of its interfaces were invalid.
+      BG8503: Invalidating 'IFoo' and all its nested types because some of its methods were invalid.
+      BG8504: Event name for 'foo' is invalid. A valid 'eventName' or 'argsType' can be assigned by adding a rule to the Metadata.xml transforms file.
+      BG8601: No '<package>' elements found.
+      BG8604: Could not find top ancestor type 'foo' for nested type 'foo'.
+      BG8605: The Java type 'foo' could not be found (are you missing a Java reference jar/aar or a Java binding library NuGet?)
+      BG8606: Some types or members could not be bound because referenced Java types could not be found. See the 'java-resolution-report.log' file for details.
+      BG8700: Unknown return type 'foo' for member 'foo'.
+      BG8701: Invalid return type 'foo' for member 'foo'.
+      BG8800: Unknown parameter type 'foo' for member 'foo (foo)'.
+      BG8801: Invalid parameter type 'foo' for member 'foo'.
+      BG8A00: Metadata.xml element '<foo>' matched no nodes.
+      BG8A01: Metadata.xml element '<add-node path="foo" />' matched no nodes.
+      BG8A04: Metadata.xml element '<attr path="foo" />' matched no nodes.
+      BG8B00: Unknown generic argument constraint type 'S' for member 'foo'.
+      BG8C00: Could not find base interface 'foo' for type 'foo'.      
+      BG8C01: For type 'IFoo', base interface 'foo' is invalid.      
+    -->
+    <NoWarn Condition=" '$(_AndroidIgnoreGeneratorWarnings)' == 'true' ">$(NoWarn);BG8102;BG8103;BG8300;BG8400;BG8401;BG8402;BG8403;BG8501;BG8502;BG8503;BG8504;BG8601;BG8604;BG8605;BG8606;BG8700;BG8701;BG8800;BG8801;BG8A00;BG8A01;BG8A04;BG8B00;BG8C00;BG8C01;nullable</NoWarn>
+
     <!-- Common package metadata -->
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,4 +15,10 @@
       <_ProjectReferencesWithVersions Include="@(_ProjectReferenceWithReassignedVersion)" />
     </ItemGroup>
   </Target>
+  
+  <PropertyGroup>
+    <!-- Mark .NET6+ packages as supporting trimming -->
+    <IsTrimmable Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))', '6.0')) ">true</IsTrimmable>
+  </PropertyGroup>
+
 </Project>

--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -23,7 +23,7 @@
        - CS1572: XML comment has a param tag for '', but there is no parameter by that name
        - XAOBS001: While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk. 
     -->
-    <NoWarn>0618;0109;0114;0628;0108;0809;1572;XAOBS001</NoWarn>
+    <NoWarn>$(NoWarn);0618;0109;0114;0628;0108;0809;1572;XAOBS001</NoWarn>
 
 @if (Model.AllowPrereleaseDependencies) {
     <!-- Allow this package to have prerelease dependencies -->


### PR DESCRIPTION
Suppress the warnings emitted by `generator` by default.  These 19K+ warnings are clearly not things that we intend to take action on, and hide warnings we ***might*** want to take action on.

This is controlled via the `$(_AndroidIgnoreGeneratorWarnings)` property.

If seeing these warnings is desired on a local build, either:
- Change `$(_AndroidIgnoreGeneratorWarnings)` to `false` in the `Directory.Build.props` file.
- Pass it as a build property:
  - `dotnet build -p:_AndroidIgnoreGeneratorWarnings=false`

Also fix some `IsTrimmable` warnings by not enabling it on `netstandard2.0` projects.