### PR TITLE
Alignment bump

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,49 +12,49 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.2",
+        "nugetVersion": "1.10.1.3",
         "nugetId": "Xamarin.AndroidX.Activity"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-compose",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.2",
+        "nugetVersion": "1.10.1.3",
         "nugetId": "Xamarin.AndroidX.Activity.Compose"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.2",
+        "nugetVersion": "1.10.1.3",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.32-alpha05",
+        "nugetVersion": "1.0.0.33-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.32-alpha05",
+        "nugetVersion": "1.0.0.33-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.32-alpha05",
+        "nugetVersion": "1.0.0.33-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.9.1",
-        "nugetVersion": "1.9.1.4",
+        "nugetVersion": "1.9.1.5",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "extraDependencies": "androidx.annotation.annotation-jvm"
       },
@@ -62,623 +62,623 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1",
+        "nugetVersion": "1.5.1.1",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation-jvm",
         "version": "1.9.1",
-        "nugetVersion": "1.9.1.4",
+        "nugetVersion": "1.9.1.5",
         "nugetId": "Xamarin.AndroidX.Annotation.Jvm"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.AppCompat"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.17",
+        "nugetVersion": "2.2.0.18",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.17",
+        "nugetVersion": "2.2.0.18",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime"
       },
       {
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater"
       },
       {
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.AutoFill"
       },
       {
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.29",
+        "nugetVersion": "1.1.0.30",
         "nugetId": "Xamarin.AndroidX.Biometric"
       },
       {
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.8.0",
-        "nugetVersion": "1.8.0.10",
+        "nugetVersion": "1.8.0.11",
         "nugetId": "Xamarin.AndroidX.Browser"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Core"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-effects",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Effects"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-extensions",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Extensions"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-mlkit-vision",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.MLKit.Vision"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-video",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.Video"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.Camera.View"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.31-alpha7",
+        "nugetVersion": "1.0.0.32-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.31-alpha5",
+        "nugetVersion": "1.0.0.32-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster"
       },
       {
         "groupId": "androidx.car.app",
         "artifactId": "app",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0",
+        "nugetVersion": "1.7.0.1",
         "nugetId": "Xamarin.AndroidX.Car.App.App"
       },
       {
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.35",
+        "nugetVersion": "1.0.0.36",
         "nugetId": "Xamarin.AndroidX.CardView"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.2",
+        "nugetVersion": "1.5.0.3",
         "nugetId": "Xamarin.AndroidX.Collection"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-jvm",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.2",
+        "nugetVersion": "1.5.0.3",
         "nugetId": "Xamarin.AndroidX.Collection.Jvm"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-ktx",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.2",
+        "nugetVersion": "1.5.0.3",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Android"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core.Android"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.2",
+        "nugetVersion": "1.7.8.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.2",
+        "nugetVersion": "1.7.8.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.2",
+        "nugetVersion": "1.7.8.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.2",
+        "nugetVersion": "1.7.8.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple.Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.2",
+        "nugetVersion": "1.3.2.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-android",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.2",
+        "nugetVersion": "1.3.2.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.2",
+        "nugetVersion": "1.3.2.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClass"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class-android",
         "version": "1.3.2",
-        "nugetVersion": "1.3.2.2",
+        "nugetVersion": "1.3.2.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClassAndroid"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-livedata",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.LiveData"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util-android",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-viewbinding",
         "version": "1.8.3",
-        "nugetVersion": "1.8.3",
+        "nugetVersion": "1.8.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.ViewBinding"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures-ktx",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures.Ktx"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.2.1",
-        "nugetVersion": "2.2.1.2",
+        "nugetVersion": "2.2.1.3",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-core",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.2",
+        "nugetVersion": "1.1.1.3",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Core"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.28",
+        "nugetVersion": "2.0.4.29",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver"
       },
       {
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.ContentPager"
       },
       {
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.2",
+        "nugetVersion": "1.3.0.3",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.16.0",
-        "nugetVersion": "1.16.0.2",
+        "nugetVersion": "1.16.0.3",
         "nugetId": "Xamarin.AndroidX.Core"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.7",
+        "nugetVersion": "1.0.0.8",
         "nugetId": "Xamarin.AndroidX.Core.Animation"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.18",
+        "nugetVersion": "1.1.0.19",
         "nugetId": "Xamarin.AndroidX.Core.GoogleShortcuts"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.16.0",
-        "nugetVersion": "1.16.0.2",
+        "nugetVersion": "1.16.0.3",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Core.Role"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-splashscreen",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.16",
+        "nugetVersion": "1.0.1.17",
         "nugetId": "Xamarin.AndroidX.Core.SplashScreen"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-viewtree",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.2",
+        "nugetVersion": "1.0.0.3",
         "nugetId": "Xamarin.AndroidX.Core.ViewTree"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.2",
+        "nugetVersion": "1.5.0.3",
         "nugetId": "Xamarin.AndroidX.Credentials"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials-play-services-auth",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.2",
+        "nugetVersion": "1.5.0.3",
         "nugetId": "Xamarin.AndroidX.Credentials.PlayServicesAuth",
         "allowPrereleaseDependencies": true
       },
@@ -686,84 +686,84 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.CursorAdapter"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.CustomView"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview-poolingcontainer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.CustomView.PoolingContainer"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-adapters",
         "version": "8.11.1",
-        "nugetVersion": "8.11.1",
+        "nugetVersion": "8.11.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-common",
         "version": "8.11.1",
-        "nugetVersion": "8.11.1",
+        "nugetVersion": "8.11.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-runtime",
         "version": "8.11.1",
-        "nugetVersion": "8.11.1",
+        "nugetVersion": "8.11.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "viewbinding",
         "version": "8.11.1",
-        "nugetVersion": "8.11.1",
+        "nugetVersion": "8.11.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-android",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-android",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-jvm",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Jvm",
         "extraDependencies": "androidx.datastore.datastore-core-android",
         "comments": "Empty package we want to redirect to Xamarin.AndroidX.DataStore.Core.Android because it is a superset of this package, causing conflicts."
@@ -772,133 +772,133 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio-jvm",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-android",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core-jvm",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-external-protobuf",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.External.Protobuf"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-proto",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Proto"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava2",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava2"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava3",
         "version": "1.1.7",
