### PR TITLE
[config.json] realign new packages with `bump-config`

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,49 +12,49 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.1",
+        "nugetVersion": "1.10.1.2",
         "nugetId": "Xamarin.AndroidX.Activity"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-compose",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.1",
+        "nugetVersion": "1.10.1.2",
         "nugetId": "Xamarin.AndroidX.Activity.Compose"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.1",
+        "nugetVersion": "1.10.1.2",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.31-alpha05",
+        "nugetVersion": "1.0.0.32-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.31-alpha05",
+        "nugetVersion": "1.0.0.32-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.31-alpha05",
+        "nugetVersion": "1.0.0.32-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.9.1",
-        "nugetVersion": "1.9.1.3",
+        "nugetVersion": "1.9.1.4",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "extraDependencies": "androidx.annotation.annotation-jvm"
       },
@@ -62,623 +62,623 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.9",
+        "nugetVersion": "1.4.1.10",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation-jvm",
         "version": "1.9.1",
-        "nugetVersion": "1.9.1.3",
+        "nugetVersion": "1.9.1.4",
         "nugetId": "Xamarin.AndroidX.Annotation.Jvm"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.6",
+        "nugetVersion": "1.7.0.7",
         "nugetId": "Xamarin.AndroidX.AppCompat"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.6",
+        "nugetVersion": "1.7.0.7",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.16",
+        "nugetVersion": "2.2.0.17",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.16",
+        "nugetVersion": "2.2.0.17",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime"
       },
       {
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater"
       },
       {
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.31",
+        "nugetVersion": "1.1.0.32",
         "nugetId": "Xamarin.AndroidX.AutoFill"
       },
       {
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.28",
+        "nugetVersion": "1.1.0.29",
         "nugetId": "Xamarin.AndroidX.Biometric"
       },
       {
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.8.0",
-        "nugetVersion": "1.8.0.9",
+        "nugetVersion": "1.8.0.10",
         "nugetId": "Xamarin.AndroidX.Browser"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Core"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-effects",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Effects"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-extensions",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Extensions"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-mlkit-vision",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.MLKit.Vision"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-video",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.Video"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.1",
+        "nugetVersion": "1.4.2.2",
         "nugetId": "Xamarin.AndroidX.Camera.View"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.30-alpha7",
+        "nugetVersion": "1.0.0.31-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.30-alpha5",
+        "nugetVersion": "1.0.0.31-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster"
       },
       {
         "groupId": "androidx.car.app",
         "artifactId": "app",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.7",
+        "nugetVersion": "1.4.0.8",
         "nugetId": "Xamarin.AndroidX.Car.App.App"
       },
       {
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.34",
+        "nugetVersion": "1.0.0.35",
         "nugetId": "Xamarin.AndroidX.CardView"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.1",
+        "nugetVersion": "1.5.0.2",
         "nugetId": "Xamarin.AndroidX.Collection"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-jvm",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.1",
+        "nugetVersion": "1.5.0.2",
         "nugetId": "Xamarin.AndroidX.Collection.Jvm"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-ktx",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.1",
+        "nugetVersion": "1.5.0.2",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Android"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core.Android"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple.Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.1",
+        "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-android",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.1",
+        "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.1",
+        "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClass"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class-android",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.1",
+        "nugetVersion": "1.3.2.2",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClassAndroid"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-livedata",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.LiveData"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-viewbinding",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.1",
+        "nugetVersion": "1.7.8.2",
         "nugetId": "Xamarin.AndroidX.Compose.UI.ViewBinding"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.6",
+        "nugetVersion": "1.2.0.7",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures-ktx",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.6",
+        "nugetVersion": "1.2.0.7",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures.Ktx"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.2.1",
-        "nugetVersion": "2.2.1.1",
+        "nugetVersion": "2.2.1.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-core",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.1",
+        "nugetVersion": "1.1.1.2",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Core"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.27",
+        "nugetVersion": "2.0.4.28",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver"
       },
       {
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.ContentPager"
       },
       {
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.16.0",
-        "nugetVersion": "1.16.0.1",
+        "nugetVersion": "1.16.0.2",
         "nugetId": "Xamarin.AndroidX.Core"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.6",
+        "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.AndroidX.Core.Animation"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.17",
+        "nugetVersion": "1.1.0.18",
         "nugetId": "Xamarin.AndroidX.Core.GoogleShortcuts"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.16.0",
-        "nugetVersion": "1.16.0.1",
+        "nugetVersion": "1.16.0.2",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Core.Role"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-splashscreen",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.15",
+        "nugetVersion": "1.0.1.16",
         "nugetId": "Xamarin.AndroidX.Core.SplashScreen"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-viewtree",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
+        "nugetVersion": "1.0.0.2",
         "nugetId": "Xamarin.AndroidX.Core.ViewTree"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.1",
+        "nugetVersion": "1.5.0.2",
         "nugetId": "Xamarin.AndroidX.Credentials"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials-play-services-auth",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.1",
+        "nugetVersion": "1.5.0.2",
         "nugetId": "Xamarin.AndroidX.Credentials.PlayServicesAuth",
         "allowPrereleaseDependencies": true
       },
@@ -686,84 +686,84 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.CursorAdapter"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.31",
+        "nugetVersion": "1.1.0.32",
         "nugetId": "Xamarin.AndroidX.CustomView"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview-poolingcontainer",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.18",
+        "nugetVersion": "1.0.0.19",
         "nugetId": "Xamarin.AndroidX.CustomView.PoolingContainer"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-adapters",
         "version": "8.9.1",
-        "nugetVersion": "8.9.1.1",
+        "nugetVersion": "8.9.1.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-common",
         "version": "8.9.1",
-        "nugetVersion": "8.9.1.1",
+        "nugetVersion": "8.9.1.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-runtime",
         "version": "8.9.1",
-        "nugetVersion": "8.9.1.1",
+        "nugetVersion": "8.9.1.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "viewbinding",
         "version": "8.9.1",
-        "nugetVersion": "8.9.1.1",
+        "nugetVersion": "8.9.1.2",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-android",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Core"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-android",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-jvm",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Jvm",
         "extraDependencies": "androidx.datastore.datastore-core-android",
         "comments": "Empty package we want to redirect to Xamarin.AndroidX.DataStore.Core.Android because it is a superset of this package, causing conflicts."
@@ -772,133 +772,133 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio-jvm",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-android",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core-jvm",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-external-protobuf",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.External.Protobuf"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-proto",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Proto"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava2",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava2"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava3",
         "version": "1.1.4",
-        "nugetVersion": "1.1.4.1",
+        "nugetVersion": "1.1.4.2",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava3"
       },
       {
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.32",
+        "nugetVersion": "1.0.1.33",
         "nugetId": "Xamarin.AndroidX.DocumentFile"
       },
       {
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.16",
+        "nugetVersion": "1.2.0.17",
         "nugetId": "Xamarin.AndroidX.DrawerLayout"
       },
       {
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.27",
+        "nugetVersion": "1.1.0.28",
         "nugetId": "Xamarin.AndroidX.Emoji"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.27",
+        "nugetVersion": "1.1.0.28",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.27",
+        "nugetVersion": "1.1.0.28",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.4",
+        "nugetVersion": "1.5.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji2"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-bundled",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.4",
+        "nugetVersion": "1.5.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji2.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-emojipicker",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.4",
+        "nugetVersion": "1.5.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji2.EmojiPicker",
         "skipExtendedTests": true,
         "comments": "Skip tests due to explicit dependency version request causes conflicts"
@@ -907,833 +907,833 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.4",
+        "nugetVersion": "1.5.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji2.Views"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views-helper",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.4",
+        "nugetVersion": "1.5.0.5",
         "nugetId": "Xamarin.AndroidX.Emoji2.ViewsHelper"
       },
       {
         "groupId": "androidx.enterprise",
         "artifactId": "enterprise-feedback",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.18",
+        "nugetVersion": "1.1.0.19",
         "nugetId": "Xamarin.AndroidX.Enterprise.Feedback"
       },
       {
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.ExifInterface"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.8.6",
-        "nugetVersion": "1.8.6.1",
+        "nugetVersion": "1.8.6.2",
         "nugetId": "Xamarin.AndroidX.Fragment"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment-ktx",
         "version": "1.8.6",
-        "nugetVersion": "1.8.6.1",
+        "nugetVersion": "1.8.6.2",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx"
       },
       {
         "groupId": "androidx.graphics",
         "artifactId": "graphics-path",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.4",
+        "nugetVersion": "1.0.1.5",
         "nugetId": "Xamarin.AndroidX.Graphics.Path"
       },
       {
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.GridLayout"
       },
       {
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.HeifWriter"
       },
       {
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Interpolator"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.34",
+        "nugetVersion": "1.0.0.35",
         "nugetId": "Xamarin.AndroidX.Leanback"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-java8",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-jvm",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Jvm"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.32",
+        "nugetVersion": "2.2.0.33",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core-ktx",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams-ktx",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-android",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose-android",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx-android",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-android",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose-android",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-ktx",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.8.7",
-        "nugetVersion": "2.8.7.3",
+        "nugetVersion": "2.8.7.4",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState"
       },
       {
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.32",
+        "nugetVersion": "1.1.0.33",
         "nugetId": "Xamarin.AndroidX.Loader"
       },
       {
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.20",
+        "nugetVersion": "1.1.0.21",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager"
       },
       {
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.10",
+        "nugetVersion": "1.7.0.11",
         "nugetId": "Xamarin.AndroidX.Media"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.10",
+        "nugetVersion": "1.3.0.11",
         "nugetId": "Xamarin.AndroidX.Media2.Common"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.10",
+        "nugetVersion": "1.3.0.11",
         "nugetId": "Xamarin.AndroidX.Media2.Session"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.10",
+        "nugetVersion": "1.3.0.11",
         "nugetId": "Xamarin.AndroidX.Media2.Widget"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-cast",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Cast"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-common",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Common"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-container",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Container"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-database",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Database"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-cronet",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.CroNet"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-rtmp",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.Rtmp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-decoder",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Decoder"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-effect",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Effect"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-dash",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Dash"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-hls",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Hls"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-rtsp",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Rtsp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-smoothstreaming",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.SmoothStreaming"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-workmanager",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.WorkManager"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-extractor",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Extractor"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-muxer",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Muxer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-session",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Session"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-transformer",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Transformer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Ui"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui-leanback",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1.1",
+        "nugetVersion": "1.6.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Ui.Leanback"
       },
       {
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.9",
+        "nugetVersion": "1.7.0.10",
         "nugetId": "Xamarin.AndroidX.MediaRouter"
       },
       {
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.32",
+        "nugetVersion": "2.0.1.33",
         "nugetId": "Xamarin.AndroidX.MultiDex"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Common"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-ktx",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment-ktx",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-ktx",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.UI"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui-ktx",
         "version": "2.8.9",
-        "nugetVersion": "2.8.9.1",
+        "nugetVersion": "2.8.9.2",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.Common"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common-jvm",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Jvm"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common-ktx",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime-ktx",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2-ktx",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.1",
+        "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2.Ktx"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Palette"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette-ktx",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.25",
+        "nugetVersion": "1.0.0.26",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx"
       },
       {
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.PercentLayout"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.13",
+        "nugetVersion": "1.2.1.14",
         "nugetId": "Xamarin.AndroidX.Preference"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.13",
+        "nugetVersion": "1.2.1.14",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx"
       },
       {
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Print"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices",
         "version": "1.1.0-beta11",
-        "nugetVersion": "1.1.0.1-beta11",
+        "nugetVersion": "1.1.0.2-beta11",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices-java",
         "version": "1.1.0-beta11",
-        "nugetVersion": "1.1.0.1-beta11",
+        "nugetVersion": "1.1.0.2-beta11",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices.Java"
       },
       {
         "groupId": "androidx.profileinstaller",
         "artifactId": "profileinstaller",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.3",
+        "nugetVersion": "1.4.1.4",
         "nugetId": "Xamarin.AndroidX.ProfileInstaller.ProfileInstaller"
       },
       {
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Recommendation"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.RecyclerView"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.26",
+        "nugetVersion": "1.1.0.27",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection"
       },
       {
         "groupId": "androidx.resourceinspection",
         "artifactId": "resourceinspection-annotation",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.20",
+        "nugetVersion": "1.0.1.21",
         "nugetId": "Xamarin.AndroidX.ResourceInspection.Annotation"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Common"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Guava"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-ktx",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Runtime"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava2",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava3",
         "version": "2.6.1",
-        "nugetVersion": "2.6.1.10",
+        "nugetVersion": "2.6.1.11",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.16",
+        "nugetVersion": "1.2.1.17",
         "nugetId": "Xamarin.AndroidX.SavedState"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.16",
+        "nugetVersion": "1.2.1.17",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx"
       },
       {
         "groupId": "androidx.security",
         "artifactId": "security-crypto",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.25",
+        "nugetVersion": "1.0.0.26",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Slice.Builders"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Slice.Core"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.32",
+        "nugetVersion": "1.0.0.33",
         "nugetId": "Xamarin.AndroidX.Slice.View"
       },
       {
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.20",
+        "nugetVersion": "1.2.0.21",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.11",
+        "nugetVersion": "2.4.0.12",
         "nugetId": "Xamarin.AndroidX.Sqlite"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.11",
+        "nugetVersion": "2.4.0.12",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework"
       },
       {
         "groupId": "androidx.startup",
         "artifactId": "startup-runtime",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.4",
         "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime"
       },
       {
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.27",
+        "nugetVersion": "1.1.0.28",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.10",
+        "nugetVersion": "1.2.0.11",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing-ktx",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.10",
+        "nugetVersion": "1.2.0.11",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing.Ktx"
       },
       {
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.5",
+        "nugetVersion": "1.5.1.6",
         "nugetId": "Xamarin.AndroidX.Transition",
         "extraDependencies": "androidx.fragment.fragment"
       },
