### PR TITLE
[build] update to .NET 10 GA

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -16,7 +16,6 @@ steps:
     displayName: 'Use dotnet $(dotnetVersion)'
     inputs:
       version: $(dotnetVersion)
-      includePreviewVersions: true
     condition: ne('$(dotnetVersion)', '')
 
   - task: UseDotNet@2
@@ -24,7 +23,6 @@ steps:
     inputs:
       version: $(dotnetNextVersion)
       performMultiLevelLookup: true
-      includePreviewVersions: true
     condition: ne('$(dotnetNextVersion)', '')
 
   - script: dotnet --info

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -19,7 +19,7 @@ variables:
   macosAgentPoolName: VSEng-VSMac-Xamarin-Shared                                        # macOS VM pool name
   
   # Tool variables
-  dotnetVersion: '9.0.306'                                                              # .NET version to install on agent
+  dotnetVersion: '9.0.308'                                                              # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'                           # NuGet.org URL to find workloads
 
@@ -34,7 +34,7 @@ variables:
   extendedTestAssembly: tests/extended/bin/$(configuration)/net$(dotnetFrameworkVersion).0/ExtendedTests.dll    # Extended tests compiled binary
 
   # dotnet-next test variables
-  dotnetNextVersion: 10.0.100-rc.2.25502.107                                            # .NET preview version to install
+  dotnetNextVersion: 10.0.100                                                           # .NET version to install
   dotnetNextFrameworkVersion: 10                                                        # The number to use for TF (eg: netX.0-android)
 
   # dnceng-public variables


### PR DESCRIPTION
This pull request updates the .NET versions used in the CI pipeline to the latest stable releases and removes the installation of preview versions during environment setup. These changes help ensure that builds use stable .NET releases and improve reliability.

.NET version updates:

* Updated the `dotnetVersion` variable from `9.0.306` to `9.0.308` in `build/ci/variables.yml` to use the latest stable .NET 9 release.
* Updated the `dotnetNextVersion` variable from the preview release `10.0.100-rc.2.25502.107` to the stable release `10.0.100` in `build/ci/variables.yml`.

Environment setup improvements:

* Removed the `includePreviewVersions: true` option from both `UseDotNet@2` tasks in `build/ci/setup-environment.yml` to prevent installation of preview .NET versions during CI setup.