-        "nugetVersion": "1.1.7",
+        "nugetVersion": "1.1.7.1",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava3"
       },
       {
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.DocumentFile"
       },
       {
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.17",
+        "nugetVersion": "1.2.0.18",
         "nugetId": "Xamarin.AndroidX.DrawerLayout"
       },
       {
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.28",
+        "nugetVersion": "1.1.0.29",
         "nugetId": "Xamarin.AndroidX.Emoji"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.28",
+        "nugetVersion": "1.1.0.29",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.28",
+        "nugetVersion": "1.1.0.29",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.5",
+        "nugetVersion": "1.5.0.6",
         "nugetId": "Xamarin.AndroidX.Emoji2"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-bundled",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.5",
+        "nugetVersion": "1.5.0.6",
         "nugetId": "Xamarin.AndroidX.Emoji2.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-emojipicker",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.5",
+        "nugetVersion": "1.5.0.6",
         "nugetId": "Xamarin.AndroidX.Emoji2.EmojiPicker",
         "skipExtendedTests": true,
         "comments": "Skip tests due to explicit dependency version request causes conflicts"
@@ -907,903 +907,903 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.5",
+        "nugetVersion": "1.5.0.6",
         "nugetId": "Xamarin.AndroidX.Emoji2.Views"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views-helper",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0.5",
+        "nugetVersion": "1.5.0.6",
         "nugetId": "Xamarin.AndroidX.Emoji2.ViewsHelper"
       },
       {
         "groupId": "androidx.enterprise",
         "artifactId": "enterprise-feedback",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.19",
+        "nugetVersion": "1.1.0.20",
         "nugetId": "Xamarin.AndroidX.Enterprise.Feedback"
       },
       {
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1",
+        "nugetVersion": "1.4.1.1",
         "nugetId": "Xamarin.AndroidX.ExifInterface"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.8.8",
-        "nugetVersion": "1.8.8",
+        "nugetVersion": "1.8.8.1",
         "nugetId": "Xamarin.AndroidX.Fragment"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment-ktx",
         "version": "1.8.8",
-        "nugetVersion": "1.8.8",
+        "nugetVersion": "1.8.8.1",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx"
       },
       {
         "groupId": "androidx.graphics",
         "artifactId": "graphics-path",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.5",
+        "nugetVersion": "1.0.1.6",
         "nugetId": "Xamarin.AndroidX.Graphics.Path"
       },
       {
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.GridLayout"
       },
       {
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.HeifWriter"
       },
       {
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Interpolator"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Leanback"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback-grid",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0",
+        "nugetVersion": "1.0.0.1",
         "nugetId": "Xamarin.AndroidX.Leanback.Grid"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.34",
+        "nugetVersion": "1.0.0.35",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-java8",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-jvm",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Jvm"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.33",
+        "nugetVersion": "2.2.0.34",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState.Android"
       },
       {
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.33",
+        "nugetVersion": "1.1.0.34",
         "nugetId": "Xamarin.AndroidX.Loader"
       },
       {
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager"
       },
       {
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.11",
+        "nugetVersion": "1.7.0.12",
         "nugetId": "Xamarin.AndroidX.Media"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.11",
+        "nugetVersion": "1.3.0.12",
         "nugetId": "Xamarin.AndroidX.Media2.Common"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.11",
+        "nugetVersion": "1.3.0.12",
         "nugetId": "Xamarin.AndroidX.Media2.Session"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.11",
+        "nugetVersion": "1.3.0.12",
         "nugetId": "Xamarin.AndroidX.Media2.Widget"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-cast",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Cast"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-common",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Common"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-container",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Container"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-database",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Database"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-cronet",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.CroNet"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-rtmp",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.Rtmp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-decoder",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Decoder"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-effect",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Effect"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-dash",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Dash"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-hls",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Hls"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-rtsp",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Rtsp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-smoothstreaming",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.SmoothStreaming"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-workmanager",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.WorkManager"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-extractor",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Extractor"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-muxer",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Muxer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-session",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1.1",
+        "nugetVersion": "1.7.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Session"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-transformer",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Transformer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Ui"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui-leanback",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1",
+        "nugetVersion": "1.7.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Ui.Leanback"
       },
       {
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1",
+        "nugetVersion": "1.8.1.1",
         "nugetId": "Xamarin.AndroidX.MediaRouter"
       },
       {
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.33",
+        "nugetVersion": "2.0.1.34",
         "nugetId": "Xamarin.AndroidX.MultiDex"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-android",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui-ktx",
         "version": "2.9.2",
-        "nugetVersion": "2.9.2",
+        "nugetVersion": "2.9.2.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common-jvm",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Jvm"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common-ktx",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime-ktx",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
+        "nugetVersion": "3.3.6.3",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Palette"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette-ktx",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.26",
+        "nugetVersion": "1.0.0.27",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx"
       },
       {
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.34",
+        "nugetVersion": "1.0.0.35",
         "nugetId": "Xamarin.AndroidX.PercentLayout"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Preference"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx"
       },
       {
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Print"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices",
         "version": "1.1.0-beta12",
-        "nugetVersion": "1.1.0.2-beta12",
+        "nugetVersion": "1.1.0.3-beta12",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices-java",
         "version": "1.1.0-beta12",
-        "nugetVersion": "1.1.0.2-beta12",
+        "nugetVersion": "1.1.0.3-beta12",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices.Java"
       },
       {
         "groupId": "androidx.profileinstaller",
         "artifactId": "profileinstaller",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.4",
+        "nugetVersion": "1.4.1.5",
         "nugetId": "Xamarin.AndroidX.ProfileInstaller.ProfileInstaller"
       },
       {
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Recommendation"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.RecyclerView"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection"
       },
       {
         "groupId": "androidx.resourceinspection",
         "artifactId": "resourceinspection-annotation",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.21",
+        "nugetVersion": "1.0.1.22",
         "nugetId": "Xamarin.AndroidX.ResourceInspection.Annotation"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Common"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-common-jvm",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Common.JVM"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Guava"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-ktx",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Runtime"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime-android",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Runtime.Android"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava2",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava3",
         "version": "2.7.2",
-        "nugetVersion": "2.7.2",
+        "nugetVersion": "2.7.2.1",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1",
+        "nugetVersion": "1.3.1.1",
         "nugetId": "Xamarin.AndroidX.SavedState"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-android",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1",
+        "nugetVersion": "1.3.1.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Android"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-compose-android",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1",
+        "nugetVersion": "1.3.1.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Compose.Android"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-ktx",
         "version": "1.3.1",
-        "nugetVersion": "1.3.1",
+        "nugetVersion": "1.3.1.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx"
       },
       {
         "groupId": "androidx.security",
         "artifactId": "security-crypto",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.26",
+        "nugetVersion": "1.0.0.27",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Slice.Builders"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Slice.Core"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.33",
+        "nugetVersion": "1.0.0.34",
         "nugetId": "Xamarin.AndroidX.Slice.View"
       },
       {
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.21",
+        "nugetVersion": "1.2.0.22",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.5.2",
-        "nugetVersion": "2.5.2",
+        "nugetVersion": "2.5.2.1",
         "nugetId": "Xamarin.AndroidX.Sqlite"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-android",
         "version": "2.5.2",
-        "nugetVersion": "2.5.2",
+        "nugetVersion": "2.5.2.1",
         "nugetId": "Xamarin.AndroidX.Sqlite.Android"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.5.2",
-        "nugetVersion": "2.5.2",
+        "nugetVersion": "2.5.2.1",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework-android",
         "version": "2.5.2",
-        "nugetVersion": "2.5.2",
+        "nugetVersion": "2.5.2.1",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework.Android"
       },
       {
         "groupId": "androidx.startup",
         "artifactId": "startup-runtime",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.4",
+        "nugetVersion": "1.2.0.5",
         "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime"
       },
       {
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.28",
+        "nugetVersion": "1.1.0.29",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing-android",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing.Android"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing-ktx",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing.Ktx"
       },
       {
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Transition",
         "extraDependencies": "androidx.fragment.fragment"
       },
@@ -1811,119 +1811,119 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.TvProvider"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.7",
+        "nugetVersion": "1.2.0.8",
         "nugetId": "Xamarin.AndroidX.VectorDrawable"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.7",
+        "nugetVersion": "1.2.0.8",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated"
       },
       {
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.2",
+        "nugetVersion": "1.2.1.3",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable"
       },
       {
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.ViewPager"
       },
       {
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.7",
+        "nugetVersion": "1.1.0.8",
         "nugetId": "Xamarin.AndroidX.ViewPager2"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.14",
+        "nugetVersion": "1.3.0.15",
         "nugetId": "Xamarin.AndroidX.Wear"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-input",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.4",
+        "nugetVersion": "1.1.0.5",
         "nugetId": "Xamarin.AndroidX.Wear.Input"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-ongoing",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.AndroidX.Wear.Ongoing"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-phone-interactions",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.PhoneInteractions"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-remote-interactions",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Wear.RemoteInteractions"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-foundation",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.2",
+        "nugetVersion": "1.4.1.3",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Foundation"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.2",
+        "nugetVersion": "1.4.1.3",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material-core",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.2",
+        "nugetVersion": "1.4.1.3",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material.Core"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-navigation",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.2",
+        "nugetVersion": "1.4.1.3",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Navigation"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression",
         "excludedRuntimeDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
         "extraDependencies": "org.jetbrains.kotlin.kotlin-stdlib"
@@ -1932,49 +1932,49 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression-pipeline",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression.Pipeline"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-external-protobuf",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.External.Protobuf"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-proto",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0",
+        "nugetVersion": "1.3.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-material",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Material"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-proto",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-renderer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.18",
+        "nugetVersion": "1.1.0.19",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Renderer",
         "frozen": true,
         "comments": "Needs androidx.wear.protolayout.protolayout-renderer:1.1.0"
@@ -1983,182 +1983,182 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Client"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.ClientGuava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-rendering",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Rendering"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-data",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Guava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-style",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
+        "nugetVersion": "1.2.1.12",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Style"
       },
       {
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.14.0",
-        "nugetVersion": "1.14.0",
+        "nugetVersion": "1.14.0.1",
         "nugetId": "Xamarin.AndroidX.WebKit"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-core",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowCore"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-core-jvm",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowCore.Jvm"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.28-alpha01",
+        "nugetVersion": "1.0.0.29-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava2",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava2"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava3",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava3"
       },
       {
         "groupId": "androidx.window.extensions.core",
         "artifactId": "core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.15",
+        "nugetVersion": "1.0.0.16",
         "nugetId": "Xamarin.AndroidX.Window.Extensions.Core.Core"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-gcm",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.GCM"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-multiprocess",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.MultiProcess"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.Runtime"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime-ktx",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava2",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.RxJava2"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava3",
         "version": "2.10.2",
-        "nugetVersion": "2.10.2",
+        "nugetVersion": "2.10.2.1",
         "nugetId": "Xamarin.AndroidX.Work.RxJava3"
       },
       {
         "groupId": "aopalliance",
         "artifactId": "aopalliance",
         "version": "1.0",
-        "nugetVersion": "1.0.0.8",
+        "nugetVersion": "1.0.0.9",
         "nugetId": "Xamarin.AopAlliance",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2167,7 +2167,7 @@
         "groupId": "com.android.billingclient",
         "artifactId": "billing",
         "version": "8.0.0",
-        "nugetVersion": "8.0.0.1",
+        "nugetVersion": "8.0.0.2",
         "nugetId": "Xamarin.Android.Google.BillingClient",
         "type": "xbd"
       },
@@ -2175,7 +2175,7 @@
         "groupId": "com.android.installreferrer",
         "artifactId": "installreferrer",
         "version": "2.2",
-        "nugetVersion": "2.2.0.4",
+        "nugetVersion": "2.2.0.5",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "type": "xbd"
       },
@@ -2183,7 +2183,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.17",
+        "nugetVersion": "1.2.1.18",
         "nugetId": "Xamarin.Android.Volley",
         "type": "xbd"
       },
@@ -2191,7 +2191,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley-cronet",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.17",
+        "nugetVersion": "1.2.1.18",
         "nugetId": "Xamarin.Android.Volley.CroNet",
         "type": "xbd"
       },
@@ -2199,7 +2199,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "annotations",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2208,7 +2208,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "avif-integration",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide.AVIF.Integration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2217,7 +2217,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "disklrucache",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide.DiskLruCache",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2226,7 +2226,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "gifdecoder",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide.GifDecoder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2235,7 +2235,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "glide",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2244,7 +2244,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "recyclerview-integration",
         "version": "4.16.0",
-        "nugetVersion": "4.16.0.13",
+        "nugetVersion": "4.16.0.14",
         "nugetId": "Xamarin.Android.Glide.RecyclerViewIntegration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2253,7 +2253,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-appcompat-theme",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.AppCompat.Theme",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2262,7 +2262,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-drawablepainter",
         "version": "0.37.3",