@@ -1741,119 +1741,119 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.34",
+        "nugetVersion": "1.0.0.35",
         "nugetId": "Xamarin.AndroidX.TvProvider"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.6",
+        "nugetVersion": "1.2.0.7",
         "nugetId": "Xamarin.AndroidX.VectorDrawable"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.6",
+        "nugetVersion": "1.2.0.7",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated"
       },
       {
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.1",
+        "nugetVersion": "1.2.1.2",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable"
       },
       {
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.ViewPager"
       },
       {
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.6",
+        "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.ViewPager2"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.13",
+        "nugetVersion": "1.3.0.14",
         "nugetId": "Xamarin.AndroidX.Wear"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-input",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Wear.Input"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-ongoing",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.22",
+        "nugetVersion": "1.0.0.23",
         "nugetId": "Xamarin.AndroidX.Wear.Ongoing"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-phone-interactions",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.PhoneInteractions"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-remote-interactions",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.RemoteInteractions"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-foundation",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.1",
+        "nugetVersion": "1.4.1.2",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Foundation"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.1",
+        "nugetVersion": "1.4.1.2",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material-core",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.1",
+        "nugetVersion": "1.4.1.2",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material.Core"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-navigation",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.1",
+        "nugetVersion": "1.4.1.2",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Navigation"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.3",
+        "nugetVersion": "1.2.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.3",
+        "nugetVersion": "1.2.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression",
         "excludedRuntimeDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
         "extraDependencies": "org.jetbrains.kotlin.kotlin-stdlib"
@@ -1862,49 +1862,49 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression-pipeline",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.3",
+        "nugetVersion": "1.2.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression.Pipeline"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-external-protobuf",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.3",
+        "nugetVersion": "1.2.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.External.Protobuf"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-proto",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.3",
+        "nugetVersion": "1.2.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.3",
+        "nugetVersion": "1.4.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-material",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.3",
+        "nugetVersion": "1.4.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Material"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-proto",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.3",
+        "nugetVersion": "1.4.1.4",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-renderer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.17",
+        "nugetVersion": "1.1.0.18",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Renderer",
         "frozen": true,
         "comments": "Needs androidx.wear.protolayout.protolayout-renderer:1.1.0"
@@ -1913,175 +1913,175 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Client"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.ClientGuava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source.Ktx"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-rendering",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Rendering"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-data",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Guava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-style",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.10",
+        "nugetVersion": "1.2.1.11",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Style"
       },
       {
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0.1",
+        "nugetVersion": "1.13.0.2",
         "nugetId": "Xamarin.AndroidX.WebKit"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.6",
+        "nugetVersion": "1.3.0.7",
         "nugetId": "Xamarin.AndroidX.Window"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.27-alpha01",
+        "nugetVersion": "1.0.0.28-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.6",
+        "nugetVersion": "1.3.0.7",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava2",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.6",
+        "nugetVersion": "1.3.0.7",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava2"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava3",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.6",
+        "nugetVersion": "1.3.0.7",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava3"
       },
       {
         "groupId": "androidx.window.extensions.core",
         "artifactId": "core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.14",
+        "nugetVersion": "1.0.0.15",
         "nugetId": "Xamarin.AndroidX.Window.Extensions.Core.Core"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-gcm",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.GCM"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-multiprocess",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.MultiProcess"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.Runtime"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime-ktx",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava2",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.RxJava2"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava3",
         "version": "2.10.0",
-        "nugetVersion": "2.10.0.4",
+        "nugetVersion": "2.10.0.5",
         "nugetId": "Xamarin.AndroidX.Work.RxJava3"
       },
       {
         "groupId": "aopalliance",
         "artifactId": "aopalliance",
         "version": "1.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AopAlliance",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2090,7 +2090,7 @@
         "groupId": "com.android.billingclient",
         "artifactId": "billing",
         "version": "7.1.1",
-        "nugetVersion": "7.1.1.3",
+        "nugetVersion": "7.1.1.4",
         "nugetId": "Xamarin.Android.Google.BillingClient",
         "type": "xbd"
       },
@@ -2098,7 +2098,7 @@
         "groupId": "com.android.billingclient",
         "artifactId": "billing-ktx",
         "version": "7.1.1",
-        "nugetVersion": "7.1.1.3",
+        "nugetVersion": "7.1.1.4",
         "nugetId": "Xamarin.Android.Google.BillingClient.Ktx",
         "type": "xbd"
       },
@@ -2106,7 +2106,7 @@
         "groupId": "com.android.installreferrer",
         "artifactId": "installreferrer",
         "version": "2.2",
-        "nugetVersion": "2.2.0.3",
+        "nugetVersion": "2.2.0.4",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "type": "xbd"
       },
@@ -2114,7 +2114,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.16",
+        "nugetVersion": "1.2.1.17",
         "nugetId": "Xamarin.Android.Volley",
         "type": "xbd"
       },
@@ -2122,7 +2122,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley-cronet",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.16",
+        "nugetVersion": "1.2.1.17",
         "nugetId": "Xamarin.Android.Volley.CroNet",
         "type": "xbd"
       },
@@ -2130,7 +2130,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "annotations",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2139,7 +2139,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "avif-integration",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide.AVIF.Integration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2148,7 +2148,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "disklrucache",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide.DiskLruCache",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2157,7 +2157,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "gifdecoder",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide.GifDecoder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2166,7 +2166,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "glide",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2175,7 +2175,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "recyclerview-integration",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.12",
+        "nugetVersion": "4.16.0.13",
         "nugetId": "Xamarin.Android.Glide.RecyclerViewIntegration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2184,7 +2184,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-appcompat-theme",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.AppCompat.Theme",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2193,7 +2193,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-drawablepainter",
         "version": "0.37.2",
-        "nugetVersion": "0.37.2.1",
+        "nugetVersion": "0.37.2.2",
         "nugetId": "Xamarin.Google.Accompanist.DrawablePainter",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2202,7 +2202,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-flowlayout",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.FlowLayout",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2211,7 +2211,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.Pager",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2220,7 +2220,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager-indicators",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.Pager.Indicators",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2229,7 +2229,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-permissions",
         "version": "0.37.2",
-        "nugetVersion": "0.37.2.1",
+        "nugetVersion": "0.37.2.2",
         "nugetId": "Xamarin.Google.Accompanist.Permissions",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2238,7 +2238,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2247,7 +2247,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder-material",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder.Material",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2256,7 +2256,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-swiperefresh",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.SwipeRefresh",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2265,7 +2265,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-systemuicontroller",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.4",
+        "nugetVersion": "0.36.0.5",
         "nugetId": "Xamarin.Google.Accompanist.SystemUIController",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2274,7 +2274,7 @@
         "groupId": "com.google.ads.interactivemedia.v3",
         "artifactId": "interactivemedia",
         "version": "3.36.0",
