### PR TITLE
[build] pass `-m:2` on Windows to fix file locking

### DIFF
--- a/build/cake/build-and-package.cake
+++ b/build/cake/build-and-package.cake
@@ -31,6 +31,11 @@ Task ("libs")
         .EnableBinaryLogger ($"./output/libs.{CONFIGURATION}.binlog")
         .WithProperty("Verbosity", VERBOSITY.ToString ());
 
+    // Limit parallelism on Windows to reduce file locking issues during parallel builds
+    // This helps prevent race conditions when multiple projects access shared .aar files
+    if (IsRunningOnWindows ())
+        settings = settings.SetMaxCpuCount(2);
+
     settings.NodeReuse = false;
 
     DotNetBuild (


### PR DESCRIPTION
Builds were randomly failing with:

    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024: The file is locked by: ".NET Host (13708)". [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024: System.IO.IOException: The process cannot access the file 'C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-common\bin\Release\net10.0-android36.0\Xamarin.Google.MLKit.PoseDetection.Common.aar' because it is being used by another process. [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Microsoft.Android.Build.Tasks.Files.HashFile(String filename) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments, ICollection`1 proguardConfigFiles, ICollection`1 extractedDirectories) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask() [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection\com.google.mlkit.pose-detection.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024: The file is locked by: ".NET Host (13708)". [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024: System.IO.IOException: The process cannot access the file 'C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-common\bin\Release\net10.0-android36.0\Xamarin.Google.MLKit.PoseDetection.Common.aar' because it is being used by another process. [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Microsoft.Android.Build.Tasks.Files.HashFile(String filename) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(IDictionary`2 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments, ICollection`1 proguardConfigFiles, ICollection`1 extractedDirectories) [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Xamarin.Android.Tasks.ResolveLibraryProjectImports.RunTask() [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]
    dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.2\tools\Xamarin.Android.EmbeddedResource.targets(40,5): error XARLP7024:    at Microsoft.Android.Build.Tasks.AndroidTask.Execute() [C:\a\_work\1\s\generated\com.google.mlkit.pose-detection-accurate\com.google.mlkit.pose-detection-accurate.csproj::TargetFramework=net10.0-android36.0]

By limiting the parallelism on Windows to 2, we reduce the likelihood of this happening. (Copilot recommended this change.)