### PR TITLE
[build] use `MicroBuild.1ES.Official` based on pipeline name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'AndroidX') }}:
     template: azure-pipelines/MicroBuild.1ES.Official.yml@1esPipelines
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10736

The `AndroidX` production pipeline *must* always use the `MicroBuild.1ES.Official` template. It would fail/warn otherwise if running on pull requests.

Update the yaml condition to behave this way, which will allow us to test changes on pull requests.