### PR TITLE
[ci] increase signing timeout to 120 minutes

### DIFF
--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -10,6 +10,7 @@ stages:
   
   - template: sign-artifacts/jobs/v2.yml@yaml-templates
     parameters:
+      timeoutInMinutes: 120
       artifactName: output-windows
       usePipelineArtifactTasks: true
       use1ESTemplate: true


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates?path=/sign-artifacts/jobs/v2.yml&version=GBmain&line=43&lineEnd=43&lineStartColumn=1&lineEndColumn=82&lineStyle=plain&_a=contents

dotnet/android-libraries/main has increased the size of packages due to the `net10.0-android` target framework.

Increase the timeout of the signing step to account for this.