-        "nugetVersion": "3.36.0.2",
+        "nugetVersion": "3.36.0.3",
         "nugetId": "Xamarin.Google.Ads.InteractiveMedia.V3.InteractiveMedia",
         "type": "xbd"
       },
@@ -2282,7 +2282,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT",
         "type": "androidlibrary"
       },
@@ -2290,7 +2290,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-api",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.API",
         "type": "androidlibrary"
       },
@@ -2298,7 +2298,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU",
         "type": "androidlibrary"
       },
@@ -2306,7 +2306,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu-api",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU.API",
         "type": "androidlibrary"
       },
@@ -2314,7 +2314,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-metadata",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Metadata",
         "type": "androidlibrary"
       },
@@ -2322,7 +2322,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support",
         "type": "androidlibrary"
       },
@@ -2330,7 +2330,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support-api",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support.API",
         "allowPrereleaseDependencies": true,
         "type": "androidlibrary",
@@ -2340,7 +2340,7 @@
         "groupId": "com.google.android",
         "artifactId": "annotations",
         "version": "4.1.1.4",
-        "nugetVersion": "4.1.1.21",
+        "nugetVersion": "4.1.1.22",
         "nugetId": "Xamarin.GoogleAndroid.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2349,7 +2349,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-api",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.3",
+        "nugetVersion": "4.0.0.4",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
         "type": "androidlibrary"
       },
@@ -2357,7 +2357,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-backend-cct",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.3",
+        "nugetVersion": "4.0.0.4",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
         "type": "androidlibrary"
       },
@@ -2365,7 +2365,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-runtime",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.3",
+        "nugetVersion": "4.0.0.4",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
         "type": "androidlibrary"
       },
@@ -2373,7 +2373,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.1",
+        "nugetVersion": "124.0.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads",
         "allowPrereleaseDependencies": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
@@ -2383,7 +2383,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-base",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.1",
+        "nugetVersion": "124.0.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Base",
         "type": "xbd"
       },
@@ -2391,7 +2391,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-identifier",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.2",
+        "nugetVersion": "118.2.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Identifier",
         "type": "xbd"
       },
@@ -2399,7 +2399,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-lite",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.1",
+        "nugetVersion": "124.0.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Lite",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -2408,7 +2408,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-afs-native",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.5",
+        "nugetVersion": "119.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.AFS.Native",
         "type": "xbd"
       },
@@ -2416,7 +2416,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.3",
+        "nugetVersion": "118.1.1.4",
         "nugetId": "Xamarin.GooglePlayServices.Analytics",
         "type": "xbd"
       },
@@ -2424,7 +2424,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics-impl",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.3",
+        "nugetVersion": "118.2.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Analytics.Impl",
         "type": "xbd"
       },
@@ -2432,7 +2432,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appindex",
         "version": "16.2.0",
-        "nugetVersion": "116.2.0.5",
+        "nugetVersion": "116.2.0.6",
         "nugetId": "Xamarin.GooglePlayServices.AppIndex",
         "type": "xbd"
       },
@@ -2440,7 +2440,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appinvite",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.21",
+        "nugetVersion": "118.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.AppInvite",
         "type": "xbd"
       },
@@ -2448,7 +2448,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appset",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.5",
+        "nugetVersion": "116.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.AppSet",
         "type": "xbd"
       },
@@ -2456,7 +2456,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-audience",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Audience",
         "type": "xbd"
       },
@@ -2464,7 +2464,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0.2",
+        "nugetVersion": "121.3.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Auth",
         "type": "xbd"
       },
@@ -2472,7 +2472,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-api-phone",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.1",
+        "nugetVersion": "118.2.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Api.Phone",
         "type": "xbd"
       },
@@ -2480,7 +2480,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-base",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.2",
+        "nugetVersion": "118.1.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Base",
         "type": "xbd"
       },
@@ -2488,7 +2488,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-blockstore",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.4",
+        "nugetVersion": "116.4.0.5",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Blockstore",
         "type": "xbd"
       },
@@ -2496,7 +2496,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-awareness",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.5",
+        "nugetVersion": "119.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Awareness",
         "type": "xbd"
       },
@@ -2504,7 +2504,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-base",
         "version": "18.7.0",
-        "nugetVersion": "118.7.0.1",
+        "nugetVersion": "118.7.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Base",
         "type": "xbd"
       },
@@ -2512,7 +2512,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-basement",
         "version": "18.7.0",
-        "nugetVersion": "118.7.0.1",
+        "nugetVersion": "118.7.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Basement",
         "type": "xbd"
       },
@@ -2520,7 +2520,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0.3",
+        "nugetVersion": "122.0.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Cast",
         "type": "xbd"
       },
@@ -2528,7 +2528,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-framework",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0.3",
+        "nugetVersion": "122.0.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Cast.Framework",
         "type": "xbd"
       },
@@ -2536,7 +2536,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-tv",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.3",
+        "nugetVersion": "121.1.1.4",
         "nugetId": "Xamarin.GooglePlayServices.Cast.TV",
         "type": "xbd"
       },
@@ -2544,7 +2544,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-clearcut",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Clearcut",
         "type": "xbd"
       },
@@ -2552,7 +2552,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cloud-messaging",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.5",
+        "nugetVersion": "117.3.0.6",
         "nugetId": "Xamarin.GooglePlayServices.CloudMessaging",
         "type": "xbd"
       },
@@ -2560,7 +2560,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-code-scanner",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.11",
+        "nugetVersion": "116.1.0.12",
         "nugetId": "Xamarin.GooglePlayServices.Code.Scanner",
         "type": "xbd"
       },
@@ -2568,7 +2568,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cronet",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.CroNet",
         "type": "xbd"
       },
@@ -2576,7 +2576,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-deviceperformance",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.5",
+        "nugetVersion": "116.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.DevicePerformance",
         "type": "xbd"
       },
@@ -2584,7 +2584,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-drive",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Drive",
         "type": "xbd"
       },
@@ -2592,7 +2592,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fido",
         "version": "21.2.0",
-        "nugetVersion": "121.2.0.1",
+        "nugetVersion": "121.2.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Fido",
         "type": "xbd"
       },
@@ -2600,7 +2600,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fitness",
         "version": "21.2.0",
-        "nugetVersion": "121.2.0.5",
+        "nugetVersion": "121.2.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Fitness",
         "type": "xbd"
       },
@@ -2608,7 +2608,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-flags",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Flags",
         "type": "xbd"
       },
@@ -2616,7 +2616,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0.5",
+        "nugetVersion": "123.2.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Games",
         "type": "xbd"
       },
@@ -2624,7 +2624,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games-v2",
         "version": "20.1.2",
-        "nugetVersion": "120.1.2.5",
+        "nugetVersion": "120.1.2.6",
         "nugetId": "Xamarin.GooglePlayServices.Games.V2",
         "type": "xbd"
       },
@@ -2632,7 +2632,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gass",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.21",
+        "nugetVersion": "120.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Gass",
         "type": "xbd"
       },
@@ -2640,7 +2640,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gcm",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Gcm",
         "type": "xbd"
       },
@@ -2648,7 +2648,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-home",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.14",
+        "nugetVersion": "116.0.0.15",
         "nugetId": "Xamarin.GooglePlayServices.Home",
         "type": "xbd"
       },
@@ -2656,7 +2656,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Identity",
         "type": "xbd"
       },
@@ -2664,7 +2664,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity-credentials",
         "version": "16.0.0-alpha04",
-        "nugetVersion": "116.0.0.1-alpha04",
+        "nugetVersion": "116.0.0.2-alpha04",
         "nugetId": "Xamarin.GooglePlayServices.Identity.Credentials",
         "type": "xbd"
       },
@@ -2672,7 +2672,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-iid",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Iid",
         "type": "xbd"
       },
@@ -2680,7 +2680,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-instantapps",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.InstantApps",
         "type": "xbd"
       },
@@ -2688,7 +2688,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-location",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0.5",
+        "nugetVersion": "121.3.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Location",
         "type": "xbd"
       },
@@ -2696,7 +2696,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-maps",
         "version": "19.2.0",
-        "nugetVersion": "119.2.0.1",
+        "nugetVersion": "119.2.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Maps",
         "type": "xbd"
       },
@@ -2704,7 +2704,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement",
         "type": "xbd"
       },
@@ -2712,7 +2712,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-api",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Api",
         "type": "xbd"
       },
@@ -2720,7 +2720,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-base",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
         "type": "xbd"
       },
@@ -2728,7 +2728,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-impl",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Impl",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2737,7 +2737,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk",
         "type": "xbd"
       },
@@ -2745,7 +2745,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk-api",
         "version": "22.4.0",
-        "nugetVersion": "122.4.0.1",
+        "nugetVersion": "122.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk.Api",
         "type": "xbd"
       },
@@ -2753,7 +2753,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-barcode-scanning",
         "version": "18.3.1",
-        "nugetVersion": "118.3.1.3",
+        "nugetVersion": "118.3.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.BarcodeScanning",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2762,7 +2762,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-face-detection",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.14",
+        "nugetVersion": "117.1.0.15",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.FaceDetection",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2771,7 +2771,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-image-labeling",
         "version": "16.0.8",
-        "nugetVersion": "116.0.8.14",
+        "nugetVersion": "116.0.8.15",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -2779,7 +2779,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-language-id",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.16",
+        "nugetVersion": "117.0.0.17",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.LanguageId",
         "type": "xbd"
       },
@@ -2787,7 +2787,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition",
         "version": "19.0.1",
-        "nugetVersion": "119.0.1.3",
+        "nugetVersion": "119.0.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition",
         "type": "xbd"
       },
@@ -2795,7 +2795,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Chinese",
         "type": "xbd"
       },
@@ -2803,7 +2803,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-common",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.3",
+        "nugetVersion": "119.1.0.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2812,7 +2812,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Devanagari",
         "type": "xbd"
       },
@@ -2820,7 +2820,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Japanese",
         "type": "xbd"
       },
@@ -2828,7 +2828,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Korean",
         "type": "xbd"
       },
@@ -2836,7 +2836,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-nearby",
         "version": "19.3.0",
-        "nugetVersion": "119.3.0.5",
+        "nugetVersion": "119.3.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Nearby",
         "type": "xbd"
       },
@@ -2844,7 +2844,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-oss-licenses",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.5",
+        "nugetVersion": "117.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Oss.Licenses",
         "type": "xbd"
       },
