### PR TITLE
[ci] clean `$(Agent.TempDirectory)/android-sdk`

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -70,6 +70,14 @@ steps:
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
+  - pwsh: |
+      if (Test-Path "${{ parameters.androidSdkRoot }}") {
+        Remove-Item "${{ parameters.androidSdkRoot }}" -Recurse -Force
+      }
+      New-Item -ItemType Directory -Path "${{ parameters.androidSdkRoot }}" -Force
+    displayName: Clean and create Android SDK directory
+    condition: eq(${{ parameters.installAndroidDependencies }}, true)
+
   - task: DotNetCoreCLI@2
     displayName: Install android dependencies GoogleV2
     inputs:


### PR DESCRIPTION
Builds are randomly failing with:

    Found corrupted package.xml at D:\a\_work\_temp\android-sdk\platforms\android-36\package.xml
    Observed package id 'cmdline-tools;19.0' in inconsistent location 'D:\a\_work\_temp\android-sdk\cmdline-tools\latest' (Expected 'D:\a\_work\_temp\android-sdk\cmdline-tools\19.0')
    Already observed package id 'cmdline-tools;19.0' in 'D:\a\_work\_temp\android-sdk\cmdline-tools\19.0'. Skipping duplicate at 'D:\a\_work\_temp\android-sdk\cmdline-tools\latest'

Let's delete the folder on each run to ensure a clean state.