-        "nugetVersion": "0.37.3",
+        "nugetVersion": "0.37.3.1",
         "nugetId": "Xamarin.Google.Accompanist.DrawablePainter",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2271,7 +2271,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-flowlayout",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.FlowLayout",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2280,7 +2280,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.Pager",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2289,7 +2289,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager-indicators",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.Pager.Indicators",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2298,7 +2298,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-permissions",
         "version": "0.37.3",
-        "nugetVersion": "0.37.3",
+        "nugetVersion": "0.37.3.1",
         "nugetId": "Xamarin.Google.Accompanist.Permissions",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2307,7 +2307,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2316,7 +2316,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder-material",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder.Material",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2325,7 +2325,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-swiperefresh",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.SwipeRefresh",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2334,7 +2334,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-systemuicontroller",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.5",
+        "nugetVersion": "0.36.0.6",
         "nugetId": "Xamarin.Google.Accompanist.SystemUIController",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2343,7 +2343,7 @@
         "groupId": "com.google.ads.interactivemedia.v3",
         "artifactId": "interactivemedia",
         "version": "3.37.0",
-        "nugetVersion": "3.37.0.1-beta01",
+        "nugetVersion": "3.37.0.2-beta01",
         "nugetId": "Xamarin.Google.Ads.InteractiveMedia.V3.InteractiveMedia",
         "type": "xbd"
       },
@@ -2351,7 +2351,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT",
         "type": "androidlibrary"
       },
@@ -2359,7 +2359,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-api",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.API",
         "type": "androidlibrary"
       },
@@ -2367,7 +2367,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU",
         "type": "androidlibrary"
       },
@@ -2375,7 +2375,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu-api",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU.API",
         "type": "androidlibrary"
       },
@@ -2383,7 +2383,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-metadata",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Metadata",
         "type": "androidlibrary"
       },
@@ -2391,7 +2391,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support",
         "type": "androidlibrary"
       },
@@ -2399,7 +2399,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support-api",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support.API",
         "allowPrereleaseDependencies": true,
         "type": "androidlibrary",
@@ -2409,7 +2409,7 @@
         "groupId": "com.google.android",
         "artifactId": "annotations",
         "version": "4.1.1.4",
-        "nugetVersion": "4.1.1.22",
+        "nugetVersion": "4.1.1.23",
         "nugetId": "Xamarin.GoogleAndroid.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2418,7 +2418,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-api",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.4",
+        "nugetVersion": "4.0.0.5",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
         "type": "androidlibrary"
       },
@@ -2426,7 +2426,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-backend-cct",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.4",
+        "nugetVersion": "4.0.0.5",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
         "type": "androidlibrary"
       },
@@ -2434,7 +2434,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-runtime",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.4",
+        "nugetVersion": "4.0.0.5",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
         "type": "androidlibrary"
       },
@@ -2442,7 +2442,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads",
         "version": "24.5.0",
-        "nugetVersion": "124.5.0",
+        "nugetVersion": "124.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Ads",
         "allowPrereleaseDependencies": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
@@ -2452,7 +2452,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-api",
         "version": "24.5.0",
-        "nugetVersion": "124.5.0",
+        "nugetVersion": "124.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Api",
         "type": "xbd"
       },
@@ -2460,7 +2460,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-base",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0",
+        "nugetVersion": "124.1.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Base",
         "type": "xbd"
       },
@@ -2468,7 +2468,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-identifier",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.3",
+        "nugetVersion": "118.2.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Identifier",
         "type": "xbd"
       },
@@ -2476,7 +2476,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-lite",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.2",
+        "nugetVersion": "124.0.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Lite",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -2485,7 +2485,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-afs-native",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.6",
+        "nugetVersion": "119.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.AFS.Native",
         "type": "xbd"
       },
@@ -2493,7 +2493,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.4",
+        "nugetVersion": "118.1.1.5",
         "nugetId": "Xamarin.GooglePlayServices.Analytics",
         "type": "xbd"
       },
@@ -2501,7 +2501,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics-impl",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.4",
+        "nugetVersion": "118.2.0.5",
         "nugetId": "Xamarin.GooglePlayServices.Analytics.Impl",
         "type": "xbd"
       },
@@ -2509,7 +2509,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appindex",
         "version": "16.2.0",
-        "nugetVersion": "116.2.0.6",
+        "nugetVersion": "116.2.0.7",
         "nugetId": "Xamarin.GooglePlayServices.AppIndex",
         "type": "xbd"
       },
@@ -2517,7 +2517,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appinvite",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.22",
+        "nugetVersion": "118.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.AppInvite",
         "type": "xbd"
       },
@@ -2525,7 +2525,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appset",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.6",
+        "nugetVersion": "116.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.AppSet",
         "type": "xbd"
       },
@@ -2533,7 +2533,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-audience",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Audience",
         "type": "xbd"
       },
@@ -2541,7 +2541,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth",
         "version": "21.4.0",
-        "nugetVersion": "121.4.0",
+        "nugetVersion": "121.4.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Auth",
         "type": "xbd"
       },
@@ -2549,7 +2549,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-api-phone",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.2",
+        "nugetVersion": "118.2.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Api.Phone",
         "type": "xbd"
       },
@@ -2557,7 +2557,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-base",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0",
+        "nugetVersion": "118.3.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Base",
         "type": "xbd"
       },
@@ -2565,7 +2565,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-blockstore",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.5",
+        "nugetVersion": "116.4.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Blockstore",
         "type": "xbd"
       },
@@ -2573,7 +2573,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-awareness",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.6",
+        "nugetVersion": "119.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Awareness",
         "type": "xbd"
       },
@@ -2581,7 +2581,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-base",
         "version": "18.7.2",
-        "nugetVersion": "118.7.2",
+        "nugetVersion": "118.7.2.1",
         "nugetId": "Xamarin.GooglePlayServices.Base",
         "type": "xbd"
       },
@@ -2589,7 +2589,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-basement",
         "version": "18.7.1",
-        "nugetVersion": "118.7.1",
+        "nugetVersion": "118.7.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Basement",
         "type": "xbd"
       },
@@ -2597,7 +2597,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0",
+        "nugetVersion": "122.1.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Cast",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2606,7 +2606,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-framework",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0",
+        "nugetVersion": "122.1.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Cast.Framework",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2615,7 +2615,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-tv",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.4",
+        "nugetVersion": "121.1.1.5",
         "nugetId": "Xamarin.GooglePlayServices.Cast.TV",
         "type": "xbd"
       },
@@ -2623,7 +2623,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-clearcut",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Clearcut",
         "type": "xbd"
       },
@@ -2631,7 +2631,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cloud-messaging",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.6",
+        "nugetVersion": "117.3.0.7",
         "nugetId": "Xamarin.GooglePlayServices.CloudMessaging",
         "type": "xbd"
       },
@@ -2639,7 +2639,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-code-scanner",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.12",
+        "nugetVersion": "116.1.0.13",
         "nugetId": "Xamarin.GooglePlayServices.Code.Scanner",
         "type": "xbd"
       },
@@ -2647,7 +2647,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cronet",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.6",
+        "nugetVersion": "118.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.CroNet",
         "type": "xbd"
       },
@@ -2655,7 +2655,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-deviceperformance",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.6",
+        "nugetVersion": "116.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.DevicePerformance",
         "type": "xbd"
       },
@@ -2663,7 +2663,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-drive",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.23",
+        "nugetVersion": "117.0.0.24",
         "nugetId": "Xamarin.GooglePlayServices.Drive",
         "type": "xbd"
       },
@@ -2671,7 +2671,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fido",
         "version": "21.2.0",
-        "nugetVersion": "121.2.0.2",
+        "nugetVersion": "121.2.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Fido",
         "type": "xbd"
       },
@@ -2679,7 +2679,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fitness",
         "version": "21.2.0",
-        "nugetVersion": "121.2.0.6",
+        "nugetVersion": "121.2.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Fitness",
         "type": "xbd"
       },
@@ -2687,7 +2687,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-flags",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.6",
+        "nugetVersion": "118.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Flags",
         "type": "xbd"
       },
@@ -2695,7 +2695,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0.6",
+        "nugetVersion": "123.2.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Games",
         "type": "xbd"
       },
@@ -2703,7 +2703,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games-v2",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0",
+        "nugetVersion": "121.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Games.V2",
         "type": "xbd"
       },
@@ -2711,7 +2711,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gass",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.22",
+        "nugetVersion": "120.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Gass",
         "type": "xbd"
       },
@@ -2719,7 +2719,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gcm",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Gcm",
         "type": "xbd"
       },
@@ -2727,7 +2727,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-home",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.15",
+        "nugetVersion": "116.0.0.16",
         "nugetId": "Xamarin.GooglePlayServices.Home",
         "type": "xbd"
       },
@@ -2735,7 +2735,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.6",
+        "nugetVersion": "118.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Identity",
         "type": "xbd"
       },
@@ -2743,7 +2743,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity-credentials",
         "version": "16.0.0-alpha04",
-        "nugetVersion": "116.0.0.2-alpha04",
+        "nugetVersion": "116.0.0.3-alpha04",
         "nugetId": "Xamarin.GooglePlayServices.Identity.Credentials",
         "type": "xbd"
       },
@@ -2751,7 +2751,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-iid",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Iid",
         "type": "xbd"
       },
@@ -2759,7 +2759,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-instantapps",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0",
+        "nugetVersion": "118.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.InstantApps",
         "type": "xbd"
       },