@@ -2852,7 +2852,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pal",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0.1",
+        "nugetVersion": "122.0.0.2",
         "nugetId": "Xamarin.GooglePlayServices.PAL",
         "type": "xbd"
       },
@@ -2860,7 +2860,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-panorama",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.11",
+        "nugetVersion": "117.1.0.12",
         "nugetId": "Xamarin.GooglePlayServices.Panorama",
         "type": "xbd"
       },
@@ -2868,7 +2868,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-password-complexity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.PasswordComplexity",
         "type": "xbd"
       },
@@ -2876,7 +2876,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pay",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0.5",
+        "nugetVersion": "116.5.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Pay",
         "type": "xbd"
       },
@@ -2884,7 +2884,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-phenotype",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Phenotype",
         "type": "xbd"
       },
@@ -2892,7 +2892,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.5",
+        "nugetVersion": "117.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Places",
         "type": "xbd"
       },
@@ -2900,7 +2900,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places-placereport",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.5",
+        "nugetVersion": "117.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Places.PlaceReport",
         "type": "xbd"
       },
@@ -2908,7 +2908,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-plus",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Plus",
         "type": "xbd"
       },
@@ -2916,7 +2916,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptcha",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.5",
+        "nugetVersion": "117.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Recaptcha",
         "type": "xbd"
       },
@@ -2924,7 +2924,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptchabase",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.1",
+        "nugetVersion": "116.1.0.2",
         "nugetId": "Xamarin.GooglePlayServices.RecaptchaBase",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2933,7 +2933,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-safetynet",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.5",
+        "nugetVersion": "118.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.SafetyNet",
         "type": "xbd"
       },
@@ -2941,7 +2941,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-stats",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.5",
+        "nugetVersion": "117.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Stats",
         "type": "xbd"
       },
@@ -2949,7 +2949,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-streamprotect",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.13",
+        "nugetVersion": "116.1.0.14",
         "nugetId": "Xamarin.GooglePlayServices.StreamProtect",
         "type": "xbd"
       },
@@ -2957,7 +2957,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.1",
+        "nugetVersion": "118.3.0.2",
         "nugetId": "Xamarin.GooglePlayServices.TagManager",
         "type": "xbd"
       },
@@ -2965,7 +2965,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-api",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.1",
+        "nugetVersion": "118.3.0.2",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.Api",
         "type": "xbd"
       },
@@ -2973,7 +2973,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-v4-impl",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.3",
+        "nugetVersion": "118.1.1.4",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.V4.Impl",
         "type": "xbd"
       },
@@ -2981,7 +2981,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tasks",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.1",
+        "nugetVersion": "118.3.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Tasks",
         "type": "xbd"
       },
@@ -2989,7 +2989,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-gpu",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.2",
+        "nugetVersion": "116.4.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Gpu",
         "type": "xbd"
       },
@@ -2997,7 +2997,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-impl",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.2",
+        "nugetVersion": "116.4.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Impl",
         "type": "xbd"
       },
@@ -3005,7 +3005,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-java",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.2",
+        "nugetVersion": "116.4.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Java",
         "type": "xbd"
       },
@@ -3013,7 +3013,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-support",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.2",
+        "nugetVersion": "116.4.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Support",
         "type": "xbd"
       },
@@ -3021,7 +3021,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-threadnetwork",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.3",
+        "nugetVersion": "116.2.1.4",
         "nugetId": "Xamarin.GooglePlayServices.ThreadNetwork",
         "type": "xbd"
       },
@@ -3029,7 +3029,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision",
         "version": "20.1.3",
-        "nugetVersion": "120.1.3.21",
+        "nugetVersion": "120.1.3.22",
         "nugetId": "Xamarin.GooglePlayServices.Vision",
         "type": "xbd"
       },
@@ -3037,7 +3037,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-common",
         "version": "19.1.3",
-        "nugetVersion": "119.1.3.23",
+        "nugetVersion": "119.1.3.24",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Common",
         "type": "xbd"
       },
@@ -3045,7 +3045,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-face-contour-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.21",
+        "nugetVersion": "116.1.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Face.Contour.Internal",
         "type": "xbd"
       },
@@ -3053,7 +3053,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-label",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.21",
+        "nugetVersion": "118.1.1.22",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabel",
         "type": "xbd"
       },
@@ -3061,7 +3061,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-labeling-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.21",
+        "nugetVersion": "116.1.0.22",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabelingInternal",
         "type": "xbd"
       },
@@ -3069,7 +3069,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wallet",
         "version": "19.4.0",
-        "nugetVersion": "119.4.0.5",
+        "nugetVersion": "119.4.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Wallet",
         "type": "xbd"
       },
@@ -3077,7 +3077,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wearable",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0.2",
+        "nugetVersion": "119.0.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Wearable",
         "type": "xbd"
       },
@@ -3085,7 +3085,7 @@
         "groupId": "com.google.android.libraries.identity.googleid",
         "artifactId": "googleid",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.9",
+        "nugetVersion": "1.1.0.10",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Identity.GoogleId",
         "frozen": true,
         "type": "xbd",
@@ -3095,7 +3095,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places",
         "version": "4.1.0",
-        "nugetVersion": "4.1.0.2",
+        "nugetVersion": "4.1.0.3",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Places",
         "type": "xbd"
       },
@@ -3103,7 +3103,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places-compat",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0.13",
+        "nugetVersion": "2.6.0.14",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Places.Compat",
         "type": "xbd"
       },
@@ -3111,7 +3111,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter",
         "version": "1.1.18",
-        "nugetVersion": "1.1.18.18",
+        "nugetVersion": "1.1.18.19",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3120,7 +3120,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter-3",
         "version": "1.0.18",
-        "nugetVersion": "1.0.18.17",
+        "nugetVersion": "1.0.18.18",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter3",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3129,7 +3129,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.12.0",
-        "nugetVersion": "1.12.0.3",
+        "nugetVersion": "1.12.0.4",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },
@@ -3137,7 +3137,7 @@
         "groupId": "com.google.android.odml",
         "artifactId": "image",
         "version": "1.0.0-beta1",
-        "nugetVersion": "1.0.0.15-beta1",
+        "nugetVersion": "1.0.0.16-beta1",
         "nugetId": "Xamarin.Google.Android.ODML.Image",
         "type": "xbd"
       },
@@ -3145,7 +3145,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.14",
+        "nugetVersion": "2.1.0.15",
         "nugetId": "Xamarin.Google.Android.Play.App.Update",
         "type": "xbd"
       },
@@ -3153,7 +3153,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update-ktx",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.14",
+        "nugetVersion": "2.1.0.15",
         "nugetId": "Xamarin.Google.Android.Play.App.Update.Ktx",
         "type": "xbd"
       },
@@ -3161,7 +3161,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "asset-delivery",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.2",
+        "nugetVersion": "2.3.0.3",
         "nugetId": "Xamarin.Google.Android.Play.Asset.Delivery",
         "type": "xbd"
       },
@@ -3169,7 +3169,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "asset-delivery-ktx",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.2",
+        "nugetVersion": "2.3.0.3",
         "nugetId": "Xamarin.Google.Android.Play.Asset.Delivery.Ktx",
         "type": "xbd"
       },
@@ -3177,7 +3177,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core",
         "version": "1.10.3",
-        "nugetVersion": "1.10.3.17",
+        "nugetVersion": "1.10.3.18",
         "nugetId": "Xamarin.Google.Android.Play.Core",
         "type": "xbd"
       },
@@ -3185,7 +3185,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-common",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.5",
+        "nugetVersion": "2.0.4.6",
         "nugetId": "Xamarin.Google.Android.Play.Core.Common",
         "type": "xbd"
       },
@@ -3193,7 +3193,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-ktx",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1.14",
+        "nugetVersion": "1.8.1.15",
         "nugetId": "Xamarin.Google.Android.Play.Core.Ktx",
         "type": "xbd"
       },
@@ -3201,7 +3201,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "feature-delivery",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.13",
+        "nugetVersion": "2.1.0.14",
         "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery",
         "type": "xbd"
       },
@@ -3209,7 +3209,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "feature-delivery-ktx",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.13",
+        "nugetVersion": "2.1.0.14",
         "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery.Ktx",
         "type": "xbd"
       },
@@ -3217,7 +3217,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "integrity",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.4",
+        "nugetVersion": "1.4.0.5",
         "nugetId": "Xamarin.Google.Android.Play.Integrity",
         "type": "xbd"
       },
@@ -3225,7 +3225,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.3",
+        "nugetVersion": "2.0.2.4",
         "nugetId": "Xamarin.Google.Android.Play.Review",
         "type": "xbd"
       },
@@ -3233,7 +3233,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review-ktx",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.3",
+        "nugetVersion": "2.0.2.4",
         "nugetId": "Xamarin.Google.Android.Play.Review.Ktx",
         "type": "xbd"
       },
@@ -3241,7 +3241,7 @@
         "groupId": "com.google.android.recaptcha",
         "artifactId": "recaptcha",
         "version": "18.7.0",
-        "nugetVersion": "18.7.0.1",
+        "nugetVersion": "18.7.0.2",
         "nugetId": "Xamarin.Google.Android.Recaptcha",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3250,7 +3250,7 @@
         "groupId": "com.google.android.tv",
         "artifactId": "tv-ads",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.2",
+        "nugetVersion": "1.0.1.3",
         "nugetId": "Xamarin.GoogleAndroid.TV.Ads",
         "type": "xbd"
       },
@@ -3258,7 +3258,7 @@
         "groupId": "com.google.android.ump",
         "artifactId": "user-messaging-platform",
         "version": "3.2.0",
-        "nugetVersion": "3.2.0.1",
+        "nugetVersion": "3.2.0.2",
         "nugetId": "Xamarin.Google.UserMessagingPlatform",
         "type": "xbd"
       },
@@ -3266,14 +3266,14 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "suggestions",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.18",
+        "nugetVersion": "1.0.0.19",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Suggestions"
       },
       {
         "groupId": "com.google.assistant.appactions",
         "artifactId": "widgets",
         "version": "0.0.1",
-        "nugetVersion": "0.0.1.19",
+        "nugetVersion": "0.0.1.20",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
         "type": "xbd"
       },
@@ -3281,7 +3281,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value-annotations",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0.6",
+        "nugetVersion": "1.11.0.7",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3290,7 +3290,7 @@
         "groupId": "com.google.code.findbugs",
         "artifactId": "jsr305",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.19",
