### PR TITLE
[ci] remove `$(signType)` variable

### DIFF
--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -14,4 +14,7 @@ stages:
       artifactName: output-windows
       usePipelineArtifactTasks: true
       checkoutType: self
-      signType: $(signType)
+      ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
+        signType: Real
+      ${{ else }}:
+        signType: Test

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -43,7 +43,3 @@ variables:
 
   # Signing settings
   TeamName: .NET MAUI
-  ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
-    signType: Real
-  ${{ else }}:
-    signType: Test


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10521

Signing steps are failing with:

    ##[warning]WARNING: Signing in this pipeline will break after August 31st due to a missing PME service connection for signing

Caused by this value being blank:

    ConnectedPMEServiceName:

To resolve this in dotnet/android, we removed usage of a variable, so I'm thinking removing `$(signType)` here will resolve the issue.