@@ -2767,7 +2767,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-location",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0.6",
+        "nugetVersion": "121.3.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Location",
         "type": "xbd"
       },
@@ -2775,7 +2775,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-maps",
         "version": "19.2.0",
-        "nugetVersion": "119.2.0.2",
+        "nugetVersion": "119.2.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Maps",
         "type": "xbd"
       },
@@ -2783,7 +2783,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement",
         "type": "xbd"
       },
@@ -2791,7 +2791,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-api",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Api",
         "type": "xbd"
       },
@@ -2799,7 +2799,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-base",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
         "type": "xbd"
       },
@@ -2807,7 +2807,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-impl",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Impl",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2816,7 +2816,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk",
         "type": "xbd"
       },
@@ -2824,7 +2824,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk-api",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk.Api",
         "type": "xbd"
       },
@@ -2832,7 +2832,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-barcode-scanning",
         "version": "18.3.1",
-        "nugetVersion": "118.3.1.4",
+        "nugetVersion": "118.3.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.BarcodeScanning",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2841,7 +2841,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-face-detection",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.15",
+        "nugetVersion": "117.1.0.16",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.FaceDetection",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2850,7 +2850,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-image-labeling",
         "version": "16.0.8",
-        "nugetVersion": "116.0.8.15",
+        "nugetVersion": "116.0.8.16",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -2858,7 +2858,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-language-id",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.17",
+        "nugetVersion": "117.0.0.18",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.LanguageId",
         "type": "xbd"
       },
@@ -2866,7 +2866,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition",
         "version": "19.0.1",
-        "nugetVersion": "119.0.1.4",
+        "nugetVersion": "119.0.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition",
         "type": "xbd"
       },
@@ -2874,7 +2874,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Chinese",
         "type": "xbd"
       },
@@ -2882,7 +2882,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-common",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.4",
+        "nugetVersion": "119.1.0.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2891,7 +2891,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Devanagari",
         "type": "xbd"
       },
@@ -2899,7 +2899,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Japanese",
         "type": "xbd"
       },
@@ -2907,7 +2907,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Korean",
         "type": "xbd"
       },
@@ -2915,7 +2915,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-nearby",
         "version": "19.3.0",
-        "nugetVersion": "119.3.0.6",
+        "nugetVersion": "119.3.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Nearby",
         "type": "xbd"
       },
@@ -2923,7 +2923,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-oss-licenses",
         "version": "17.2.1",
-        "nugetVersion": "117.2.1",
+        "nugetVersion": "117.2.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Oss.Licenses",
         "type": "xbd"
       },
@@ -2931,7 +2931,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pal",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0",
+        "nugetVersion": "122.1.0.1",
         "nugetId": "Xamarin.GooglePlayServices.PAL",
         "type": "xbd"
       },
@@ -2939,7 +2939,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-panorama",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.12",
+        "nugetVersion": "117.1.0.13",
         "nugetId": "Xamarin.GooglePlayServices.Panorama",
         "type": "xbd"
       },
@@ -2947,7 +2947,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-password-complexity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.6",
+        "nugetVersion": "118.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.PasswordComplexity",
         "type": "xbd"
       },
@@ -2955,7 +2955,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pay",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0.6",
+        "nugetVersion": "116.5.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Pay",
         "type": "xbd"
       },
@@ -2963,7 +2963,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-phenotype",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Phenotype",
         "type": "xbd"
       },
@@ -2971,7 +2971,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.6",
+        "nugetVersion": "117.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Places",
         "type": "xbd"
       },
@@ -2979,7 +2979,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places-placereport",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.6",
+        "nugetVersion": "117.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Places.PlaceReport",
         "type": "xbd"
       },
@@ -2987,7 +2987,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-plus",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.23",
+        "nugetVersion": "117.0.0.24",
         "nugetId": "Xamarin.GooglePlayServices.Plus",
         "type": "xbd"
       },
@@ -2995,7 +2995,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptcha",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.6",
+        "nugetVersion": "117.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Recaptcha",
         "type": "xbd"
       },
@@ -3003,7 +3003,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptchabase",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.2",
+        "nugetVersion": "116.1.0.3",
         "nugetId": "Xamarin.GooglePlayServices.RecaptchaBase",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3012,7 +3012,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-safetynet",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.6",
+        "nugetVersion": "118.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.SafetyNet",
         "type": "xbd"
       },
@@ -3020,7 +3020,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-stats",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.6",
+        "nugetVersion": "117.1.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Stats",
         "type": "xbd"
       },
@@ -3028,7 +3028,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-streamprotect",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.14",
+        "nugetVersion": "116.1.0.15",
         "nugetId": "Xamarin.GooglePlayServices.StreamProtect",
         "type": "xbd"
       },
@@ -3036,7 +3036,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.2",
+        "nugetVersion": "118.3.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TagManager",
         "type": "xbd"
       },
@@ -3044,7 +3044,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-api",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.2",
+        "nugetVersion": "118.3.0.3",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.Api",
         "type": "xbd"
       },
@@ -3052,7 +3052,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-v4-impl",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.4",
+        "nugetVersion": "118.1.1.5",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.V4.Impl",
         "type": "xbd"
       },
@@ -3060,7 +3060,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tasks",
         "version": "18.3.2",
-        "nugetVersion": "118.3.2",
+        "nugetVersion": "118.3.2.1",
         "nugetId": "Xamarin.GooglePlayServices.Tasks",
         "type": "xbd"
       },
@@ -3068,7 +3068,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-gpu",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.3",
+        "nugetVersion": "116.4.0.4",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Gpu",
         "type": "xbd"
       },
@@ -3076,7 +3076,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-impl",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.3",
+        "nugetVersion": "116.4.0.4",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Impl",
         "type": "xbd"
       },
@@ -3084,7 +3084,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-java",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.3",
+        "nugetVersion": "116.4.0.4",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Java",
         "type": "xbd"
       },
@@ -3092,7 +3092,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-support",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.3",
+        "nugetVersion": "116.4.0.4",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Support",
         "type": "xbd"
       },
@@ -3100,7 +3100,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-threadnetwork",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0",
+        "nugetVersion": "116.3.0.1",
         "nugetId": "Xamarin.GooglePlayServices.ThreadNetwork",
         "type": "xbd"
       },
@@ -3108,7 +3108,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision",
         "version": "20.1.3",
-        "nugetVersion": "120.1.3.22",
+        "nugetVersion": "120.1.3.23",
         "nugetId": "Xamarin.GooglePlayServices.Vision",
         "type": "xbd"
       },
@@ -3116,7 +3116,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-common",
         "version": "19.1.3",
-        "nugetVersion": "119.1.3.24",
+        "nugetVersion": "119.1.3.25",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Common",
         "type": "xbd"
       },
@@ -3124,7 +3124,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-face-contour-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.22",
+        "nugetVersion": "116.1.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Face.Contour.Internal",
         "type": "xbd"
       },
@@ -3132,7 +3132,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-label",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.22",
+        "nugetVersion": "118.1.1.23",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabel",
         "type": "xbd"
       },
@@ -3140,7 +3140,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-labeling-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.22",
+        "nugetVersion": "116.1.0.23",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabelingInternal",
         "type": "xbd"
       },
@@ -3148,7 +3148,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wallet",
         "version": "19.4.0",
-        "nugetVersion": "119.4.0.6",
+        "nugetVersion": "119.4.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Wallet",
         "type": "xbd"
       },
@@ -3156,7 +3156,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wearable",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0.3",
+        "nugetVersion": "119.0.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Wearable",
         "type": "xbd"
       },
@@ -3164,7 +3164,7 @@
         "groupId": "com.google.android.libraries.identity.googleid",
         "artifactId": "googleid",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.10",
+        "nugetVersion": "1.1.0.11",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Identity.GoogleId",
         "frozen": true,
         "type": "xbd",
@@ -3174,7 +3174,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places",
         "version": "4.4.1",
-        "nugetVersion": "4.4.1.1",
+        "nugetVersion": "4.4.1.2",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Places",
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp",
         "type": "xbd"
@@ -3183,7 +3183,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places-compat",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0.14",
+        "nugetVersion": "2.6.0.15",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Places.Compat",
         "type": "xbd"
       },
@@ -3191,7 +3191,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter",
         "version": "1.1.18",
-        "nugetVersion": "1.1.18.19",
+        "nugetVersion": "1.1.18.20",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3200,7 +3200,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter-3",
         "version": "1.0.18",
-        "nugetVersion": "1.0.18.18",
+        "nugetVersion": "1.0.18.19",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter3",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3209,7 +3209,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.12.0",
-        "nugetVersion": "1.12.0.4",
+        "nugetVersion": "1.12.0.5",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },
@@ -3217,7 +3217,7 @@
         "groupId": "com.google.android.odml",
         "artifactId": "image",
         "version": "1.0.0-beta1",
-        "nugetVersion": "1.0.0.16-beta1",
+        "nugetVersion": "1.0.0.17-beta1",
         "nugetId": "Xamarin.Google.Android.ODML.Image",
         "type": "xbd"
       },
@@ -3225,7 +3225,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.15",
+        "nugetVersion": "2.1.0.16",
         "nugetId": "Xamarin.Google.Android.Play.App.Update",
         "type": "xbd"
       },
@@ -3233,7 +3233,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update-ktx",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.15",
+        "nugetVersion": "2.1.0.16",
         "nugetId": "Xamarin.Google.Android.Play.App.Update.Ktx",
         "type": "xbd"
       },