+        "nugetVersion": "3.0.2.20",
         "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
         "assemblyName": "Jsr305Binding",
         "type": "androidlibrary",
@@ -3300,7 +3300,7 @@
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.13.0",
-        "nugetVersion": "2.13.0.1",
+        "nugetVersion": "2.13.0.2",
         "nugetId": "GoogleGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3309,7 +3309,7 @@
         "groupId": "com.google.crypto.tink",
         "artifactId": "tink-android",
         "version": "1.17.0",
-        "nugetVersion": "1.17.0.1",
+        "nugetVersion": "1.17.0.2",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3318,7 +3318,7 @@
         "groupId": "com.google.dagger",
         "artifactId": "dagger",
         "version": "2.56.2",
-        "nugetVersion": "2.56.2.1",
+        "nugetVersion": "2.56.2.2",
         "nugetId": "Xamarin.Google.Dagger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3327,7 +3327,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
         "version": "2.37.0",
-        "nugetVersion": "2.37.0.1",
+        "nugetVersion": "2.37.0.2",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3336,7 +3336,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_type_annotations",
         "version": "2.37.0",
-        "nugetVersion": "2.37.0.1",
+        "nugetVersion": "2.37.0.2",
         "nugetId": "Xamarin.Google.ErrorProne.TypeAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3345,7 +3345,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-abt",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0.5",
+        "nugetVersion": "122.0.0.6",
         "nugetId": "Xamarin.Firebase.Abt",
         "type": "xbd"
       },
@@ -3353,7 +3353,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads",
         "version": "23.6.0",
-        "nugetVersion": "123.6.0.2",
+        "nugetVersion": "123.6.0.3",
         "nugetId": "Xamarin.Firebase.Ads",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core",
         "type": "xbd"
@@ -3362,7 +3362,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads-lite",
         "version": "23.6.0",
-        "nugetVersion": "123.6.0.2",
+        "nugetVersion": "123.6.0.3",
         "nugetId": "Xamarin.Firebase.Ads.Lite",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -3371,7 +3371,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics",
         "version": "22.3.0",
-        "nugetVersion": "122.3.0.1",
+        "nugetVersion": "122.3.0.2",
         "nugetId": "Xamarin.Firebase.Analytics",
         "type": "xbd"
       },
@@ -3379,7 +3379,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics-impl",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.21",
+        "nugetVersion": "116.3.0.22",
         "nugetId": "Xamarin.Firebase.Analytics.Impl",
         "type": "xbd"
       },
@@ -3387,7 +3387,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics-ktx",
         "version": "22.3.0",
-        "nugetVersion": "122.3.0.1",
+        "nugetVersion": "122.3.0.2",
         "nugetId": "Xamarin.Firebase.Analytics.Ktx",
         "type": "xbd"
       },
@@ -3395,7 +3395,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-annotations",
         "version": "16.2.0",
-        "nugetVersion": "116.2.0.13",
+        "nugetVersion": "116.2.0.14",
         "nugetId": "Xamarin.Firebase.Annotations",
         "type": "xbd"
       },
@@ -3403,7 +3403,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.AppCheck",
         "type": "xbd"
       },
@@ -3411,7 +3411,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-debug",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.AppCheck.Debug",
         "type": "xbd"
       },
@@ -3419,7 +3419,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.9",
+        "nugetVersion": "117.1.0.10",
         "nugetId": "Xamarin.Firebase.AppCheck.Interop",
         "type": "xbd"
       },
@@ -3427,7 +3427,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-ktx",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.AppCheck.Ktx",
         "type": "xbd"
       },
@@ -3435,7 +3435,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-playintegrity",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.AppCheck.PlayIntegrity",
         "type": "xbd"
       },
@@ -3443,7 +3443,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-safetynet",
         "version": "16.1.2",
-        "nugetVersion": "116.1.2.13",
+        "nugetVersion": "116.1.2.14",
         "nugetId": "Xamarin.Firebase.AppCheck.SafetyNet",
         "type": "xbd"
       },
@@ -3451,7 +3451,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.24",
+        "nugetVersion": "120.0.0.25",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "type": "xbd"
       },
@@ -3459,7 +3459,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0.1",
+        "nugetVersion": "123.2.0.2",
         "nugetId": "Xamarin.Firebase.Auth",
         "type": "xbd"
       },
@@ -3467,7 +3467,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth-interop",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.21",
+        "nugetVersion": "120.0.0.22",
         "nugetId": "Xamarin.Firebase.Auth.Interop",
         "type": "xbd"
       },
@@ -3475,7 +3475,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth-ktx",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0.1",
+        "nugetVersion": "123.2.0.2",
         "nugetId": "Xamarin.Firebase.Auth.Ktx",
         "type": "xbd"
       },
@@ -3483,7 +3483,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.5",
+        "nugetVersion": "121.0.0.6",
         "nugetId": "Xamarin.Firebase.Common",
         "type": "xbd"
       },
@@ -3491,7 +3491,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common-ktx",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.5",
+        "nugetVersion": "121.0.0.6",
         "nugetId": "Xamarin.Firebase.Common.Ktx",
         "type": "xbd"
       },
@@ -3499,7 +3499,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-components",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.3",
+        "nugetVersion": "118.0.1.4",
         "nugetId": "Xamarin.Firebase.Components",
         "type": "xbd"
       },
@@ -3507,7 +3507,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.1",
+        "nugetVersion": "122.1.0.2",
         "nugetId": "Xamarin.Firebase.Config",
         "type": "xbd"
       },
@@ -3515,7 +3515,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config-interop",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Firebase.Config.Interop",
         "type": "xbd"
       },
@@ -3523,7 +3523,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config-ktx",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.1",
+        "nugetVersion": "122.1.0.2",
         "nugetId": "Xamarin.Firebase.Config.Ktx",
         "type": "xbd"
       },
@@ -3531,7 +3531,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-core",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.14",
+        "nugetVersion": "121.1.1.15",
         "nugetId": "Xamarin.Firebase.Core",
         "type": "xbd"
       },
@@ -3539,7 +3539,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crash",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.21",
+        "nugetVersion": "116.2.1.22",
         "nugetId": "Xamarin.Firebase.Crash",
         "type": "xbd"
       },
@@ -3547,7 +3547,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics",
         "version": "19.4.2",
-        "nugetVersion": "119.4.2.1",
+        "nugetVersion": "119.4.2.2",
         "nugetId": "Xamarin.Firebase.Crashlytics",
         "extraDependencies": "com.google.dagger.dagger",
         "type": "xbd"
@@ -3556,7 +3556,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics-ktx",
         "version": "19.4.2",
-        "nugetVersion": "119.4.2.1",
+        "nugetVersion": "119.4.2.2",
         "nugetId": "Xamarin.Firebase.Crashlytics.Ktx",
         "type": "xbd"
       },
@@ -3564,7 +3564,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics-ndk",
         "version": "19.4.2",
-        "nugetVersion": "119.4.2.1",
+        "nugetVersion": "119.4.2.2",
         "nugetId": "Xamarin.Firebase.Crashlytics.NDK",
         "type": "xbd"
       },
@@ -3572,7 +3572,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.5",
+        "nugetVersion": "121.0.0.6",
         "nugetId": "Xamarin.Firebase.Database",
         "type": "xbd"
       },
@@ -3580,7 +3580,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-collection",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.14",
+        "nugetVersion": "118.0.1.15",
         "nugetId": "Xamarin.Firebase.Database.Collection",
         "type": "xbd"
       },
@@ -3588,7 +3588,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-connection",
         "version": "16.0.2",
-        "nugetVersion": "116.0.2.21",
+        "nugetVersion": "116.0.2.22",
         "nugetId": "Xamarin.Firebase.Database.Connection",
         "type": "xbd"
       },
@@ -3596,7 +3596,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-ktx",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.5",
+        "nugetVersion": "121.0.0.6",
         "nugetId": "Xamarin.Firebase.Database.Ktx",
         "type": "xbd"
       },
@@ -3604,7 +3604,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-datatransport",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0.5",
+        "nugetVersion": "119.0.0.6",
         "nugetId": "Xamarin.Firebase.Datatransport",
         "type": "xbd"
       },
@@ -3612,7 +3612,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-dynamic-links",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.5",
+        "nugetVersion": "122.1.0.6",
         "nugetId": "Xamarin.Firebase.Dynamic.Links",
         "type": "xbd"
       },
@@ -3620,7 +3620,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-dynamic-links-ktx",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.5",
+        "nugetVersion": "122.1.0.6",
         "nugetId": "Xamarin.Firebase.Dynamic.Links.Ktx",
         "type": "xbd"
       },
@@ -3628,7 +3628,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Firebase.Encoders",
         "type": "xbd"
       },
@@ -3636,7 +3636,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-json",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.13",
+        "nugetVersion": "118.0.1.14",
         "nugetId": "Xamarin.Firebase.Encoders.JSON",
         "type": "xbd"
       },
@@ -3644,7 +3644,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-proto",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.16",
+        "nugetVersion": "116.0.0.17",
         "nugetId": "Xamarin.Firebase.Encoders.Proto",
         "type": "xbd"
       },
@@ -3652,7 +3652,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore",
         "version": "25.1.3",
-        "nugetVersion": "125.1.3.1",
+        "nugetVersion": "125.1.3.2",
         "nugetId": "Xamarin.Firebase.Firestore",
         "extraDependencies": "com.google.guava.guava",
         "type": "xbd",
@@ -3663,7 +3663,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore-ktx",
         "version": "25.1.3",
-        "nugetVersion": "125.1.3.1",
+        "nugetVersion": "125.1.3.2",
         "nugetId": "Xamarin.Firebase.Firestore.Ktx",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3673,7 +3673,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-functions",
         "version": "21.2.1",
-        "nugetVersion": "121.2.1.1",
+        "nugetVersion": "121.2.1.2",
         "nugetId": "Xamarin.Firebase.Functions",
         "type": "xbd"
       },
@@ -3681,7 +3681,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-functions-ktx",
         "version": "21.2.1",
-        "nugetVersion": "121.2.1.1",
+        "nugetVersion": "121.2.1.2",
         "nugetId": "Xamarin.Firebase.Functions.Ktx",
         "type": "xbd"
       },
@@ -3689,7 +3689,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid",
         "version": "21.1.0",
-        "nugetVersion": "121.1.0.21",
+        "nugetVersion": "121.1.0.22",
         "nugetId": "Xamarin.Firebase.Iid",
         "type": "xbd"
       },
