### PR TITLE
[ci] `macos12` is no longer available, use `macos14`.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,8 +77,10 @@ extends:
           name: macos
           buildPool:
             name: $(macosAgentPoolName)
-            vmImage: $(macosImage)
             os: macOS
+            demands:
+              - macOS.Name -equals Sonoma
+              - macOS.Architecture -equals x64
           runDotnetNextTest: ${{ parameters.RunDotnetNextTest }}
 
     - template: build/ci/stage-standard-tests.yml@self

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -53,8 +53,14 @@ steps:
         }
       displayName: Install Preview .NET Workloads
 
+  - bash: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home"
+    displayName: Use Java 11 SDK (Mac)
+    condition: eq( variables['Agent.OS'], 'Darwin' )
+          
   - task: JavaToolInstaller@0
-    displayName: Use Java 11 SDK
+    displayName: Use Java 11 SDK (Windows)
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
     inputs:
       versionSpec: '11'
       jdkArchitectureOption: 'x64'

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -16,8 +16,7 @@ variables:
   windowsImage: 1ESPT-Windows2022                                                       # Windows VM image name
   
   # macOS specific variables
-  macosAgentPoolName: Azure Pipelines                                                   # macOS VM pool name
-  macosImage: internal-macos12                                                          # macOS VM image name
+  macosAgentPoolName: VSEng-VSMac-Xamarin-Shared                                        # macOS VM pool name
   
   # Tool variables
   dotnetVersion: '8.0.403'                                                              # .NET version to install on agent

--- a/utilities.cake
+++ b/utilities.cake
@@ -1620,6 +1620,7 @@ Task("tools-executive-oreder-csv-and-markdown")
     (
         () =>
         {
+        try {
             StringBuilder sb = new StringBuilder();
             StringBuilder sb_md = new StringBuilder();
             sb.AppendLine("BuildToolName,BuildToolVersion");
@@ -1887,6 +1888,10 @@ Task("tools-executive-oreder-csv-and-markdown")
 			System.IO.File.WriteAllText("./docs/buildtoolsinventory.md", sb_md.ToString());
 
             return;
+        } catch (Exception ex) { 
+          // Don't fail the build if this fails.
+          Console.WriteLine (ex); 
+        }
         }
     );
 


### PR DESCRIPTION
The Mac pool we use `internal-macos12` is no longer available.  Ideally we could just use the public Azure Pipelines pool, but those machines are underpowered and doubles the (already long!) time taken to build our packages.  Switch to the internal `VSEng-VSMac-Xamarin-Shared` mac pool already in use by `dotnet/android` and MAUI.

`JavaToolInstaller@0` does not seem to work on this image, even though there are many versions of Java SDK already installed on the image.  Set `JAVA_HOME` to Java SDK 11 so we can build.

Additionally, the `tools-executive-oreder-csv-and-markdown` Cake task does not work on these images because it expects `gradle` and other tools to be available in the `$PATH` which they aren't.  As we do not consume or ship these files from the build, add a try/catch block to the task so that it does not fail the build if it fails.