@@ -3241,7 +3241,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "asset-delivery",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
+        "nugetVersion": "2.3.0.4",
         "nugetId": "Xamarin.Google.Android.Play.Asset.Delivery",
         "type": "xbd"
       },
@@ -3249,7 +3249,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core",
         "version": "1.10.3",
-        "nugetVersion": "1.10.3.18",
+        "nugetVersion": "1.10.3.19",
         "nugetId": "Xamarin.Google.Android.Play.Core",
         "type": "xbd"
       },
@@ -3257,7 +3257,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-common",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.6",
+        "nugetVersion": "2.0.4.7",
         "nugetId": "Xamarin.Google.Android.Play.Core.Common",
         "type": "xbd"
       },
@@ -3265,7 +3265,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-ktx",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1.15",
+        "nugetVersion": "1.8.1.16",
         "nugetId": "Xamarin.Google.Android.Play.Core.Ktx",
         "type": "xbd"
       },
@@ -3273,7 +3273,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "feature-delivery",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.14",
+        "nugetVersion": "2.1.0.15",
         "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery",
         "type": "xbd"
       },
@@ -3281,7 +3281,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "integrity",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.5",
+        "nugetVersion": "1.4.0.6",
         "nugetId": "Xamarin.Google.Android.Play.Integrity",
         "type": "xbd"
       },
@@ -3289,7 +3289,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.4",
+        "nugetVersion": "2.0.2.5",
         "nugetId": "Xamarin.Google.Android.Play.Review",
         "type": "xbd"
       },
@@ -3297,7 +3297,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review-ktx",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.4",
+        "nugetVersion": "2.0.2.5",
         "nugetId": "Xamarin.Google.Android.Play.Review.Ktx",
         "type": "xbd"
       },
@@ -3305,7 +3305,7 @@
         "groupId": "com.google.android.recaptcha",
         "artifactId": "recaptcha",
         "version": "18.7.1",
-        "nugetVersion": "18.7.1",
+        "nugetVersion": "18.7.1.1",
         "nugetId": "Xamarin.Google.Android.Recaptcha",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3314,7 +3314,7 @@
         "groupId": "com.google.android.tv",
         "artifactId": "tv-ads",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.3",
+        "nugetVersion": "1.0.1.4",
         "nugetId": "Xamarin.GoogleAndroid.TV.Ads",
         "type": "xbd"
       },
@@ -3322,7 +3322,7 @@
         "groupId": "com.google.android.ump",
         "artifactId": "user-messaging-platform",
         "version": "3.2.0",
-        "nugetVersion": "3.2.0.2",
+        "nugetVersion": "3.2.0.3",
         "nugetId": "Xamarin.Google.UserMessagingPlatform",
         "type": "xbd"
       },
@@ -3330,14 +3330,14 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "suggestions",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.19",
+        "nugetVersion": "1.0.0.20",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Suggestions"
       },
       {
         "groupId": "com.google.assistant.appactions",
         "artifactId": "widgets",
         "version": "0.0.1",
-        "nugetVersion": "0.0.1.20",
+        "nugetVersion": "0.0.1.21",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
         "type": "xbd"
       },
@@ -3345,7 +3345,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1",
+        "nugetVersion": "1.8.1.1",
         "nugetId": "Xamarin.Google.AutoValue",
         "frozen": true,
         "type": "androidlibrary",
@@ -3355,7 +3355,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value-annotations",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0.7",
+        "nugetVersion": "1.11.0.8",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3364,7 +3364,7 @@
         "groupId": "com.google.code.findbugs",
         "artifactId": "jsr305",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.20",
+        "nugetVersion": "3.0.2.21",
         "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
         "assemblyName": "Jsr305Binding",
         "type": "androidlibrary",
@@ -3374,7 +3374,7 @@
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.13.1",
-        "nugetVersion": "2.13.1",
+        "nugetVersion": "2.13.1.1",
         "nugetId": "GoogleGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3383,7 +3383,7 @@
         "groupId": "com.google.crypto.tink",
         "artifactId": "tink-android",
         "version": "1.18.0",
-        "nugetVersion": "1.18.0",
+        "nugetVersion": "1.18.0.1",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3392,7 +3392,7 @@
         "groupId": "com.google.dagger",
         "artifactId": "dagger",
         "version": "2.56.2",
-        "nugetVersion": "2.56.2",
+        "nugetVersion": "2.56.2.1",
         "nugetId": "Xamarin.Google.Dagger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3401,7 +3401,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
         "version": "2.41.0",
-        "nugetVersion": "2.41.0",
+        "nugetVersion": "2.41.0.1",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3410,7 +3410,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_type_annotations",
         "version": "2.41.0",
-        "nugetVersion": "2.41.0",
+        "nugetVersion": "2.41.0.1",
         "nugetId": "Xamarin.Google.ErrorProne.TypeAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3419,7 +3419,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-abt",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.Firebase.Abt",
         "type": "xbd"
       },
@@ -3427,7 +3427,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads",
         "version": "23.6.0",
-        "nugetVersion": "123.6.0.3",
+        "nugetVersion": "123.6.0.4",
         "nugetId": "Xamarin.Firebase.Ads",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core",
         "type": "xbd"
@@ -3436,7 +3436,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.Firebase.Analytics",
         "type": "xbd"
       },
@@ -3444,7 +3444,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics-impl",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.22",
+        "nugetVersion": "116.3.0.23",
         "nugetId": "Xamarin.Firebase.Analytics.Impl",
         "type": "xbd"
       },
@@ -3452,7 +3452,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-annotations",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.Firebase.Annotations",
         "type": "xbd"
       },
@@ -3460,7 +3460,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0",
+        "nugetVersion": "119.0.0.1",
         "nugetId": "Xamarin.Firebase.AppCheck",
         "type": "xbd"
       },
@@ -3468,7 +3468,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.10",
+        "nugetVersion": "117.1.0.11",
         "nugetId": "Xamarin.Firebase.AppCheck.Interop",
         "type": "xbd"
       },
@@ -3476,7 +3476,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-playintegrity",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0",
+        "nugetVersion": "119.0.0.1",
         "nugetId": "Xamarin.Firebase.AppCheck.PlayIntegrity",
         "type": "xbd"
       },
@@ -3484,7 +3484,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.25",
+        "nugetVersion": "120.0.0.26",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "type": "xbd"
       },
@@ -3492,7 +3492,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0",
+        "nugetVersion": "124.0.0.1",
         "nugetId": "Xamarin.Firebase.Auth",
         "type": "xbd"
       },
@@ -3500,7 +3500,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth-interop",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.22",
+        "nugetVersion": "120.0.0.23",
         "nugetId": "Xamarin.Firebase.Auth.Interop",
         "type": "xbd"
       },
@@ -3508,7 +3508,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.Common",
         "type": "xbd"
       },
@@ -3516,7 +3516,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common-ktx",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.6",
+        "nugetVersion": "121.0.0.7",
         "nugetId": "Xamarin.Firebase.Common.Ktx",
         "type": "xbd"
       },
@@ -3524,7 +3524,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-components",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0",
+        "nugetVersion": "119.0.0.1",
         "nugetId": "Xamarin.Firebase.Components",
         "type": "xbd"
       },
@@ -3532,7 +3532,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config",
         "version": "23.0.0",
-        "nugetVersion": "123.0.0",
+        "nugetVersion": "123.0.0.1",
         "nugetId": "Xamarin.Firebase.Config",
         "type": "xbd"
       },
@@ -3540,7 +3540,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config-interop",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.8",
+        "nugetVersion": "116.0.1.9",
         "nugetId": "Xamarin.Firebase.Config.Interop",
         "type": "xbd"
       },
@@ -3548,7 +3548,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-core",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.15",
+        "nugetVersion": "121.1.1.16",
         "nugetId": "Xamarin.Firebase.Core",
         "type": "xbd"
       },
@@ -3556,7 +3556,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crash",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.22",
+        "nugetVersion": "116.2.1.23",
         "nugetId": "Xamarin.Firebase.Crash",
         "type": "xbd"
       },
@@ -3564,7 +3564,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.Firebase.Crashlytics",
         "extraDependencies": "com.google.dagger.dagger",
         "type": "xbd"
@@ -3573,7 +3573,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics-ndk",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.Firebase.Crashlytics.NDK",
         "type": "xbd"
       },
@@ -3581,7 +3581,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.Database",
         "type": "xbd"
       },
@@ -3589,7 +3589,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-collection",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.15",
+        "nugetVersion": "118.0.1.16",
         "nugetId": "Xamarin.Firebase.Database.Collection",
         "type": "xbd"
       },
@@ -3597,7 +3597,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-connection",
         "version": "16.0.2",
-        "nugetVersion": "116.0.2.22",
+        "nugetVersion": "116.0.2.23",
         "nugetId": "Xamarin.Firebase.Database.Connection",
         "type": "xbd"
       },
@@ -3605,7 +3605,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-datatransport",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.Firebase.Datatransport",
         "type": "xbd"
       },
@@ -3613,7 +3613,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-dynamic-links",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.6",
+        "nugetVersion": "122.1.0.7",
         "nugetId": "Xamarin.Firebase.Dynamic.Links",
         "type": "xbd"
       },
@@ -3621,7 +3621,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Firebase.Encoders",
         "type": "xbd"
       },
@@ -3629,7 +3629,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-json",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.14",
+        "nugetVersion": "118.0.1.15",
         "nugetId": "Xamarin.Firebase.Encoders.JSON",
         "type": "xbd"
       },
@@ -3637,7 +3637,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-proto",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.17",
+        "nugetVersion": "116.0.0.18",
         "nugetId": "Xamarin.Firebase.Encoders.Proto",
         "type": "xbd"
       },