@@ -3697,7 +3697,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.21",
+        "nugetVersion": "117.1.0.22",
         "nugetId": "Xamarin.Firebase.Iid.Interop",
         "type": "xbd"
       },
@@ -3705,7 +3705,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging",
         "version": "21.0.2",
-        "nugetVersion": "121.0.2.1",
+        "nugetVersion": "121.0.2.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3715,7 +3715,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging-display",
         "version": "21.0.2",
-        "nugetVersion": "121.0.2.1",
+        "nugetVersion": "121.0.2.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3725,7 +3725,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging-display-ktx",
         "version": "21.0.2",
-        "nugetVersion": "121.0.2.1",
+        "nugetVersion": "121.0.2.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display.Ktx",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3735,7 +3735,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging-ktx",
         "version": "21.0.2",
-        "nugetVersion": "121.0.2.1",
+        "nugetVersion": "121.0.2.2",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Ktx",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3745,7 +3745,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.Installations",
         "type": "xbd"
       },
@@ -3753,7 +3753,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations-interop",
         "version": "17.2.0",
-        "nugetVersion": "117.2.0.9",
+        "nugetVersion": "117.2.0.10",
         "nugetId": "Xamarin.Firebase.Installations.InterOp",
         "type": "xbd"
       },
@@ -3761,7 +3761,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations-ktx",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.5",
+        "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.Installations.Ktx",
         "type": "xbd"
       },
@@ -3769,7 +3769,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-invites",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Firebase.Invites",
         "type": "xbd"
       },
@@ -3777,7 +3777,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-measurement-connector",
         "version": "20.0.1",
-        "nugetVersion": "120.0.1.9",
+        "nugetVersion": "120.0.1.10",
         "nugetId": "Xamarin.Firebase.Measurement.Connector",
         "type": "xbd"
       },
@@ -3785,7 +3785,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-messaging",
         "version": "24.1.1",
-        "nugetVersion": "124.1.1.1",
+        "nugetVersion": "124.1.1.2",
         "nugetId": "Xamarin.Firebase.Messaging",
         "type": "xbd"
       },
@@ -3793,7 +3793,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-messaging-directboot",
         "version": "24.1.1",
-        "nugetVersion": "124.1.1.1",
+        "nugetVersion": "124.1.1.2",
         "nugetId": "Xamarin.Firebase.Messaging.DirectBoot",
         "type": "xbd"
       },
@@ -3801,7 +3801,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-messaging-ktx",
         "version": "24.1.1",
-        "nugetVersion": "124.1.1.1",
+        "nugetVersion": "124.1.1.2",
         "nugetId": "Xamarin.Firebase.Messaging.Ktx",
         "type": "xbd"
       },
@@ -3809,7 +3809,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-common",
         "version": "22.1.2",
-        "nugetVersion": "122.1.2.21",
+        "nugetVersion": "122.1.2.22",
         "nugetId": "Xamarin.Firebase.ML.Common",
         "type": "xbd"
       },
@@ -3817,7 +3817,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-model-interpreter",
         "version": "22.0.4",
-        "nugetVersion": "122.0.4.21",
+        "nugetVersion": "122.0.4.22",
         "nugetId": "Xamarin.Firebase.ML.Model.Interpreter",
         "type": "xbd"
       },
@@ -3825,7 +3825,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language",
         "version": "22.0.1",
-        "nugetVersion": "122.0.1.21",
+        "nugetVersion": "122.0.1.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language",
         "type": "xbd"
       },
@@ -3833,7 +3833,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-language-id-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.21",
+        "nugetVersion": "120.0.8.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Id.Model",
         "type": "xbd"
       },
@@ -3841,7 +3841,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply",
         "version": "18.0.8",
-        "nugetVersion": "118.0.8.21",
+        "nugetVersion": "118.0.8.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply",
         "type": "xbd"
       },
@@ -3849,7 +3849,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.21",
+        "nugetVersion": "120.0.8.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply.Model",
         "type": "xbd"
       },
@@ -3857,7 +3857,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate",
         "version": "22.0.2",
-        "nugetVersion": "122.0.2.20",
+        "nugetVersion": "122.0.2.21",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate",
         "type": "xbd"
       },
@@ -3865,7 +3865,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate-model",
         "version": "20.0.9",
-        "nugetVersion": "120.0.9.21",
+        "nugetVersion": "120.0.9.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate.Model",
         "type": "xbd"
       },
@@ -3873,7 +3873,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0.21",
+        "nugetVersion": "124.1.0.22",
         "nugetId": "Xamarin.Firebase.ML.Vision",
         "type": "xbd"
       },
@@ -3881,7 +3881,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-automl",
         "version": "18.0.6",
-        "nugetVersion": "118.0.6.21",
+        "nugetVersion": "118.0.6.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.AutoML",
         "type": "xbd"
       },
@@ -3889,7 +3889,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-barcode-model",
         "version": "16.1.2",
-        "nugetVersion": "116.1.2.21",
+        "nugetVersion": "116.1.2.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.BarCode.Model",
         "type": "xbd"
       },
@@ -3897,7 +3897,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-face-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.21",
+        "nugetVersion": "120.0.2.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.Face.Model",
         "type": "xbd"
       },
@@ -3905,7 +3905,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-image-label-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.21",
+        "nugetVersion": "120.0.2.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.Image.Label.Model",
         "type": "xbd"
       },
@@ -3913,7 +3913,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-internal-vkp",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.21",
+        "nugetVersion": "117.0.2.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -3921,7 +3921,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-object-detection-model",
         "version": "19.0.6",
-        "nugetVersion": "119.0.6.21",
+        "nugetVersion": "119.0.6.22",
         "nugetId": "Xamarin.Firebase.ML.Vision.Object.Detection.Model",
         "type": "xbd"
       },
@@ -3929,7 +3929,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-perf",
         "version": "21.0.5",
-        "nugetVersion": "121.0.5.1",
+        "nugetVersion": "121.0.5.2",
         "nugetId": "Xamarin.Firebase.Perf",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3939,7 +3939,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-perf-ktx",
         "version": "21.0.5",
-        "nugetVersion": "121.0.5.1",
+        "nugetVersion": "121.0.5.2",
         "nugetId": "Xamarin.Firebase.Perf.Ktx",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3949,7 +3949,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-sessions",
         "version": "2.1.0",
-        "nugetVersion": "102.1.0.1",
+        "nugetVersion": "102.1.0.2",
         "nugetId": "Xamarin.Firebase.Sessions",
         "type": "xbd"
       },
@@ -3957,7 +3957,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage",
         "version": "21.0.1",
-        "nugetVersion": "121.0.1.3",
+        "nugetVersion": "121.0.1.4",
         "nugetId": "Xamarin.Firebase.Storage",
         "type": "xbd"
       },
@@ -3965,7 +3965,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Firebase.Storage.Common",
         "type": "xbd"
       },
@@ -3973,7 +3973,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage-ktx",
         "version": "21.0.1",
-        "nugetVersion": "121.0.1.3",
+        "nugetVersion": "121.0.1.4",
         "nugetId": "Xamarin.Firebase.Storage.Ktx",
         "type": "xbd"
       },
@@ -3981,7 +3981,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "protolite-well-known-types",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.1",
+        "nugetVersion": "118.0.1.2",
         "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3991,7 +3991,7 @@
         "groupId": "com.google.flatbuffers",
         "artifactId": "flatbuffers-java",
         "version": "25.2.10",
-        "nugetVersion": "25.2.10.1",
+        "nugetVersion": "25.2.10.2",
         "nugetId": "Xamarin.Google.FlatBuffers.Java",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4000,7 +4000,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger",
         "version": "0.8",
-        "nugetVersion": "0.8.0.11",
+        "nugetVersion": "0.8.0.12",
         "nugetId": "Xamarin.Flogger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4009,7 +4009,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger-system-backend",
         "version": "0.8",
-        "nugetVersion": "0.8.0.11",
+        "nugetVersion": "0.8.0.12",
         "nugetId": "Xamarin.Flogger.SystemBackend",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4018,7 +4018,7 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.3",
-        "nugetVersion": "1.0.3.1",
+        "nugetVersion": "1.0.3.2",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4027,7 +4027,7 @@
         "groupId": "com.google.guava",
         "artifactId": "guava",
         "version": "33.4.8-android",
-        "nugetVersion": "33.4.8.1",
+        "nugetVersion": "33.4.8.2",
         "nugetId": "Xamarin.Google.Guava",
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
         "type": "androidlibrary",
@@ -4037,7 +4037,7 @@
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.27",
+        "nugetVersion": "1.0.0.28",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4046,7 +4046,7 @@
         "groupId": "com.google.inject",
         "artifactId": "guice",
         "version": "7.0.0",
-        "nugetVersion": "7.0.0.5",
+        "nugetVersion": "7.0.0.6",
         "nugetId": "Xamarin.Google.Inject.Guice",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4055,7 +4055,7 @@
         "groupId": "com.google.j2objc",
         "artifactId": "j2objc-annotations",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.9",
+        "nugetVersion": "3.0.0.10",
         "nugetId": "Xamarin.Google.J2Objc.Annotations",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4064,7 +4064,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.3",
+        "nugetVersion": "117.3.0.4",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning",
         "type": "xbd"
       },
@@ -4072,7 +4072,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.16",
+        "nugetVersion": "117.0.0.17",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning.Common",
         "type": "xbd"
       },
@@ -4080,7 +4080,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "common",
         "version": "18.11.0",
-        "nugetVersion": "118.11.0.3",
+        "nugetVersion": "118.11.0.4",
         "nugetId": "Xamarin.Google.MLKit.Common",
         "type": "xbd"
       },
@@ -4088,7 +4088,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "digital-ink-recognition",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.13",
+        "nugetVersion": "118.1.0.14",
         "nugetId": "Xamarin.Google.MLKit.DigitalInk.Recognition",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -4097,7 +4097,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "face-detection",
         "version": "16.1.7",
-        "nugetVersion": "116.1.7.3",
+        "nugetVersion": "116.1.7.4",
         "nugetId": "Xamarin.Google.MLKit.FaceDetection",
         "type": "xbd"
       },
@@ -4105,7 +4105,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling",
         "version": "17.0.9",
-        "nugetVersion": "117.0.9.3",
+        "nugetVersion": "117.0.9.4",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -4113,7 +4113,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-automl",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.22",
+        "nugetVersion": "116.2.1.23",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.AutoML",
         "type": "xbd"
       },