@@ -3645,7 +3645,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore",
         "version": "26.0.0",
-        "nugetVersion": "126.0.0",
+        "nugetVersion": "126.0.0.1",
         "nugetId": "Xamarin.Firebase.Firestore",
         "extraDependencies": "com.google.guava.guava",
         "type": "xbd",
@@ -3656,7 +3656,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-functions",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.Functions",
         "type": "xbd"
       },
@@ -3664,7 +3664,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid",
         "version": "21.1.0",
-        "nugetVersion": "121.1.0.22",
+        "nugetVersion": "121.1.0.23",
         "nugetId": "Xamarin.Firebase.Iid",
         "type": "xbd"
       },
@@ -3672,7 +3672,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.22",
+        "nugetVersion": "117.1.0.23",
         "nugetId": "Xamarin.Firebase.Iid.Interop",
         "type": "xbd"
       },
@@ -3680,7 +3680,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.InAppMessaging",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3690,7 +3690,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging-display",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3700,7 +3700,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0",
+        "nugetVersion": "119.0.0.1",
         "nugetId": "Xamarin.Firebase.Installations",
         "type": "xbd"
       },
@@ -3708,7 +3708,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations-interop",
         "version": "17.2.0",
-        "nugetVersion": "117.2.0.10",
+        "nugetVersion": "117.2.0.11",
         "nugetId": "Xamarin.Firebase.Installations.InterOp",
         "type": "xbd"
       },
@@ -3716,7 +3716,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-invites",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Firebase.Invites",
         "type": "xbd"
       },
@@ -3724,7 +3724,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-measurement-connector",
         "version": "20.0.1",
-        "nugetVersion": "120.0.1.10",
+        "nugetVersion": "120.0.1.11",
         "nugetId": "Xamarin.Firebase.Measurement.Connector",
         "type": "xbd"
       },
@@ -3732,7 +3732,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-messaging",
         "version": "25.0.0",
-        "nugetVersion": "125.0.0",
+        "nugetVersion": "125.0.0.1",
         "nugetId": "Xamarin.Firebase.Messaging",
         "type": "xbd"
       },
@@ -3740,7 +3740,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-common",
         "version": "22.1.2",
-        "nugetVersion": "122.1.2.22",
+        "nugetVersion": "122.1.2.23",
         "nugetId": "Xamarin.Firebase.ML.Common",
         "type": "xbd"
       },
@@ -3748,7 +3748,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-model-interpreter",
         "version": "22.0.4",
-        "nugetVersion": "122.0.4.22",
+        "nugetVersion": "122.0.4.23",
         "nugetId": "Xamarin.Firebase.ML.Model.Interpreter",
         "type": "xbd"
       },
@@ -3756,7 +3756,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language",
         "version": "22.0.1",
-        "nugetVersion": "122.0.1.22",
+        "nugetVersion": "122.0.1.23",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language",
         "type": "xbd"
       },
@@ -3764,7 +3764,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-language-id-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.22",
+        "nugetVersion": "120.0.8.23",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Id.Model",
         "type": "xbd"
       },
@@ -3772,7 +3772,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply",
         "version": "18.0.8",
-        "nugetVersion": "118.0.8.22",
+        "nugetVersion": "118.0.8.23",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply",
         "type": "xbd"
       },
@@ -3780,7 +3780,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.22",
+        "nugetVersion": "120.0.8.23",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply.Model",
         "type": "xbd"
       },
@@ -3788,7 +3788,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate",
         "version": "22.0.2",
-        "nugetVersion": "122.0.2.21",
+        "nugetVersion": "122.0.2.22",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate",
         "type": "xbd"
       },
@@ -3796,7 +3796,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate-model",
         "version": "20.0.9",
-        "nugetVersion": "120.0.9.22",
+        "nugetVersion": "120.0.9.23",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate.Model",
         "type": "xbd"
       },
@@ -3804,7 +3804,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0.22",
+        "nugetVersion": "124.1.0.23",
         "nugetId": "Xamarin.Firebase.ML.Vision",
         "type": "xbd"
       },
@@ -3812,7 +3812,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-automl",
         "version": "18.0.6",
-        "nugetVersion": "118.0.6.22",
+        "nugetVersion": "118.0.6.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.AutoML",
         "type": "xbd"
       },
@@ -3820,7 +3820,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-barcode-model",
         "version": "16.1.2",
-        "nugetVersion": "116.1.2.22",
+        "nugetVersion": "116.1.2.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.BarCode.Model",
         "type": "xbd"
       },
@@ -3828,7 +3828,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-face-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.22",
+        "nugetVersion": "120.0.2.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.Face.Model",
         "type": "xbd"
       },
@@ -3836,7 +3836,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-image-label-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.22",
+        "nugetVersion": "120.0.2.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.Image.Label.Model",
         "type": "xbd"
       },
@@ -3844,7 +3844,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-internal-vkp",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.22",
+        "nugetVersion": "117.0.2.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -3852,7 +3852,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-object-detection-model",
         "version": "19.0.6",
-        "nugetVersion": "119.0.6.22",
+        "nugetVersion": "119.0.6.23",
         "nugetId": "Xamarin.Firebase.ML.Vision.Object.Detection.Model",
         "type": "xbd"
       },
@@ -3860,7 +3860,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-perf",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.Perf",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3870,7 +3870,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-sessions",
         "version": "3.0.0",
-        "nugetVersion": "103.0.0",
+        "nugetVersion": "103.0.0.1",
         "nugetId": "Xamarin.Firebase.Sessions",
         "type": "xbd"
       },
@@ -3878,7 +3878,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage",
         "version": "22.0.0",
-        "nugetVersion": "122.0.0",
+        "nugetVersion": "122.0.0.1",
         "nugetId": "Xamarin.Firebase.Storage",
         "type": "xbd"
       },
@@ -3886,7 +3886,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Firebase.Storage.Common",
         "type": "xbd"
       },
@@ -3894,7 +3894,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "protolite-well-known-types",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.2",
+        "nugetVersion": "118.0.1.3",
         "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -3904,7 +3904,7 @@
         "groupId": "com.google.flatbuffers",
         "artifactId": "flatbuffers-java",
         "version": "25.2.10",
-        "nugetVersion": "25.2.10.2",
+        "nugetVersion": "25.2.10.3",
         "nugetId": "Xamarin.Google.FlatBuffers.Java",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3913,7 +3913,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger",
         "version": "0.9",
-        "nugetVersion": "0.9.0",
+        "nugetVersion": "0.9.0.1",
         "nugetId": "Xamarin.Flogger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3922,7 +3922,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger-system-backend",
         "version": "0.9",
-        "nugetVersion": "0.9.0",
+        "nugetVersion": "0.9.0.1",
         "nugetId": "Xamarin.Flogger.SystemBackend",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3931,7 +3931,7 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.3",
-        "nugetVersion": "1.0.3.2",
+        "nugetVersion": "1.0.3.3",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3940,7 +3940,7 @@
         "groupId": "com.google.guava",
         "artifactId": "guava",
         "version": "33.4.8-android",
-        "nugetVersion": "33.4.8.2",
+        "nugetVersion": "33.4.8.3",
         "nugetId": "Xamarin.Google.Guava",
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
         "type": "androidlibrary",
@@ -3950,7 +3950,7 @@
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.28",
+        "nugetVersion": "1.0.0.29",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3959,7 +3959,7 @@
         "groupId": "com.google.inject",
         "artifactId": "guice",
         "version": "7.0.0",
-        "nugetVersion": "7.0.0.6",
+        "nugetVersion": "7.0.0.7",
         "nugetId": "Xamarin.Google.Inject.Guice",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3968,7 +3968,7 @@
         "groupId": "com.google.j2objc",
         "artifactId": "j2objc-annotations",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.10",
+        "nugetVersion": "3.0.0.11",
         "nugetId": "Xamarin.Google.J2Objc.Annotations",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -3977,7 +3977,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.4",
+        "nugetVersion": "117.3.0.5",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning",
         "type": "xbd"
       },
@@ -3985,7 +3985,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.17",
+        "nugetVersion": "117.0.0.18",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning.Common",
         "type": "xbd"
       },
@@ -3993,7 +3993,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "common",
         "version": "18.11.0",
-        "nugetVersion": "118.11.0.4",
+        "nugetVersion": "118.11.0.5",
         "nugetId": "Xamarin.Google.MLKit.Common",
         "type": "xbd"
       },
@@ -4001,7 +4001,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "digital-ink-recognition",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.14",
+        "nugetVersion": "118.1.0.15",
         "nugetId": "Xamarin.Google.MLKit.DigitalInk.Recognition",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -4010,7 +4010,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "face-detection",
         "version": "16.1.7",
-        "nugetVersion": "116.1.7.4",
+        "nugetVersion": "116.1.7.5",
         "nugetId": "Xamarin.Google.MLKit.FaceDetection",
         "type": "xbd"
       },
@@ -4018,7 +4018,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling",
         "version": "17.0.9",
-        "nugetVersion": "117.0.9.4",
+        "nugetVersion": "117.0.9.5",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -4026,7 +4026,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-automl",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.23",
+        "nugetVersion": "116.2.1.24",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.AutoML",
         "type": "xbd"
       },
@@ -4034,7 +4034,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-common",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.15",
+        "nugetVersion": "118.1.0.16",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4043,7 +4043,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.4",
+        "nugetVersion": "117.0.3.5",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom",
         "type": "xbd"
       },