@@ -4121,7 +4121,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-common",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.14",
+        "nugetVersion": "118.1.0.15",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4130,7 +4130,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.3",
+        "nugetVersion": "117.0.3.4",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom",
         "type": "xbd"
       },
@@ -4138,7 +4138,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.16",
+        "nugetVersion": "117.0.0.17",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom.Common",
         "type": "xbd"
       },
@@ -4146,7 +4146,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-default-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.16",
+        "nugetVersion": "117.0.0.17",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Default.Common",
         "type": "xbd"
       },
@@ -4154,7 +4154,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id",
         "version": "17.0.6",
-        "nugetVersion": "117.0.6.3",
+        "nugetVersion": "117.0.6.4",
         "nugetId": "Xamarin.Google.MLKit.Language.Id",
         "type": "xbd"
       },
@@ -4162,7 +4162,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.14",
+        "nugetVersion": "116.1.0.15",
         "nugetId": "Xamarin.Google.MLKit.Language.Id.Common",
         "type": "xbd"
       },
@@ -4170,7 +4170,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "linkfirebase",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.16",
+        "nugetVersion": "117.0.0.17",
         "nugetId": "Xamarin.Google.MLKit.LinkFirebase",
         "type": "xbd"
       },
@@ -4178,7 +4178,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "mediapipe-internal",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.21",
+        "nugetVersion": "116.0.0.22",
         "nugetId": "Xamarin.Google.MLKit.MediaPipe.Internal",
         "type": "xbd"
       },
@@ -4186,7 +4186,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.3",
+        "nugetVersion": "117.0.2.4",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection",
         "type": "xbd"
       },
@@ -4194,7 +4194,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-common",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.17",
+        "nugetVersion": "118.0.0.18",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4203,7 +4203,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-custom",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.3",
+        "nugetVersion": "117.0.2.4",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Custom",
         "type": "xbd"
       },
@@ -4211,7 +4211,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection",
         "type": "xbd"
       },
@@ -4219,7 +4219,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-accurate",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Accurate",
         "type": "xbd"
       },
@@ -4227,7 +4227,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.21",
+        "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Common",
         "type": "xbd"
       },
@@ -4235,7 +4235,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply",
         "version": "17.0.4",
-        "nugetVersion": "117.0.4.3",
+        "nugetVersion": "117.0.4.4",
         "nugetId": "Xamarin.Google.MLKit.SmartReply",
         "type": "xbd"
       },
@@ -4243,7 +4243,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.14",
+        "nugetVersion": "116.1.0.15",
         "nugetId": "Xamarin.Google.MLKit.SmartReply.Common",
         "type": "xbd"
       },
@@ -4251,7 +4251,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition",
         "type": "xbd"
       },
@@ -4259,7 +4259,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-bundled-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.3",
+        "nugetVersion": "117.0.0.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Bundled.Common",
         "type": "xbd"
       },
@@ -4267,7 +4267,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Chinese",
         "type": "xbd"
       },
@@ -4275,7 +4275,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Devanagari",
         "type": "xbd"
       },
@@ -4283,7 +4283,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Japanese",
         "type": "xbd"
       },
@@ -4291,7 +4291,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.3",
+        "nugetVersion": "116.0.1.4",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Korean",
         "type": "xbd"
       },
@@ -4299,7 +4299,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "translate",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.3",
+        "nugetVersion": "117.0.3.4",
         "nugetId": "Xamarin.Google.MLKit.Translate",
         "type": "xbd"
       },
@@ -4307,7 +4307,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-common",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.14",
+        "nugetVersion": "117.3.0.15",
         "nugetId": "Xamarin.Google.MLKit.Vision.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4316,7 +4316,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-interfaces",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.8",
+        "nugetVersion": "116.3.0.9",
         "nugetId": "Xamarin.Google.MLKit.Vision.Interfaces",
         "type": "xbd"
       },
@@ -4324,7 +4324,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-internal-vkp",
         "version": "18.2.3",
-        "nugetVersion": "118.2.3.3",
+        "nugetVersion": "118.2.3.4",
         "nugetId": "Xamarin.Google.MLKit.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -4332,7 +4332,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-javalite",
         "version": "4.30.2",
-        "nugetVersion": "4.30.2.1",
+        "nugetVersion": "4.30.2.2",
         "nugetId": "Xamarin.Protobuf.JavaLite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4342,7 +4342,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-lite",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.19",
+        "nugetVersion": "3.0.1.20",
         "nugetId": "Xamarin.Protobuf.Lite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4352,7 +4352,7 @@
         "groupId": "com.google.zxing",
         "artifactId": "core",
         "version": "3.5.3",
-        "nugetVersion": "3.5.3.7",
+        "nugetVersion": "3.5.3.8",
         "nugetId": "Xamarin.Google.ZXing.Core",
         "assemblyName": "Google.ZXing.Core",
         "type": "androidlibrary",
@@ -4362,7 +4362,7 @@
         "groupId": "com.squareup",
         "artifactId": "javapoet",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0.15",
+        "nugetVersion": "1.13.0.16",
         "nugetId": "Square.JavaPoet",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4371,7 +4371,7 @@
         "groupId": "com.squareup.okhttp",
         "artifactId": "okhttp",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5.19",
+        "nugetVersion": "2.7.5.20",
         "nugetId": "Square.OkHttp",
         "excludedRuntimeDependencies": "com.squareup.okio.okio,com.google.android.android",
         "type": "androidlibrary",
@@ -4381,7 +4381,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "logging-interceptor",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.9",
+        "nugetVersion": "4.12.0.10",
         "nugetId": "Square.OkHttp3.LoggingInterceptor",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4390,7 +4390,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.9",
+        "nugetVersion": "4.12.0.10",
         "nugetId": "Square.OkHttp3",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4399,7 +4399,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-brotli",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.7",
+        "nugetVersion": "4.12.0.8",
         "nugetId": "Square.OkHttp3.OkHttp.Brotli",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4408,7 +4408,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-tls",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.7",
+        "nugetVersion": "4.12.0.8",
         "nugetId": "Square.OkHttp3.OkHttp.TLS",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4417,7 +4417,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-urlconnection",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.9",
+        "nugetVersion": "4.12.0.10",
         "nugetId": "Square.OkHttp3.UrlConnection",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4426,7 +4426,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio",
         "version": "3.9.1",
-        "nugetVersion": "3.9.1.3",
+        "nugetVersion": "3.9.1.4",
         "nugetId": "Square.OkIO",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4435,7 +4435,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio-jvm",
         "version": "3.9.1",
-        "nugetVersion": "3.9.1.3",
+        "nugetVersion": "3.9.1.4",
         "nugetId": "Square.OkIO.JVM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4444,7 +4444,7 @@
         "groupId": "com.squareup.picasso",
         "artifactId": "picasso",
         "version": "2.8",
-        "nugetVersion": "2.8.0.18",
+        "nugetVersion": "2.8.0.19",
         "nugetId": "Square.Picasso",
         "frozen": true,
         "type": "androidlibrary",
@@ -4454,7 +4454,7 @@
         "groupId": "com.squareup.retrofit",
         "artifactId": "retrofit",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.19",
+        "nugetVersion": "1.9.0.20",
         "nugetId": "Square.Retrofit",
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp,com.google.code.gson.gson,com.google.android.android,io.reactivex.rxjava,com.google.appengine.appengine-api-1.0-sdk",
         "type": "androidlibrary",
@@ -4464,7 +4464,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "adapter-rxjava2",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0.5",
+        "nugetVersion": "2.11.0.6",
         "nugetId": "Square.Retrofit2.AdapterRxJava2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4473,7 +4473,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-gson",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0.5",
+        "nugetVersion": "2.11.0.6",
         "nugetId": "Square.Retrofit2.ConverterGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4482,7 +4482,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-scalars",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0.5",
+        "nugetVersion": "2.11.0.6",
         "nugetId": "Square.Retrofit2.ConverterScalars",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4491,7 +4491,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "retrofit",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0.5",
+        "nugetVersion": "2.11.0.6",
         "nugetId": "Square.Retrofit2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4500,7 +4500,7 @@
         "groupId": "dev.chrisbanes.snapper",
         "artifactId": "snapper",
         "version": "0.3.0",
-        "nugetVersion": "0.3.0.18",
+        "nugetVersion": "0.3.0.19",
         "nugetId": "Xamarin.Dev.ChrisBanes.Snapper",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4509,7 +4509,7 @@
         "groupId": "io.antmedia",
         "artifactId": "rtmp-client",
         "version": "3.2.0",
-        "nugetVersion": "3.2.0.5",
+        "nugetVersion": "3.2.0.6",
         "nugetId": "Xamarin.Android.AntMedia.RtmpClient",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4518,7 +4518,7 @@
         "groupId": "io.github.aakira",
         "artifactId": "napier",
         "version": "2.7.1",
-        "nugetVersion": "2.7.1.10",
+        "nugetVersion": "2.7.1.11",
         "nugetId": "Xamarin.AAkira.Napier",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4527,7 +4527,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-android",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4536,7 +4536,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-api",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Api",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4545,7 +4545,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-context",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Context",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4554,7 +4554,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-core",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4563,7 +4563,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-okhttp",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.OkHttp",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4572,7 +4572,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-protobuf-lite",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Protobuf.Lite",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4581,7 +4581,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-stub",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Stub",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4590,7 +4590,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-util",
         "version": "1.63.2",
-        "nugetVersion": "1.63.2.4",
+        "nugetVersion": "1.63.2.5",
         "nugetId": "Xamarin.Grpc.Util",
         "excludedRuntimeDependencies": "io.grpc.grpc-core,junit.junit,io.grpc.grpc-testing,org.mockito.mockito-core",
         "type": "androidlibrary",
@@ -4600,7 +4600,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-api",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.12",
+        "nugetVersion": "0.31.1.13",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4609,7 +4609,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-contrib-grpc-metrics",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.12",
+        "nugetVersion": "0.31.1.13",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4618,7 +4618,7 @@
         "groupId": "io.perfmark",
         "artifactId": "perfmark-api",
         "version": "0.27.0",
-        "nugetVersion": "0.27.0.7",
+        "nugetVersion": "0.27.0.8",
         "nugetId": "Xamarin.Io.PerfMark.PerfMarkApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4627,7 +4627,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxandroid",
         "version": "2.1.1",