@@ -4051,7 +4051,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.17",
+        "nugetVersion": "117.0.0.18",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom.Common",
         "type": "xbd"
       },
@@ -4059,7 +4059,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-default-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.17",
+        "nugetVersion": "117.0.0.18",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Default.Common",
         "type": "xbd"
       },
@@ -4067,7 +4067,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id",
         "version": "17.0.6",
-        "nugetVersion": "117.0.6.4",
+        "nugetVersion": "117.0.6.5",
         "nugetId": "Xamarin.Google.MLKit.Language.Id",
         "type": "xbd"
       },
@@ -4075,7 +4075,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.15",
+        "nugetVersion": "116.1.0.16",
         "nugetId": "Xamarin.Google.MLKit.Language.Id.Common",
         "type": "xbd"
       },
@@ -4083,7 +4083,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "linkfirebase",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.17",
+        "nugetVersion": "117.0.0.18",
         "nugetId": "Xamarin.Google.MLKit.LinkFirebase",
         "type": "xbd"
       },
@@ -4091,7 +4091,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "mediapipe-internal",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.22",
+        "nugetVersion": "116.0.0.23",
         "nugetId": "Xamarin.Google.MLKit.MediaPipe.Internal",
         "type": "xbd"
       },
@@ -4099,7 +4099,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.4",
+        "nugetVersion": "117.0.2.5",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection",
         "type": "xbd"
       },
@@ -4107,7 +4107,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-common",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.18",
+        "nugetVersion": "118.0.0.19",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4116,7 +4116,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-custom",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.4",
+        "nugetVersion": "117.0.2.5",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Custom",
         "type": "xbd"
       },
@@ -4124,7 +4124,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection",
         "type": "xbd"
       },
@@ -4132,7 +4132,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-accurate",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Accurate",
         "type": "xbd"
       },
@@ -4140,7 +4140,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.22",
+        "nugetVersion": "117.0.0.23",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Common",
         "type": "xbd"
       },
@@ -4148,7 +4148,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply",
         "version": "17.0.4",
-        "nugetVersion": "117.0.4.4",
+        "nugetVersion": "117.0.4.5",
         "nugetId": "Xamarin.Google.MLKit.SmartReply",
         "type": "xbd"
       },
@@ -4156,7 +4156,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.15",
+        "nugetVersion": "116.1.0.16",
         "nugetId": "Xamarin.Google.MLKit.SmartReply.Common",
         "type": "xbd"
       },
@@ -4164,7 +4164,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition",
         "type": "xbd"
       },
@@ -4172,7 +4172,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-bundled-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.4",
+        "nugetVersion": "117.0.0.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Bundled.Common",
         "type": "xbd"
       },
@@ -4180,7 +4180,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Chinese",
         "type": "xbd"
       },
@@ -4188,7 +4188,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Devanagari",
         "type": "xbd"
       },
@@ -4196,7 +4196,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Japanese",
         "type": "xbd"
       },
@@ -4204,7 +4204,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.4",
+        "nugetVersion": "116.0.1.5",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Korean",
         "type": "xbd"
       },
@@ -4212,7 +4212,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "translate",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.4",
+        "nugetVersion": "117.0.3.5",
         "nugetId": "Xamarin.Google.MLKit.Translate",
         "type": "xbd"
       },
@@ -4220,7 +4220,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-common",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.15",
+        "nugetVersion": "117.3.0.16",
         "nugetId": "Xamarin.Google.MLKit.Vision.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4229,7 +4229,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-interfaces",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.9",
+        "nugetVersion": "116.3.0.10",
         "nugetId": "Xamarin.Google.MLKit.Vision.Interfaces",
         "type": "xbd"
       },
@@ -4237,7 +4237,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-internal-vkp",
         "version": "18.2.3",
-        "nugetVersion": "118.2.3.4",
+        "nugetVersion": "118.2.3.5",
         "nugetId": "Xamarin.Google.MLKit.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -4245,7 +4245,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-javalite",
         "version": "4.31.1",
-        "nugetVersion": "4.31.1",
+        "nugetVersion": "4.31.1.1",
         "nugetId": "Xamarin.Protobuf.JavaLite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4255,7 +4255,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-lite",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.20",
+        "nugetVersion": "3.0.1.21",
         "nugetId": "Xamarin.Protobuf.Lite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4265,7 +4265,7 @@
         "groupId": "com.google.zxing",
         "artifactId": "core",
         "version": "3.5.3",
-        "nugetVersion": "3.5.3.8",
+        "nugetVersion": "3.5.3.9",
         "nugetId": "Xamarin.Google.ZXing.Core",
         "assemblyName": "Google.ZXing.Core",
         "type": "androidlibrary",
@@ -4275,7 +4275,7 @@
         "groupId": "com.squareup",
         "artifactId": "javapoet",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0.16",
+        "nugetVersion": "1.13.0.17",
         "nugetId": "Square.JavaPoet",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4284,7 +4284,7 @@
         "groupId": "com.squareup.okhttp",
         "artifactId": "okhttp",
         "version": "2.7.5",
-        "nugetVersion": "2.7.5.20",
+        "nugetVersion": "2.7.5.21",
         "nugetId": "Square.OkHttp",
         "excludedRuntimeDependencies": "com.squareup.okio.okio,com.google.android.android",
         "type": "androidlibrary",
@@ -4294,7 +4294,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "logging-interceptor",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.LoggingInterceptor",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4303,7 +4303,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3",
         "extraDependencies": "com.squareup.okhttp3.okhttp-android",
         "type": "androidlibrary",
@@ -4313,7 +4313,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-android",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4322,7 +4322,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-brotli",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.OkHttp.Brotli",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4331,7 +4331,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-java-net-cookiejar",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.JavaNetCookieJar",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4340,7 +4340,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-jvm",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.JVM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4349,7 +4349,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-tls",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.OkHttp.TLS",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4358,7 +4358,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-urlconnection",
         "version": "5.1.0",
-        "nugetVersion": "5.1.0.1",
+        "nugetVersion": "5.1.0.2",
         "nugetId": "Square.OkHttp3.UrlConnection",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4367,7 +4367,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio",
         "version": "3.15.0",
-        "nugetVersion": "3.15.0",
+        "nugetVersion": "3.15.0.1",
         "nugetId": "Square.OkIO",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4376,7 +4376,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio-jvm",
         "version": "3.15.0",
-        "nugetVersion": "3.15.0",
+        "nugetVersion": "3.15.0.1",
         "nugetId": "Square.OkIO.JVM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4385,7 +4385,7 @@
         "groupId": "com.squareup.picasso",
         "artifactId": "picasso",
         "version": "2.8",
-        "nugetVersion": "2.8.0.19",
+        "nugetVersion": "2.8.0.20",
         "nugetId": "Square.Picasso",
         "frozen": true,
         "type": "androidlibrary",
@@ -4395,7 +4395,7 @@
         "groupId": "com.squareup.retrofit",
         "artifactId": "retrofit",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.20",
+        "nugetVersion": "1.9.0.21",
         "nugetId": "Square.Retrofit",
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp,com.google.code.gson.gson,com.google.android.android,io.reactivex.rxjava,com.google.appengine.appengine-api-1.0-sdk",
         "type": "androidlibrary",
@@ -4405,7 +4405,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "adapter-rxjava2",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0",
+        "nugetVersion": "3.0.0.1",
         "nugetId": "Square.Retrofit2.AdapterRxJava2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4414,7 +4414,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-gson",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0",
+        "nugetVersion": "3.0.0.1",
         "nugetId": "Square.Retrofit2.ConverterGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4423,7 +4423,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-scalars",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0",
+        "nugetVersion": "3.0.0.1",
         "nugetId": "Square.Retrofit2.ConverterScalars",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4432,7 +4432,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "retrofit",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0",
+        "nugetVersion": "3.0.0.1",
         "nugetId": "Square.Retrofit2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4441,7 +4441,7 @@
         "groupId": "dev.chrisbanes.snapper",
         "artifactId": "snapper",
         "version": "0.3.0",
-        "nugetVersion": "0.3.0.19",
+        "nugetVersion": "0.3.0.20",
         "nugetId": "Xamarin.Dev.ChrisBanes.Snapper",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4450,7 +4450,7 @@
         "groupId": "io.antmedia",
         "artifactId": "rtmp-client",
         "version": "3.2.0",
-        "nugetVersion": "3.2.0.6",
+        "nugetVersion": "3.2.0.7",
         "nugetId": "Xamarin.Android.AntMedia.RtmpClient",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4459,7 +4459,7 @@
         "groupId": "io.github.aakira",
         "artifactId": "napier",
         "version": "2.7.1",
-        "nugetVersion": "2.7.1.11",
+        "nugetVersion": "2.7.1.12",
         "nugetId": "Xamarin.AAkira.Napier",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4468,7 +4468,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-android",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4477,7 +4477,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-api",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Api",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4486,7 +4486,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-context",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Context",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4495,7 +4495,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-core",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4504,7 +4504,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-okhttp",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.OkHttp",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4513,7 +4513,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-protobuf-lite",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Protobuf.Lite",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4522,7 +4522,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-stub",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Stub",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4531,7 +4531,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-util",
         "version": "1.74.0",
-        "nugetVersion": "1.74.0",
+        "nugetVersion": "1.74.0.1",
         "nugetId": "Xamarin.Grpc.Util",
         "excludedRuntimeDependencies": "io.grpc.grpc-core,junit.junit,io.grpc.grpc-testing,org.mockito.mockito-core",
         "type": "androidlibrary",
@@ -4541,7 +4541,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-api",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.13",
+        "nugetVersion": "0.31.1.14",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4550,7 +4550,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-contrib-grpc-metrics",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.13",
+        "nugetVersion": "0.31.1.14",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4559,7 +4559,7 @@
         "groupId": "io.perfmark",
         "artifactId": "perfmark-api",
         "version": "0.27.0",
-        "nugetVersion": "0.27.0.8",
+        "nugetVersion": "0.27.0.9",
         "nugetId": "Xamarin.Io.PerfMark.PerfMarkApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4568,7 +4568,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxandroid",
         "version": "2.1.1",
-        "nugetVersion": "2.1.1.19",
+        "nugetVersion": "2.1.1.20",
         "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4577,7 +4577,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxjava",
         "version": "2.2.21",
-        "nugetVersion": "2.2.21.26",
+        "nugetVersion": "2.2.21.27",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4587,7 +4587,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxkotlin",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.19",
+        "nugetVersion": "2.4.0.20",
         "nugetId": "Xamarin.Android.ReactiveX.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4596,7 +4596,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxandroid",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.18",
+        "nugetVersion": "3.0.2.19",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4605,7 +4605,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxjava",
         "version": "3.1.11",
-        "nugetVersion": "3.1.11",
+        "nugetVersion": "3.1.11.1",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4614,7 +4614,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxkotlin",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.19",
+        "nugetVersion": "3.0.1.20",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4623,7 +4623,7 @@
         "groupId": "jakarta.inject",
         "artifactId": "jakarta.inject-api",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.6",
+        "nugetVersion": "2.0.1.7",
         "nugetId": "Xamarin.Jakarta.Inject.InjectApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4632,7 +4632,7 @@
         "groupId": "javax.inject",
         "artifactId": "javax.inject",
         "version": "1",
-        "nugetVersion": "1.0.0.20",
+        "nugetVersion": "1.0.0.21",
         "nugetId": "Xamarin.JavaX.Inject",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4641,7 +4641,7 @@
         "groupId": "org.aomedia.avif.android",
         "artifactId": "avif",
         "version": "1.1.1.14d8e3c4",
-        "nugetVersion": "1.1.1.349758408",
+        "nugetVersion": "1.1.1.349758409",
         "nugetId": "Xamarin.AOMedia.AVIF.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4651,7 +4651,7 @@
         "groupId": "org.brotli",
         "artifactId": "dec",
         "version": "0.1.2",
-        "nugetVersion": "0.1.2.8",
+        "nugetVersion": "0.1.2.9",
         "nugetId": "Xamarin.Brotli.Dec",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4660,7 +4660,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-compat-qual",
         "version": "2.5.6",
-        "nugetVersion": "2.5.6.12",
+        "nugetVersion": "2.5.6.13",
         "nugetId": "Xamarin.CheckerFramework.CheckerCompatQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4669,7 +4669,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-qual",
         "version": "3.49.5",
-        "nugetVersion": "3.49.5",
+        "nugetVersion": "3.49.5.1",
         "nugetId": "Xamarin.CheckerFramework.CheckerQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4678,7 +4678,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-api",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.8",
+        "nugetVersion": "119.6045.31.9",
         "nugetId": "Xamarin.Chromium.CroNet.Api",
         "type": "androidlibrary"
       },
@@ -4686,7 +4686,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-common",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.8",
+        "nugetVersion": "119.6045.31.9",
         "nugetId": "Xamarin.Chromium.CroNet.Common",
         "type": "androidlibrary"
       },
@@ -4694,7 +4694,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-embedded",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.8",
+        "nugetVersion": "119.6045.31.9",
         "nugetId": "Xamarin.Chromium.CroNet.Embedded",
         "type": "androidlibrary"
       },
@@ -4702,7 +4702,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-fallback",
         "version": "119.6045.31",
-        "nugetVersion": "119.6045.31.8",
+        "nugetVersion": "119.6045.31.9",
         "nugetId": "Xamarin.Chromium.CroNet.Fallback",
         "type": "androidlibrary"
       },
@@ -4710,7 +4710,7 @@
         "groupId": "org.codehaus.mojo",
         "artifactId": "animal-sniffer-annotations",
         "version": "1.24",
-        "nugetVersion": "1.24.0.6",
+        "nugetVersion": "1.24.0.7",
         "nugetId": "Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4719,7 +4719,7 @@
         "groupId": "org.jetbrains",
         "artifactId": "annotations",
         "version": "26.0.2",
-        "nugetVersion": "26.0.2.2",
+        "nugetVersion": "26.0.2.3",
         "nugetId": "Xamarin.Jetbrains.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4728,7 +4728,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-android-extensions-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.Android.Extensions.Runtime.Library",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4737,7 +4737,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-parcelize-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.Parcelize.Runtime",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4746,7 +4746,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4758,7 +4758,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4767,7 +4767,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.4",
+        "nugetVersion": "2.0.21.5",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "frozen": true,
         "type": "androidlibrary",
@@ -4780,7 +4780,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4792,7 +4792,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0",
+        "nugetVersion": "2.2.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4804,7 +4804,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu",
         "version": "0.29.0",
-        "nugetVersion": "0.29.0",
+        "nugetVersion": "0.29.0.1",
         "nugetId": "Xamarin.KotlinX.AtomicFU",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4813,7 +4813,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu-jvm",
         "version": "0.29.0",
-        "nugetVersion": "0.29.0",
+        "nugetVersion": "0.29.0.1",
         "nugetId": "Xamarin.KotlinX.AtomicFU.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4822,7 +4822,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4831,7 +4831,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4840,7 +4840,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4849,7 +4849,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-guava",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Guava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4858,7 +4858,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-jdk8",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4867,7 +4867,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-play-services",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Play.Services",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4876,7 +4876,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-reactive",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4885,7 +4885,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4894,7 +4894,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx3",
         "version": "1.10.2",
-        "nugetVersion": "1.10.2",
+        "nugetVersion": "1.10.2.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx3",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4903,7 +4903,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4912,7 +4912,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core-jvm",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4921,7 +4921,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Json",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4930,7 +4930,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json-jvm",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Json.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4939,7 +4939,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4948,7 +4948,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf-jvm",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0",
+        "nugetVersion": "1.9.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4957,7 +4957,7 @@
         "groupId": "org.jspecify",
         "artifactId": "jspecify",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.3",
+        "nugetVersion": "1.0.0.4",
         "nugetId": "Xamarin.JSpecify",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4966,7 +4966,7 @@
         "groupId": "org.ow2.asm",
         "artifactId": "asm",
         "version": "9.8",
-        "nugetVersion": "9.8.0.2",
+        "nugetVersion": "9.8.0.3",
         "nugetId": "Xamarin.OW2.ASM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4975,7 +4975,7 @@
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.4",
-        "nugetVersion": "1.0.4.20",
+        "nugetVersion": "1.0.4.21",
         "nugetId": "Xamarin.Android.ReactiveStreams",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4984,7 +4984,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-android",
         "version": "1.13.1",
-        "nugetVersion": "1.13.1.14",
+        "nugetVersion": "1.13.1.15",
         "nugetId": "Xamarin.TensorFlow.Android",
         "assemblyName": "org.tensorflow.tensorflow-android",
         "type": "androidlibrary",
@@ -4994,7 +4994,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.6",
+        "nugetVersion": "2.16.1.7",
         "nugetId": "Xamarin.TensorFlow.Lite",
         "frozen": true,
         "type": "androidlibrary",
@@ -5004,7 +5004,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.6",
+        "nugetVersion": "2.16.1.7",
         "nugetId": "Xamarin.TensorFlow.Lite.Api",
         "frozen": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-api",
@@ -5015,7 +5015,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.6",
+        "nugetVersion": "2.16.1.7",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu",
         "frozen": true,
         "type": "androidlibrary",
@@ -5025,7 +5025,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.6",
+        "nugetVersion": "2.16.1.7",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu.Api",
         "frozen": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-gpu-api",
@@ -5036,7 +5036,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-metadata",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.2",
+        "nugetVersion": "0.5.0.3",
         "nugetId": "Xamarin.TensorFlow.Lite.Metadata",
         "assemblyName": "org.tensorflow.tensorflow-lite-metadata",
         "type": "androidlibrary",
@@ -5046,7 +5046,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-select-tf-ops",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.6",
+        "nugetVersion": "2.16.1.7",
         "nugetId": "Xamarin.TensorFlow.Lite.Select.TF.Ops",
         "assemblyName": "org.tensorflow.tensorflow-lite-select-tf-ops",
         "type": "androidlibrary",
@@ -5056,7 +5056,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.2",
+        "nugetVersion": "0.5.0.3",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-support",
         "type": "androidlibrary",
@@ -5066,7 +5066,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support-api",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.2",
+        "nugetVersion": "0.5.0.3",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Api",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-support-api",
@@ -5078,7 +5078,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio",
         "type": "androidlibrary",
@@ -5088,7 +5088,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio-play-services",
         "type": "androidlibrary",
@@ -5098,7 +5098,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-base",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Base.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-base",
         "type": "androidlibrary",
@@ -5108,7 +5108,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text",
         "type": "androidlibrary",
@@ -5118,7 +5118,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text-play-services",
         "type": "androidlibrary",
@@ -5128,7 +5128,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision",
         "type": "androidlibrary",
@@ -5138,7 +5138,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.11",
+        "nugetVersion": "0.4.4.12",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.PlayServices.Library",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision-play-services",


### PR DESCRIPTION
Context: https://github.com/dotnet/android-libraries/pull/1243

Ran `dotnet cake --target=bump-config`, as we have new API changes coming in #1243 related to guava.