-        "nugetVersion": "2.1.1.18",
+        "nugetVersion": "2.1.1.19",
         "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4636,7 +4636,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxjava",
         "version": "2.2.21",
-        "nugetVersion": "2.2.21.25",
+        "nugetVersion": "2.2.21.26",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4646,7 +4646,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxkotlin",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.18",
+        "nugetVersion": "2.4.0.19",
         "nugetId": "Xamarin.Android.ReactiveX.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4655,7 +4655,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxandroid",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.17",
+        "nugetVersion": "3.0.2.18",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4664,7 +4664,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxjava",
         "version": "3.1.10",
-        "nugetVersion": "3.1.10.2",
+        "nugetVersion": "3.1.10.3",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4673,7 +4673,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxkotlin",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.18",
+        "nugetVersion": "3.0.1.19",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4682,7 +4682,7 @@
         "groupId": "jakarta.inject",
         "artifactId": "jakarta.inject-api",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.5",
+        "nugetVersion": "2.0.1.6",
         "nugetId": "Xamarin.Jakarta.Inject.InjectApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4691,7 +4691,7 @@
         "groupId": "javax.inject",
         "artifactId": "javax.inject",
         "version": "1",
-        "nugetVersion": "1.0.0.19",
+        "nugetVersion": "1.0.0.20",
         "nugetId": "Xamarin.JavaX.Inject",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4700,7 +4700,7 @@
         "groupId": "org.aomedia.avif.android",
         "artifactId": "avif",
         "version": "1.1.1.14d8e3c4",
-        "nugetVersion": "1.1.1.349758407",
+        "nugetVersion": "1.1.1.349758408",
         "nugetId": "Xamarin.AOMedia.AVIF.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4710,7 +4710,7 @@
         "groupId": "org.brotli",
         "artifactId": "dec",
         "version": "0.1.2",
-        "nugetVersion": "0.1.2.7",
+        "nugetVersion": "0.1.2.8",
         "nugetId": "Xamarin.Brotli.Dec",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4719,7 +4719,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-compat-qual",
         "version": "2.5.6",
-        "nugetVersion": "2.5.6.11",
+        "nugetVersion": "2.5.6.12",
         "nugetId": "Xamarin.CheckerFramework.CheckerCompatQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4728,7 +4728,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-qual",
         "version": "3.49.2",
-        "nugetVersion": "3.49.2.1",
+        "nugetVersion": "3.49.2.2",
         "nugetId": "Xamarin.CheckerFramework.CheckerQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4737,7 +4737,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-api",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.7",
+        "nugetVersion": "119.6045.31.8",
         "nugetId": "Xamarin.Chromium.CroNet.Api",
         "type": "androidlibrary"
       },
@@ -4745,7 +4745,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-common",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.7",
+        "nugetVersion": "119.6045.31.8",
         "nugetId": "Xamarin.Chromium.CroNet.Common",
         "type": "androidlibrary"
       },
@@ -4753,7 +4753,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-embedded",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.7",
+        "nugetVersion": "119.6045.31.8",
         "nugetId": "Xamarin.Chromium.CroNet.Embedded",
         "type": "androidlibrary"
       },
@@ -4761,7 +4761,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-fallback",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.7",
+        "nugetVersion": "119.6045.31.8",
         "nugetId": "Xamarin.Chromium.CroNet.Fallback",
         "type": "androidlibrary"
       },
@@ -4769,7 +4769,7 @@
         "groupId": "org.codehaus.mojo",
         "artifactId": "animal-sniffer-annotations",
         "version": "1.24",
-        "nugetVersion": "1.24.0.5",
+        "nugetVersion": "1.24.0.6",
         "nugetId": "Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4778,7 +4778,7 @@
         "groupId": "org.jetbrains",
         "artifactId": "annotations",
         "version": "26.0.2",
-        "nugetVersion": "26.0.2.1",
+        "nugetVersion": "26.0.2.2",
         "nugetId": "Xamarin.Jetbrains.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4787,7 +4787,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-android-extensions-runtime",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.Android.Extensions.Runtime.Library",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4796,7 +4796,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-parcelize-runtime",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.Parcelize.Runtime",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4805,7 +4805,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4817,7 +4817,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4826,7 +4826,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4838,7 +4838,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4850,7 +4850,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.3",
+        "nugetVersion": "2.0.21.4",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4862,7 +4862,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu",
         "version": "0.26.1",
-        "nugetVersion": "0.26.1.2",
+        "nugetVersion": "0.26.1.3",
         "nugetId": "Xamarin.KotlinX.AtomicFU",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4871,7 +4871,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu-jvm",
         "version": "0.26.1",
-        "nugetVersion": "0.26.1.2",
+        "nugetVersion": "0.26.1.3",
         "nugetId": "Xamarin.KotlinX.AtomicFU.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4880,7 +4880,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4889,7 +4889,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4898,7 +4898,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4907,7 +4907,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-guava",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Guava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4916,7 +4916,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-jdk8",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4925,7 +4925,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-play-services",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Play.Services",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4934,7 +4934,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-reactive",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4943,7 +4943,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4952,7 +4952,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx3",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.3",
+        "nugetVersion": "1.9.0.4",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx3",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4961,7 +4961,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4970,7 +4970,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core-jvm",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4979,7 +4979,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Json",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4988,7 +4988,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json-jvm",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Json.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4997,7 +4997,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5006,7 +5006,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf-jvm",
         "version": "1.7.3",
-        "nugetVersion": "1.7.3.4",
+        "nugetVersion": "1.7.3.5",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5015,7 +5015,7 @@
         "groupId": "org.jspecify",
         "artifactId": "jspecify",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.JSpecify",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5024,7 +5024,7 @@
         "groupId": "org.ow2.asm",
         "artifactId": "asm",
         "version": "9.8",
-        "nugetVersion": "9.8.0.1",
+        "nugetVersion": "9.8.0.2",
         "nugetId": "Xamarin.OW2.ASM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5033,7 +5033,7 @@
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.4",
-        "nugetVersion": "1.0.4.19",
+        "nugetVersion": "1.0.4.20",
         "nugetId": "Xamarin.Android.ReactiveStreams",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5042,7 +5042,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-android",
         "version": "1.13.1",
-        "nugetVersion": "1.13.1.13",
+        "nugetVersion": "1.13.1.14",
         "nugetId": "Xamarin.TensorFlow.Android",
         "assemblyName": "org.tensorflow.tensorflow-android",
         "type": "androidlibrary",
@@ -5052,7 +5052,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.5",
+        "nugetVersion": "2.16.1.6",
         "nugetId": "Xamarin.TensorFlow.Lite",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5061,7 +5061,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.5",
+        "nugetVersion": "2.16.1.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Api",
         "assemblyName": "org.tensorflow.tensorflow-lite-api",
         "type": "androidlibrary",
@@ -5071,7 +5071,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.5",
+        "nugetVersion": "2.16.1.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5080,7 +5080,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.5",
+        "nugetVersion": "2.16.1.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu.Api",
         "assemblyName": "org.tensorflow.tensorflow-lite-gpu-api",
         "type": "androidlibrary",
@@ -5090,7 +5090,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-metadata",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.1",
+        "nugetVersion": "0.5.0.2",
         "nugetId": "Xamarin.TensorFlow.Lite.Metadata",
         "assemblyName": "org.tensorflow.tensorflow-lite-metadata",
         "type": "androidlibrary",
@@ -5100,7 +5100,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-select-tf-ops",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.5",
+        "nugetVersion": "2.16.1.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Select.TF.Ops",
         "assemblyName": "org.tensorflow.tensorflow-lite-select-tf-ops",
         "type": "androidlibrary",
@@ -5110,7 +5110,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.1",
+        "nugetVersion": "0.5.0.2",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-support",
         "type": "androidlibrary",
@@ -5120,7 +5120,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support-api",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.1",
+        "nugetVersion": "0.5.0.2",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Api",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-support-api",
@@ -5132,7 +5132,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio",
         "type": "androidlibrary",
@@ -5142,7 +5142,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio-play-services",
         "type": "androidlibrary",
@@ -5152,7 +5152,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-base",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Base.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-base",
         "type": "androidlibrary",
@@ -5162,7 +5162,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text",
         "type": "androidlibrary",
@@ -5172,7 +5172,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text-play-services",
         "type": "androidlibrary",
@@ -5182,7 +5182,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision",
         "type": "androidlibrary",
@@ -5192,7 +5192,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.10",
+        "nugetVersion": "0.4.4.11",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.PlayServices.Library",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision-play-services",

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -1,0 +1,24 @@
+# Development Tips
+
+This is a collection of tasks you might want to do in this repository, and how to do them.
+
+## Bumping Versions
+
+In the case of [#1118][1118], we introduced `net10.0-android` target
+framework to better support trimming and NativeAOT scenarios.
+
+This means that many of the packages *changed*, but the Maven artifact
+did not change. The NuGet packages here use the fourth component of
+the version number to indicate this, so you can bump the version of
+the NuGet package without changing the Maven artifact.
+
+To "bump" the fourth component of the version number, you can run:
+
+```bash
+dotnet cake --target=bump-config
+```
+
+You should see the changes to `config.json`, noticing that none of the
+`dependencyOnly=true` entries have been changed.
+
+[1118]: https://github.com/dotnet/android-libraries/pull/1118

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
@@ -28,6 +28,9 @@ static class BumpCommand
 		var config = await BindingConfig.Load (configFile);
 
 		foreach (var art in config.MavenArtifacts) {
+			if (art.DependencyOnly)
+				continue;
+
 			var version = "";
 			var release = "";
 			var revision = 0;


### PR DESCRIPTION
Because the new packages contain a new `net10.0-android` target framework inside, we need to "bump" the versions of them all by `.1`.

This way we can push new packages without conflicts:

    Pushing Xamarin.AndroidX.Browser.1.8.0.9.nupkg to 'https://www.nuget.org/api/v2/package'...
    PUT https://www.nuget.org/api/v2/package/
    Conflict https://www.nuget.org/api/v2/package/ 564ms
    Package 'D:\a\_work\1\AndroidX\nuget-signed\Xamarin.AndroidX.Browser.1.8.0.9.nupkg' already exists at feed 'https://www.nuget.org/api/v2/package'.

To do this, I ran:

    dotnet cake --target=bump-config

I also fixed an issue with `BumpCommand`, making it skip `dependencyOnly=true` dependencies.